### PR TITLE
Enable caching on API

### DIFF
--- a/merger-tracker/backend/requirements.txt
+++ b/merger-tracker/backend/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.104.1
 uvicorn[standard]==0.24.0
 python-multipart==0.0.6
+fastapi-cache2[memory]==0.2.1


### PR DESCRIPTION
- Add fastapi-cache2 library for in-memory caching
- Cache /api/stats for 1 hour (data syncs every 6 hours)
- Cache /api/mergers for 30 minutes
- Cache /api/mergers/{id} for 30 minutes
- Cache /api/timeline for 30 minutes
- Cache /api/industries for 1 hour
- Add HTTP Cache-Control headers for browser caching
- Initialize cache on application startup
