### PR TITLE
Fix Cloudflare branch preview deployment

### DIFF
--- a/merger-tracker/backend/.env.example
+++ b/merger-tracker/backend/.env.example
@@ -8,6 +8,9 @@ ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
 
 # For production (Railway), set to your frontend domain:
 # ALLOWED_ORIGINS=https://mergers.fyi,https://www.mergers.fyi
+#
+# Note: Cloudflare Pages preview branches (*.mergers-fyi.pages.dev) are
+# automatically allowed via regex pattern in main.py
 
 # Database
 DATABASE_PATH=mergers.db

--- a/merger-tracker/backend/main.py
+++ b/merger-tracker/backend/main.py
@@ -42,7 +42,7 @@ async def startup_event():
     print("✓ Application startup complete")
 
 # CORS middleware for frontend access
-# Allow production domain and localhost for development
+# Allow production domain, Cloudflare preview branches, and localhost for development
 allowed_origins = [
     "https://mergers.fyi",
     "https://www.mergers.fyi",
@@ -55,9 +55,14 @@ env_origins = os.getenv("ALLOWED_ORIGINS", "")
 if env_origins:
     allowed_origins.extend([origin.strip() for origin in env_origins.split(",")])
 
+# Regex pattern to match all Cloudflare Pages preview deployments
+# Matches: https://*.mergers-fyi.pages.dev and https://mergers.fyi
+allow_origin_regex = r"https://([a-z0-9-]+\.)?mergers-fyi(\.pages\.dev)?"
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=allowed_origins,
+    allow_origin_regex=allow_origin_regex,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
Added allow_origin_regex pattern to support all Cloudflare Pages preview deployments at *.mergers-fyi.pages.dev. This allows preview branches to access the API without CORS restrictions while maintaining security.

- Added regex pattern: https://([a-z0-9-]+\.)?mergers-fyi(\.pages\.dev)?
- Updated .env.example with documentation
- Maintains existing allowed_origins for production and localhost