### PR TITLE
Handle ampersands in filename sanitization

### DIFF
--- a/scripts/extract_mergers.py
+++ b/scripts/extract_mergers.py
@@ -53,7 +53,7 @@ def sanitize_filename(filename):
 
     Characters replaced:
     - Colons (:) -> hyphen (-) - problematic on Windows
-    - Other problematic characters are replaced with underscores
+    - Ampersands (&) -> 'and' - not allowed in safe filename regex
 
     Returns None if the filename cannot be sanitized (e.g., path traversal attempts).
     """
@@ -70,6 +70,9 @@ def sanitize_filename(filename):
 
     # Replace colons with hyphens (common in document titles like "Company: Document")
     sanitized = filename.replace(':', ' -')
+
+    # Replace ampersands with 'and' (common in company names like "Toyota & Ford")
+    sanitized = sanitized.replace('&', 'and')
 
     # Clean up any double spaces that might result
     while '  ' in sanitized:


### PR DESCRIPTION
## Summary
Updated the `sanitize_filename()` function to properly handle ampersands (&) by replacing them with the word "and" instead of leaving them in filenames.

## Changes
- Added ampersand (&) to character replacement logic in `sanitize_filename()`
- Ampersands are now replaced with "and" to comply with safe filename regex requirements
- Updated docstring to document the ampersand replacement behavior
- Removed outdated docstring reference to generic "other problematic characters"

## Details
Ampersands are not allowed in the safe filename regex pattern and commonly appear in company names (e.g., "Toyota & Ford"). This change ensures such filenames are properly sanitized while maintaining readability by converting "&" to "and" rather than an underscore or other symbol.

https://claude.ai/code/session_01WpLbn2gNyxF9Nsw8tb49dy