### PR TITLE
Track other parties field in Molex merger

### DIFF
--- a/extract_mergers.py
+++ b/extract_mergers.py
@@ -135,6 +135,7 @@ def parse_merger_file(filepath, existing_merger_data=None):
 
         merger_data['acquirers'] = get_parties('field--name-field-acccgov-applicants')
         merger_data['targets'] = get_parties('field--name-field-acccgov-pub-reg-targets')
+        merger_data['other_parties'] = get_parties('field--name-field-acccgov-other-parties')
 
         # --- ANZSIC Codes ---
         merger_data['anszic_codes'] = []

--- a/merger-tracker/backend/database.py
+++ b/merger-tracker/backend/database.py
@@ -35,12 +35,12 @@ def init_database():
         )
     """)
 
-    # Parties table (acquirers and targets)
+    # Parties table (acquirers, targets, and other parties)
     cursor.execute("""
         CREATE TABLE IF NOT EXISTS parties (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             merger_id TEXT NOT NULL,
-            party_type TEXT NOT NULL, -- 'acquirer' or 'target'
+            party_type TEXT NOT NULL, -- 'acquirer', 'target', or 'other'
             name TEXT NOT NULL,
             identifier_type TEXT,
             identifier TEXT,

--- a/merger-tracker/backend/main.py
+++ b/merger-tracker/backend/main.py
@@ -126,6 +126,13 @@ def get_mergers(
             )
             merger['targets'] = [dict(row) for row in cursor.fetchall()]
 
+            # Get other parties
+            cursor.execute(
+                "SELECT * FROM parties WHERE merger_id = ? AND party_type = 'other'",
+                (merger_id,)
+            )
+            merger['other_parties'] = [dict(row) for row in cursor.fetchall()]
+
             # Get ANZSIC codes
             cursor.execute(
                 "SELECT * FROM anzsic_codes WHERE merger_id = ?",
@@ -172,6 +179,13 @@ def get_merger(merger_id: str, response: Response):
             (merger_id,)
         )
         merger['targets'] = [dict(row) for row in cursor.fetchall()]
+
+        # Get other parties
+        cursor.execute(
+            "SELECT * FROM parties WHERE merger_id = ? AND party_type = 'other'",
+            (merger_id,)
+        )
+        merger['other_parties'] = [dict(row) for row in cursor.fetchall()]
 
         # Get ANZSIC codes
         cursor.execute(

--- a/merger-tracker/backend/sync_data.py
+++ b/merger-tracker/backend/sync_data.py
@@ -165,6 +165,18 @@ def sync_from_json(json_path: str):
                     target.get('identifier')
                 ))
 
+            # Insert other parties
+            for other_party in merger_data.get('other_parties', []):
+                cursor.execute("""
+                    INSERT INTO parties (merger_id, party_type, name, identifier_type, identifier)
+                    VALUES (?, 'other', ?, ?, ?)
+                """, (
+                    merger_id,
+                    other_party['name'],
+                    other_party.get('identifier_type'),
+                    other_party.get('identifier')
+                ))
+
             # Insert ANZSIC codes
             for anzsic in merger_data.get('anszic_codes', []):
                 cursor.execute("""

--- a/merger-tracker/frontend/src/pages/MergerDetail.jsx
+++ b/merger-tracker/frontend/src/pages/MergerDetail.jsx
@@ -154,6 +154,27 @@ function MergerDetail() {
         </div>
       </div>
 
+      {/* Other Parties */}
+      {merger.other_parties && merger.other_parties.length > 0 && (
+        <div className="bg-white rounded-lg shadow p-6 mb-6">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">
+            Other Party(ies)
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {merger.other_parties.map((party, idx) => (
+              <div key={idx} className="mb-3">
+                <p className="font-medium text-gray-900">{party.name}</p>
+                {party.identifier && (
+                  <p className="text-sm text-gray-500">
+                    {party.identifier_type}: {party.identifier}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
       {/* Description */}
       {merger.merger_description && (
         <div className="bg-white rounded-lg shadow p-6 mb-6">

--- a/mergers.json
+++ b/mergers.json
@@ -21,6 +21,7 @@
         "identifier": "51 164 839 061"
       }
     ],
+    "other_parties": [],
     "anszic_codes": [
       {
         "code": "121",
@@ -83,6 +84,7 @@
         "identifier": "90 629 359 726"
       }
     ],
+    "other_parties": [],
     "anszic_codes": [
       {
         "code": "2499",
@@ -144,6 +146,7 @@
         "identifier": "11658440"
       }
     ],
+    "other_parties": [],
     "anszic_codes": [
       {
         "code": "1701",
@@ -213,6 +216,7 @@
         "identifier": "691 053 317"
       }
     ],
+    "other_parties": [],
     "anszic_codes": [
       {
         "code": "2619",
@@ -261,6 +265,7 @@
         "identifier": "45 081 823 743"
       }
     ],
+    "other_parties": [],
     "anszic_codes": [
       {
         "code": "1211",
@@ -313,6 +318,7 @@
         "identifier": "4460561"
       }
     ],
+    "other_parties": [],
     "anszic_codes": [
       {
         "code": "080",
@@ -369,6 +375,7 @@
         "identifier": "17 010 672 321"
       }
     ],
+    "other_parties": [],
     "anszic_codes": [
       {
         "code": "2462",
@@ -415,6 +422,13 @@
         "name": "Smiths Interconnect Group Limited",
         "identifier_type": null,
         "identifier": "UK CRN  06641403"
+      }
+    ],
+    "other_parties": [
+      {
+        "name": "Koch, Inc.",
+        "identifier_type": null,
+        "identifier": "Company number  992449504"
       }
     ],
     "anszic_codes": [


### PR DESCRIPTION
This change adds full support for tracking additional parties (beyond acquirers and targets) in merger cases. Currently, only the Molex merger (MN-01061) has an other party: Koch, Inc.

Changes made:
- Updated scraper (extract_mergers.py) to extract 'Other party(ies)' field
- Updated mergers.json with Koch, Inc. as other_party for Molex merger
- Extended database schema to support 'other' party_type in parties table
- Updated sync_data.py to insert other_parties into database
- Updated backend API (main.py) to query and return other_parties
- Updated frontend MergerDetail.jsx to conditionally display other parties