### PR TITLE
Add waiver determination statistics and visualization

### DIFF
--- a/merger-tracker/frontend/public/data/stats.json
+++ b/merger-tracker/frontend/public/data/stats.json
@@ -9,6 +9,10 @@
     "Approved": 10,
     "Referred to phase 2": 2
   },
+  "by_waiver_determination": {
+    "Approved": 16,
+    "Not approved": 3
+  },
   "phase_duration": {
     "average_days": 29.1,
     "median_days": 25,

--- a/merger-tracker/frontend/src/pages/Dashboard.jsx
+++ b/merger-tracker/frontend/src/pages/Dashboard.jsx
@@ -92,11 +92,11 @@ function Dashboard() {
     };
   };
 
-  const statusData = {
-    labels: Object.keys(stats.by_status),
+  const determinationData = {
+    labels: Object.keys(stats.by_determination),
     datasets: [
       {
-        data: Object.values(stats.by_status),
+        data: Object.values(stats.by_determination),
         backgroundColor: ['#335145', '#e07a5f', '#6b8f7f', '#8cafa0'],
         borderWidth: 2,
         borderColor: '#fff',
@@ -104,12 +104,18 @@ function Dashboard() {
     ],
   };
 
-  const determinationData = {
-    labels: Object.keys(stats.by_determination),
+  // Order waiver determinations with Approved first (green), Not approved second (salmon)
+  const waiverLabels = ['Approved', 'Not approved'].filter(
+    (label) => stats.by_waiver_determination && stats.by_waiver_determination[label]
+  );
+  const waiverDeterminationData = {
+    labels: waiverLabels,
     datasets: [
       {
-        data: Object.values(stats.by_determination),
-        backgroundColor: ['#335145', '#e07a5f', '#6b8f7f', '#8cafa0'],
+        data: waiverLabels.map((label) => stats.by_waiver_determination[label]),
+        backgroundColor: waiverLabels.map((label) =>
+          label === 'Approved' ? '#335145' : '#e07a5f'
+        ),
         borderWidth: 2,
         borderColor: '#fff',
       },
@@ -279,17 +285,7 @@ function Dashboard() {
           );
         })()}
 
-        {/* Status Distribution */}
-        <div className="bg-white p-6 rounded-lg shadow">
-          <h2 className="text-lg font-semibold text-gray-900 mb-4">
-            Mergers by status
-          </h2>
-          <div className="h-64" role="img" aria-label={`Doughnut chart showing distribution of mergers by status: ${Object.entries(stats.by_status).map(([status, count]) => `${count} ${status}`).join(', ')}`}>
-            <Doughnut data={statusData} options={chartOptions} />
-          </div>
-        </div>
-
-        {/* Determination Distribution */}
+        {/* Phase 1 Determination Distribution */}
         {Object.keys(stats.by_determination).length > 0 && (
           <div className="bg-white p-6 rounded-lg shadow">
             <h2 className="text-lg font-semibold text-gray-900 mb-4">
@@ -297,6 +293,18 @@ function Dashboard() {
             </h2>
             <div className="h-64" role="img" aria-label={`Doughnut chart showing distribution of Phase 1 determinations: ${Object.entries(stats.by_determination).map(([det, count]) => `${count} ${det}`).join(', ')}`}>
               <Doughnut data={determinationData} options={chartOptions} />
+            </div>
+          </div>
+        )}
+
+        {/* Waiver Determination Distribution */}
+        {stats.by_waiver_determination && Object.keys(stats.by_waiver_determination).length > 0 && (
+          <div className="bg-white p-6 rounded-lg shadow">
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">
+              Waiver determinations
+            </h2>
+            <div className="h-64" role="img" aria-label={`Doughnut chart showing distribution of waiver determinations: ${Object.entries(stats.by_waiver_determination).map(([det, count]) => `${count} ${det}`).join(', ')}`}>
+              <Doughnut data={waiverDeterminationData} options={chartOptions} />
             </div>
           </div>
         )}

--- a/scripts/generate_static_data.py
+++ b/scripts/generate_static_data.py
@@ -299,6 +299,13 @@ def generate_stats_json(mergers: list) -> dict:
         det = enriched.get('phase_1_determination')
         if det:
             by_determination[det] += 1
+
+    # By waiver determination
+    by_waiver_determination = defaultdict(int)
+    for m in waiver_mergers:
+        det = normalize_determination(m.get('accc_determination'))
+        if det:
+            by_waiver_determination[det] += 1
     
     # Phase durations (notifications only)
     durations = []
@@ -399,6 +406,7 @@ def generate_stats_json(mergers: list) -> dict:
         "total_waivers": total_waivers,
         "by_status": dict(by_status),
         "by_determination": dict(by_determination),
+        "by_waiver_determination": dict(by_waiver_determination),
         "phase_duration": {
             "average_days": avg_duration,
             "median_days": median_duration,


### PR DESCRIPTION
## Summary
This PR adds tracking and visualization of waiver determination outcomes (Approved/Not approved) to the merger tracker dashboard, providing better insights into waiver processing results.

## Key Changes
- **Backend (generate_static_data.py)**: Added `by_waiver_determination` calculation that counts waiver merger outcomes by their ACCC determination status
- **Frontend (Dashboard.jsx)**: 
  - Renamed `statusData` to `determinationData` for clarity
  - Added new `waiverDeterminationData` chart configuration with ordered labels (Approved first, Not approved second)
  - Implemented color mapping for waiver determinations (green for Approved, salmon for Not approved)
  - Removed the "Mergers by status" chart section
  - Added new "Waiver determinations" card with doughnut chart visualization
  - Updated "Determination Distribution" label to "Phase 1 Determination Distribution" for clarity
- **Data (stats.json)**: Added sample `by_waiver_determination` data structure with counts

## Implementation Details
- Waiver determination labels are filtered to only display categories present in the data
- Color scheme is dynamically mapped based on determination type for consistency
- Proper accessibility attributes (aria-label) included for the new chart
- Conditional rendering ensures the waiver determinations section only displays when data is available

https://claude.ai/code/session_012gELnamFyuQvMafL3NPH5x