### PR TITLE
Align Phase 1 determinations chart colors with status chart

### DIFF
--- a/merger-tracker/frontend/src/pages/Dashboard.jsx
+++ b/merger-tracker/frontend/src/pages/Dashboard.jsx
@@ -105,7 +105,7 @@ function Dashboard() {
     datasets: [
       {
         data: Object.values(stats.by_determination),
-        backgroundColor: ['#10b981', '#ef4444', '#6b7280'],
+        backgroundColor: ['#335145', '#e07a5f', '#6b8f7f', '#8cafa0'],
         borderWidth: 2,
         borderColor: '#fff',
       },


### PR DESCRIPTION
Use consistent color palette (#335145, #e07a5f, etc.) for both
charts so "Approved" matches "Assessment completed" (dark green)
and "Referred to phase 2" matches "Under assessment" (salmon).

https://claude.ai/code/session_01QDKqfTz7m6cokFcBTqSuhV