### PR TITLE
Add recent determinations section to dashboard

### DIFF
--- a/merger-tracker/frontend/public/data/stats.json
+++ b/merger-tracker/frontend/public/data/stats.json
@@ -119,5 +119,61 @@
       "effective_notification_datetime": "2026-01-16T12:00:00Z",
       "is_waiver": false
     }
+  ],
+  "recent_determinations": [
+    {
+      "merger_id": "MN-01069",
+      "merger_name": "Danone \u2013 further 1% interest in Danone Saputo Dairy Australia",
+      "determination": "Approved",
+      "determination_date": "2026-01-28T12:00:00Z",
+      "determination_type": "final",
+      "is_waiver": false,
+      "stage": "Phase 1 - initial assessment"
+    },
+    {
+      "merger_id": "WA-05003",
+      "merger_name": "KKR led consortium \u2013 Saviynt",
+      "determination": "Approved",
+      "determination_date": "2026-01-27T12:00:00Z",
+      "determination_type": "final",
+      "is_waiver": true,
+      "stage": "Waiver application"
+    },
+    {
+      "merger_id": "WA-35002",
+      "merger_name": "IFS \u2013 Softeon",
+      "determination": "Approved",
+      "determination_date": "2026-01-27T12:00:00Z",
+      "determination_type": "final",
+      "is_waiver": true,
+      "stage": "Waiver application"
+    },
+    {
+      "merger_id": "WA-85004",
+      "merger_name": "Treysta Wealth Management \u2013 Locumsgroup",
+      "determination": "Approved",
+      "determination_date": "2026-01-27T12:00:00Z",
+      "determination_type": "final",
+      "is_waiver": true,
+      "stage": "Waiver application"
+    },
+    {
+      "merger_id": "MN-01019",
+      "merger_name": "Ampol \u2013 EG Australia",
+      "determination": "Referred to phase 2",
+      "determination_date": "2026-01-21T12:00:00Z",
+      "determination_type": "phase_transition",
+      "is_waiver": false,
+      "stage": "Phase 2 - detailed assessment"
+    },
+    {
+      "merger_id": "WA-35003",
+      "merger_name": "Salesforce \u2013 Qualified",
+      "determination": "Not approved",
+      "determination_date": "2026-01-21T12:00:00Z",
+      "determination_type": "final",
+      "is_waiver": true,
+      "stage": "Waiver application"
+    }
   ]
 }

--- a/merger-tracker/frontend/src/components/RecentDeterminationsTable.jsx
+++ b/merger-tracker/frontend/src/components/RecentDeterminationsTable.jsx
@@ -1,0 +1,108 @@
+import { Link } from 'react-router-dom';
+import { formatDate } from '../utils/dates';
+
+function DeterminationBadge({ determination }) {
+  const getStyle = () => {
+    if (determination === 'Approved') {
+      return 'bg-green-100 text-green-800';
+    } else if (determination === 'Not approved') {
+      return 'bg-red-100 text-red-800';
+    } else if (determination === 'Referred to phase 2') {
+      return 'bg-amber-100 text-amber-800';
+    }
+    return 'bg-gray-100 text-gray-800';
+  };
+
+  return (
+    <span
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getStyle()}`}
+      role="status"
+      aria-label={`Determination: ${determination}`}
+    >
+      {determination}
+    </span>
+  );
+}
+
+function RecentDeterminationsTable({ determinations }) {
+  if (!determinations || determinations.length === 0) {
+    return (
+      <div className="bg-white rounded-lg shadow p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">
+          Recent determinations
+        </h2>
+        <p className="text-gray-500 text-sm">No recent determinations.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow">
+      <div className="px-4 sm:px-6 py-4 border-b border-gray-200">
+        <h2 className="text-lg font-semibold text-gray-900">
+          Recent determinations
+        </h2>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th
+                scope="col"
+                className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              >
+                Date
+              </th>
+              <th
+                scope="col"
+                className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              >
+                Merger
+              </th>
+              <th
+                scope="col"
+                className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+              >
+                Determination
+              </th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {determinations.map((item) => (
+              <tr
+                key={`${item.merger_id}-${item.determination_date}-${item.determination_type}`}
+                className="relative hover:bg-gray-50"
+              >
+                <td className="px-3 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                  {formatDate(item.determination_date)}
+                </td>
+                <td className="px-3 sm:px-6 py-4 text-sm text-gray-900">
+                  <Link
+                    to={`/mergers/${item.merger_id}`}
+                    className="text-primary after:absolute after:inset-0"
+                    aria-label={`View merger details for ${item.merger_name}`}
+                  >
+                    {item.merger_name}
+                  </Link>
+                  <div className="text-xs text-gray-500 mt-0.5 flex items-center gap-2">
+                    <span>{item.merger_id}</span>
+                    {item.is_waiver && (
+                      <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800">
+                        Waiver
+                      </span>
+                    )}
+                  </div>
+                </td>
+                <td className="px-3 sm:px-6 py-4 whitespace-nowrap text-sm">
+                  <DeterminationBadge determination={item.determination} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export default RecentDeterminationsTable;

--- a/scripts/generate_static_data.py
+++ b/scripts/generate_static_data.py
@@ -349,7 +349,48 @@ def generate_stats_json(mergers: list) -> dict:
         }
         for m in sorted_mergers[:5]
     ]
-    
+
+    # Recent determinations (approvals, declines, stage transitions)
+    determination_events = []
+
+    for m in mergers:
+        merger_id = m['merger_id']
+        merger_name = m['merger_name']
+        is_waiver = is_waiver_merger(m)
+
+        # Check for final determination (approved/not approved)
+        det = normalize_determination(m.get('accc_determination'))
+        det_date = m.get('determination_publication_date')
+        if det and det_date:
+            determination_events.append({
+                "merger_id": merger_id,
+                "merger_name": merger_name,
+                "determination": det,
+                "determination_date": det_date,
+                "determination_type": "final",
+                "is_waiver": is_waiver,
+                "stage": m.get('stage')
+            })
+
+        # Check for Phase 2 referrals (stage transitions)
+        for event in m.get('events', []):
+            title = event.get('title', '')
+            if 'subject to Phase 2 review' in title:
+                determination_events.append({
+                    "merger_id": merger_id,
+                    "merger_name": merger_name,
+                    "determination": "Referred to phase 2",
+                    "determination_date": event.get('date'),
+                    "determination_type": "phase_transition",
+                    "is_waiver": is_waiver,
+                    "stage": "Phase 2 - detailed assessment"
+                })
+                break
+
+    # Sort by date descending and take top 6
+    determination_events.sort(key=lambda x: x.get('determination_date', ''), reverse=True)
+    recent_determinations = determination_events[:6]
+
     return {
         "total_mergers": total_notifications,
         "total_waivers": total_waivers,
@@ -364,7 +405,8 @@ def generate_stats_json(mergers: list) -> dict:
             "all_business_durations": business_durations
         },
         "top_industries": top_industries,
-        "recent_mergers": recent_mergers
+        "recent_mergers": recent_mergers,
+        "recent_determinations": recent_determinations
     }
 
 


### PR DESCRIPTION
## Summary
This PR adds a new "Recent determinations" section to the dashboard that displays the most recent merger approval decisions, rejections, and phase transitions. It also reorganizes the dashboard layout to prioritize recent determinations and recently notified mergers above the analytics charts.

## Key Changes

- **New Component**: Created `RecentDeterminationsTable.jsx` to display recent merger determinations with:
  - Color-coded determination badges (green for approved, red for rejected, amber for phase 2 referrals)
  - Merger links for easy navigation
  - Waiver status indicators
  - Responsive table design with mobile-friendly styling

- **Data Generation**: Updated `generate_static_data.py` to:
  - Extract determination events from merger data (final determinations and phase 2 referrals)
  - Sort determinations by date in descending order
  - Include top 6 most recent determinations in stats.json

- **Dashboard Reorganization**:
  - Moved "Recent determinations" section to top of dashboard (above charts)
  - Moved "Recently notified mergers" section above analytics charts
  - Filtered "Upcoming events" to show only events within 7 days
  - Improved visual hierarchy and content prioritization

- **Data Updates**: Added 6 sample recent determinations to stats.json covering:
  - Approved mergers (Phase 1 and waiver applications)
  - Rejected waiver application
  - Phase 2 referral

## Implementation Details

- Determination types tracked: `final` (approval/rejection) and `phase_transition` (Phase 2 referral)
- Determination badges use semantic HTML with proper ARIA labels for accessibility
- Table includes merger ID, name, determination status, and date
- Waiver applications are clearly marked with an amber badge
- All merger names are clickable links to detailed merger pages

https://claude.ai/code/session_011mkwF9hqKsquYBYReZGHU5