### PR TITLE
Fix merger statistics subtitle grammar

### DIFF
--- a/merger-tracker/frontend/src/pages/Dashboard.jsx
+++ b/merger-tracker/frontend/src/pages/Dashboard.jsx
@@ -140,7 +140,7 @@ function Dashboard() {
         <StatCard
           title="Mergers"
           value={`${stats.by_status['Under assessment'] || 0} under assessment`}
-          subtitle={`${stats.total_mergers} notified${stats.total_waivers ? `, ${stats.total_waivers} waiver${stats.total_waivers !== 1 ? 's' : ''}` : ''}`}
+          subtitle={`${stats.total_mergers} notified${stats.total_waivers ? ` and ${stats.total_waivers} waiver${stats.total_waivers !== 1 ? 's' : ''}` : ''}`}
           icon="🔍"
         />
         <StatCard


### PR DESCRIPTION
## Summary
Updated the merger statistics subtitle text to use more natural grammar when displaying both notified mergers and waivers.

## Changes
- Changed the conjunction from a comma (`,`) to "and" in the StatCard subtitle
- Updated text from `"X notified, Y waiver(s)"` to `"X notified and Y waiver(s)"`
- This improves readability and grammatical correctness when displaying multiple statistics together

## Details
The subtitle now reads more naturally when both merger and waiver counts are present. For example:
- Before: `"5 notified, 2 waivers"`
- After: `"5 notified and 2 waivers"`

The change maintains the existing logic for singular/plural waiver formatting and only displays the waiver count when it exists.

https://claude.ai/code/session_01G8Q7Ws2AQXUCdKFiUfiGG9