### PR TITLE
claude/industry-chip-filtering-C3kAl

### DIFF
--- a/merger-tracker/frontend/src/pages/MergerDetail.jsx
+++ b/merger-tracker/frontend/src/pages/MergerDetail.jsx
@@ -359,13 +359,13 @@ function MergerDetail() {
             </h2>
             <div className="flex flex-wrap gap-2">
               {merger.anzsic_codes.map((code, idx) => (
-                <span
+                <Link
                   key={idx}
-                  className="inline-flex items-center px-3 py-1 rounded-md text-sm bg-gray-100 text-gray-700"
+                  to={`/mergers?q=${encodeURIComponent(code.name)}`}
+                  className="inline-flex items-center px-3 py-1 rounded-md text-sm bg-gray-100 text-gray-700 hover:bg-gray-200 transition-colors cursor-pointer"
                 >
-                  <span className="font-medium mr-1">{code.code}:</span>
                   {code.name}
-                </span>
+                </Link>
               ))}
             </div>
           </div>


### PR DESCRIPTION
- Convert industry chips on merger detail page to clickable links
- Clicking an industry chip now navigates to /mergers?q={industry name}
- Remove ANZSIC code numbers from display (show only industry names)
- Add hover effect for better UX