### PR TITLE
Fix phase 1 determination tracking to properly identify referrals

### DIFF
--- a/merger-tracker/frontend/public/data/stats.json
+++ b/merger-tracker/frontend/public/data/stats.json
@@ -6,7 +6,8 @@
     "Under assessment": 12
   },
   "by_determination": {
-    "Approved": 9
+    "Approved": 9,
+    "Referred to phase 2": 2
   },
   "phase_duration": {
     "average_days": 27.555555555555557,

--- a/scripts/generate_static_data.py
+++ b/scripts/generate_static_data.py
@@ -290,10 +290,12 @@ def generate_stats_json(mergers: list) -> dict:
         status = m.get('status', 'Unknown')
         by_status[status] += 1
     
-    # By determination (notifications only, normalized)
+    # By Phase 1 determination (notifications only)
+    # Use enriched phase_1_determination which correctly identifies "Referred to phase 2"
     by_determination = defaultdict(int)
     for m in notification_mergers:
-        det = normalize_determination(m.get('accc_determination'))
+        enriched = enrich_merger(m)
+        det = enriched.get('phase_1_determination')
         if det:
             by_determination[det] += 1
     


### PR DESCRIPTION
## Summary
Updated the stats generation logic to correctly identify and track "Referred to phase 2" determinations by using the enriched merger data instead of just normalizing the raw determination field.

## Changes
- Modified `generate_stats_json()` to use `enrich_merger()` function which properly identifies phase 1 determinations including referrals to phase 2
- Updated the by_determination stats to now include "Referred to phase 2" category (currently showing 2 cases)
- Improved code comments to clarify that stats are based on Phase 1 determinations from notifications

## Implementation Details
- Previously, the code was using `normalize_determination()` on raw ACCC determination data, which didn't properly capture the "Referred to phase 2" classification
- Now leverages the existing `enrich_merger()` function that contains the logic to correctly identify phase 1 determination outcomes
- This ensures consistency with how merger enrichment is handled elsewhere in the codebase

https://claude.ai/code/session_01LBMxPGesLq9wxY8MGizhrR