### PR TITLE
Hide past events from upcoming events table on dashboard

### DIFF
--- a/merger-tracker/frontend/src/pages/Dashboard.jsx
+++ b/merger-tracker/frontend/src/pages/Dashboard.jsx
@@ -18,7 +18,7 @@ import UpcomingEventsTable from '../components/UpcomingEventsTable';
 import RecentDeterminationsTable from '../components/RecentDeterminationsTable';
 import SEO from '../components/SEO';
 import { API_ENDPOINTS } from '../config';
-import { formatDate, getDaysRemaining } from '../utils/dates';
+import { formatDate, getDaysRemaining, isDatePast } from '../utils/dates';
 import { dataCache } from '../utils/dataCache';
 
 ChartJS.register(
@@ -234,6 +234,7 @@ function Dashboard() {
       {/* Upcoming Events (within 7 days) */}
       {upcomingEvents && (() => {
         const eventsWithin7Days = upcomingEvents.filter(event => {
+          if (isDatePast(event.date)) return false;
           const daysRemaining = getDaysRemaining(event.date);
           return daysRemaining !== null && daysRemaining <= 7;
         });

--- a/merger-tracker/frontend/src/utils/dates.js
+++ b/merger-tracker/frontend/src/utils/dates.js
@@ -138,3 +138,20 @@ export const getDaysRemaining = (endDate) => {
     return null;
   }
 };
+
+/**
+ * Check if a date is in the past (before the start of today)
+ * @param {string} dateString - Date in ISO format
+ * @returns {boolean} True if the date is before today
+ */
+export const isDatePast = (dateString) => {
+  if (!dateString) return false;
+  try {
+    const date = parseISO(dateString);
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    return date < today;
+  } catch (e) {
+    return false;
+  }
+};


### PR DESCRIPTION
The upcoming events filter was showing events that had already passed
because getDaysRemaining returns 0 for both today and past dates.
Added isDatePast utility function and use it to filter out events
before today's date.

https://claude.ai/code/session_01JKk9RRHdc9pfwjq9q8gqfo