### PR TITLE
Fix scraped files from ACCC website

### DIFF
--- a/extract_mergers.py
+++ b/extract_mergers.py
@@ -89,7 +89,7 @@ def parse_merger_file(filepath, existing_merger_data=None):
         # --- Basic Information ---
         merger_data['merger_name'] = soup.find('h1', class_='page-title').get_text(strip=True) if soup.find('h1', class_='page-title') else None
         
-        status_tag = soup.find('div', class_='field--name-field-acccgov-merger-status')
+        status_tag = soup.select_one('.field--name-field-acccgov-merger-status .field__item')
         merger_data['status'] = status_tag.get_text(strip=True) if status_tag else None
 
         id_tag = soup.select_one('.field--name-dynamic-token-fieldnode-acccgov-merger-id .field__item')

--- a/mergers.json
+++ b/mergers.json
@@ -1,7 +1,7 @@
 [
   {
     "merger_name": "Asahi \u2013 Warehouse site on Tilburn Rd, Deer Park (Vic)",
-    "status": "Acquisition statusAssessment completed",
+    "status": "Assessment completed",
     "merger_id": "MN-01016",
     "effective_notification_datetime": "2025-08-15T12:00:00Z",
     "stage": "Phase 1 - initial assessment",
@@ -52,7 +52,7 @@
   },
   {
     "merger_name": "Kongsberg Defence \u2013 site within Newcastle Airport precinct",
-    "status": "Acquisition statusAssessment completed",
+    "status": "Assessment completed",
     "merger_id": "MN-01017",
     "effective_notification_datetime": "2025-08-08T12:00:00Z",
     "stage": "Phase 1 - initial assessment",
@@ -103,7 +103,7 @@
   },
   {
     "merger_name": "Ampol \u2013 EG Australia",
-    "status": "Acquisition statusUnder assessment",
+    "status": "Under assessment",
     "merger_id": "MN-01019",
     "effective_notification_datetime": "2025-10-10T12:00:00Z",
     "stage": "Phase 1 - initial assessment",
@@ -153,7 +153,7 @@
   },
   {
     "merger_name": "La Caisse \u2013 Edify NSW Development assets",
-    "status": "Acquisition statusUnder assessment",
+    "status": "Under assessment",
     "merger_id": "MN-01031",
     "effective_notification_datetime": "2025-10-29T12:00:00Z",
     "stage": "Phase 1 - initial assessment",
@@ -190,7 +190,7 @@
   },
   {
     "merger_name": "Asahi \u2013 Warehouse site on Weedman and Montgomery Streets, Redbank (Qld)",
-    "status": "Acquisition statusUnder assessment",
+    "status": "Under assessment",
     "merger_id": "MN-01035",
     "effective_notification_datetime": "2025-10-24T12:00:00Z",
     "stage": "Phase 1 - initial assessment",
@@ -227,7 +227,7 @@
   },
   {
     "merger_name": "Anglo American - Teck Resources",
-    "status": "Acquisition statusAssessment completed",
+    "status": "Assessment completed",
     "merger_id": "MN-01037",
     "effective_notification_datetime": "2025-10-24T12:00:00Z",
     "stage": "Phase 1 - initial assessment",
@@ -278,7 +278,7 @@
   },
   {
     "merger_name": "Caterpillar \u2013 RPMGlobal Holdings",
-    "status": "Acquisition statusUnder assessment",
+    "status": "Under assessment",
     "merger_id": "MN-01058",
     "effective_notification_datetime": "2025-11-10T12:00:00Z",
     "stage": "Phase 1 - initial assessment",
@@ -323,7 +323,7 @@
   },
   {
     "merger_name": "Molex \u2013 Smiths Interconnect",
-    "status": "Acquisition statusUnder assessment",
+    "status": "Under assessment",
     "merger_id": "MN-01061",
     "effective_notification_datetime": "2025-11-13T12:00:00Z",
     "stage": "Phase 1 - initial assessment",


### PR DESCRIPTION
Applied the same fix as PR #24 (merger ID field) to the status field extraction. Changed from extracting text from the outer div (which included the "Acquisition status" label) to selecting only the .field__item child element.

This resolves the issue where status values contained the label prefix:
- "Acquisition statusUnder assessment" -> "Under assessment"
- "Acquisition statusAssessment completed" -> "Assessment completed"

Also regenerated mergers.json with the corrected status values.