### PR TITLE
Fix Railway deployment healthcheck failure

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,16 @@
+"""
+Wrapper module for Railway deployment.
+This allows Railway to find the app at the root level while keeping the actual
+implementation in merger-tracker/backend/
+"""
+import sys
+from pathlib import Path
+
+# Add the backend directory to Python path
+backend_path = Path(__file__).parent / "merger-tracker" / "backend"
+sys.path.insert(0, str(backend_path))
+
+# Import the FastAPI app from the backend
+from main import app
+
+__all__ = ["app"]

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,11 +1,8 @@
 [phases.setup]
-nixPkgs = ["python311", "python311Packages.pip"]
+nixPkgs = ["python311", "gcc"]
 
 [phases.install]
-cmds = ["pip install -r merger-tracker/backend/requirements.txt"]
-
-[phases.build]
-cmds = ["cd merger-tracker/backend"]
+cmds = ["python -m venv --copies /opt/venv && . /opt/venv/bin/activate && pip install -r requirements.txt"]
 
 [start]
-cmd = "cd merger-tracker/backend && uvicorn main:app --host 0.0.0.0 --port $PORT"
+cmd = "uvicorn main:app --host 0.0.0.0 --port $PORT"

--- a/railway.toml
+++ b/railway.toml
@@ -1,8 +1,9 @@
 [build]
 builder = "nixpacks"
-buildCommand = "cd merger-tracker/backend && pip install -r requirements.txt"
 
 [deploy]
-startCommand = "cd merger-tracker/backend && uvicorn main:app --host 0.0.0.0 --port $PORT"
+startCommand = "uvicorn main:app --host 0.0.0.0 --port $PORT"
 restartPolicyType = "on_failure"
 restartPolicyMaxRetries = 10
+healthcheckPath = "/"
+healthcheckTimeout = 100

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.104.1
+uvicorn[standard]==0.24.0
+python-multipart==0.0.6


### PR DESCRIPTION
The Railway build was failing because Nixpacks couldn't find the main.py module at the root level. The FastAPI app was located in merger-tracker/backend/, but Nixpacks auto-detection was looking at the root directory.

Changes:
- Created root-level main.py as a wrapper that imports from merger-tracker/backend
- Created root-level requirements.txt with all necessary dependencies
- Simplified nixpacks.toml to work from root directory
- Updated railway.toml with proper healthcheck configuration

This allows Nixpacks to find and start the app correctly while maintaining the actual implementation in the backend subdirectory.