### PR TITLE
Update extraction script to use requirements.txt

### DIFF
--- a/.github/workflows/extract.yml
+++ b/.github/workflows/extract.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install beautifulsoup4==4.12.3 requests markdownify
+          pip install -r requirements.txt
 
       - name: Run extraction script
         run: python extract_mergers.py


### PR DESCRIPTION
- Replace hardcoded dependencies with pip install -r requirements.txt
- Ensures all required packages including pdfplumber are installed
- Resolves ModuleNotFoundError in extract_mergers.py