### PR TITLE
Add phase dropdown to mergers page

### DIFF
--- a/merger-tracker/frontend/src/pages/Mergers.jsx
+++ b/merger-tracker/frontend/src/pages/Mergers.jsx
@@ -149,7 +149,7 @@ function Mergers() {
                 <option value="all">All phases</option>
                 <option value="phase1">Phase 1</option>
                 <option value="phase2">Phase 2</option>
-                <option value="waivers">Waivers</option>
+                <option value="waivers">Waiver</option>
               </select>
             </div>
             <div>


### PR DESCRIPTION
Replace the type dropdown (waiver/notification) with a phase dropdown that allows filtering by:
- Phase 1
- Phase 2
- Waivers

This provides better visibility into the different stages of merger assessments.

https://claude.ai/code/session_01M8Tc9aeTsYBo3c44SWRPxg