### PR TITLE
Fix mobile menu text color for better contrast

### DIFF
--- a/merger-tracker/frontend/src/components/Navbar.jsx
+++ b/merger-tracker/frontend/src/components/Navbar.jsx
@@ -144,7 +144,7 @@ function Navbar() {
               to="/"
               className={`block pl-3 pr-4 py-2 border-l-4 text-base font-medium ${
                 isActive('/')
-                  ? 'bg-primary-light border-primary text-primary'
+                  ? 'bg-primary-light border-primary text-white'
                   : 'border-transparent text-gray-600 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-900'
               }`}
               onClick={() => setMobileMenuOpen(false)}
@@ -155,7 +155,7 @@ function Navbar() {
               to="/mergers"
               className={`block pl-3 pr-4 py-2 border-l-4 text-base font-medium ${
                 isActive('/mergers')
-                  ? 'bg-primary-light border-primary text-primary'
+                  ? 'bg-primary-light border-primary text-white'
                   : 'border-transparent text-gray-600 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-900'
               }`}
               onClick={() => setMobileMenuOpen(false)}
@@ -166,7 +166,7 @@ function Navbar() {
               to="/timeline"
               className={`block pl-3 pr-4 py-2 border-l-4 text-base font-medium ${
                 isActive('/timeline')
-                  ? 'bg-primary-light border-primary text-primary'
+                  ? 'bg-primary-light border-primary text-white'
                   : 'border-transparent text-gray-600 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-900'
               }`}
               onClick={() => setMobileMenuOpen(false)}
@@ -177,7 +177,7 @@ function Navbar() {
               to="/industries"
               className={`block pl-3 pr-4 py-2 border-l-4 text-base font-medium ${
                 isActive('/industries')
-                  ? 'bg-primary-light border-primary text-primary'
+                  ? 'bg-primary-light border-primary text-white'
                   : 'border-transparent text-gray-600 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-900'
               }`}
               onClick={() => setMobileMenuOpen(false)}


### PR DESCRIPTION
Changed active page text color in mobile hamburger menu from dark green
(text-primary) to white (text-white) to improve readability against the
green background (bg-primary-light).