### PR TITLE
Fix URL path formatting for Timms questionnaire document

### DIFF
--- a/data/processed/mergers.json
+++ b/data/processed/mergers.json
@@ -1313,7 +1313,7 @@
         "title": "Symal Group / Timms Group and L&D Group - Questionnaire",
         "display_title": "Symal Group / Timms Group and L&D Group - Questionnaire",
         "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/%20Timms%20-%20third-party%20questionnaire%20-%20FINAL_0.docx",
-        "url_gh": "/matters/MN-25002/ Timms - third-party questionnaire - FINAL_0.pdf",
+        "url_gh": "/matters/MN-25002/Timms - third-party questionnaire - FINAL_0.pdf",
         "status": "live"
       },
       {

--- a/merger-tracker/frontend/public/data/mergers.json
+++ b/merger-tracker/frontend/public/data/mergers.json
@@ -1527,7 +1527,7 @@
           "title": "Symal Group / Timms Group and L&D Group - Questionnaire",
           "display_title": "Symal Group / Timms Group and L&D Group - Questionnaire",
           "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/%20Timms%20-%20third-party%20questionnaire%20-%20FINAL_0.docx",
-          "url_gh": "/matters/MN-25002/ Timms - third-party questionnaire - FINAL_0.pdf",
+          "url_gh": "/matters/MN-25002/Timms - third-party questionnaire - FINAL_0.pdf",
           "status": "live",
           "phase": null
         },

--- a/merger-tracker/frontend/public/data/mergers/MN-25002.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-25002.json
@@ -95,7 +95,7 @@
       "title": "Symal Group / Timms Group and L&D Group - Questionnaire",
       "display_title": "Symal Group / Timms Group and L&D Group - Questionnaire",
       "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/%20Timms%20-%20third-party%20questionnaire%20-%20FINAL_0.docx",
-      "url_gh": "/matters/MN-25002/ Timms - third-party questionnaire - FINAL_0.pdf",
+      "url_gh": "/matters/MN-25002/Timms - third-party questionnaire - FINAL_0.pdf",
       "status": "live",
       "phase": null
     },

--- a/merger-tracker/frontend/public/data/timeline.json
+++ b/merger-tracker/frontend/public/data/timeline.json
@@ -5,7 +5,7 @@
       "title": "Symal Group / Timms Group and L&D Group - Questionnaire",
       "display_title": "Symal Group / Timms Group and L&D Group - Questionnaire",
       "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/%20Timms%20-%20third-party%20questionnaire%20-%20FINAL_0.docx",
-      "url_gh": "/matters/MN-25002/ Timms - third-party questionnaire - FINAL_0.pdf",
+      "url_gh": "/matters/MN-25002/Timms - third-party questionnaire - FINAL_0.pdf",
       "status": "live",
       "merger_id": "MN-25002",
       "merger_name": "Symal Group - Timms Group and L&D Group",

--- a/scripts/extract_mergers.py
+++ b/scripts/extract_mergers.py
@@ -335,7 +335,7 @@ def parse_merger_file(filepath, existing_merger_data=None):
                     # Get original filename and determine serve filename
                     # For DOCX files, url_gh points to PDF (created by separate workflow)
                     parsed_url = urlparse(url)
-                    original_filename = unquote(os.path.basename(parsed_url.path))
+                    original_filename = unquote(os.path.basename(parsed_url.path)).strip()
                     serve_filename = get_serve_filename(original_filename)
                     
                     event['url_gh'] = f"/matters/{merger_id}/{serve_filename}"


### PR DESCRIPTION
## Summary
This PR fixes a URL path formatting issue in the merger document metadata where an extra space was present in the GitHub URL path for the Timms Group questionnaire document.

## Changes Made
- **Data files updated**: Removed leading space in `url_gh` path across 4 JSON files:
  - `data/processed/mergers.json`
  - `merger-tracker/frontend/public/data/mergers.json`
  - `merger-tracker/frontend/public/data/mergers/MN-25002.json`
  - `merger-tracker/frontend/public/data/timeline.json`
  
  Changed from: `/matters/MN-25002/ Timms - third-party questionnaire - FINAL_0.pdf`
  
  Changed to: `/matters/MN-25002/Timms - third-party questionnaire - FINAL_0.pdf`

- **Script fix**: Added `.strip()` to the filename extraction logic in `scripts/extract_mergers.py` to prevent similar whitespace issues in future document processing. This ensures that any leading/trailing whitespace in extracted filenames is removed before constructing the serve path.

## Implementation Details
The root cause was likely a space character in the original filename that wasn't being trimmed during the URL path construction. The script fix ensures this won't happen again by stripping whitespace from the extracted filename before using it to build the `url_gh` path.

https://claude.ai/code/session_01PEVPJKkj2svPjsY8qRftDQ