### PR TITLE
Refactor filter state management to sync with URL parameters

### DIFF
--- a/merger-tracker/frontend/src/pages/Mergers.jsx
+++ b/merger-tracker/frontend/src/pages/Mergers.jsx
@@ -26,14 +26,9 @@ function Mergers() {
   const [phaseFilter, setPhaseFilter] = useState('all');
 
   useEffect(() => {
-    const queryParam = searchParams.get('q');
-    if (queryParam) {
-      setSearchTerm(queryParam);
-    }
-    const statusParam = searchParams.get('status');
-    if (statusParam) {
-      setStatusFilter(statusParam);
-    }
+    setSearchTerm(searchParams.get('q') || '');
+    setStatusFilter(searchParams.get('status') || 'all');
+    setPhaseFilter(searchParams.get('phase') || 'all');
   }, [searchParams]);
 
   useEffect(() => {
@@ -56,6 +51,16 @@ function Mergers() {
     } finally {
       setLoading(false);
     }
+  };
+
+  const updateParam = (key, value, defaultValue) => {
+    const params = new URLSearchParams(searchParams);
+    if (value && value !== defaultValue) {
+      params.set(key, value);
+    } else {
+      params.delete(key);
+    }
+    setSearchParams(params);
   };
 
   const filterMergers = () => {
@@ -125,15 +130,7 @@ function Mergers() {
                   placeholder="Search mergers, companies, or industries..."
                   aria-label="Search mergers, companies, or industries"
                   value={searchTerm}
-                  onChange={(e) => {
-                    const value = e.target.value;
-                    setSearchTerm(value);
-                    if (value) {
-                      setSearchParams({ q: value });
-                    } else {
-                      setSearchParams({});
-                    }
-                  }}
+                  onChange={(e) => updateParam('q', e.target.value, '')}
                 />
               </div>
             </div>
@@ -148,7 +145,7 @@ function Mergers() {
                 id="phase"
                 className="w-full px-3 py-2.5 bg-gray-50 border border-gray-200 rounded-xl text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary focus:bg-white transition-all appearance-none"
                 value={phaseFilter}
-                onChange={(e) => setPhaseFilter(e.target.value)}
+                onChange={(e) => updateParam('phase', e.target.value, 'all')}
                 aria-label="Filter by merger phase"
               >
                 <option value="all">All phases</option>
@@ -168,7 +165,7 @@ function Mergers() {
                 id="status"
                 className="w-full px-3 py-2.5 bg-gray-50 border border-gray-200 rounded-xl text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary focus:bg-white transition-all appearance-none"
                 value={statusFilter}
-                onChange={(e) => setStatusFilter(e.target.value)}
+                onChange={(e) => updateParam('status', e.target.value, 'all')}
                 aria-label="Filter by merger status"
               >
                 {outcomes.map((outcome) => (


### PR DESCRIPTION
## Summary
Improved the filter state management in the Mergers page to properly synchronize all filter states (search, status, and phase) with URL query parameters. This ensures filters persist across page navigation and provides a better user experience.

## Key Changes
- **Simplified URL parameter initialization**: Consolidated the `useEffect` hook that reads query parameters to handle all three filters (search, status, phase) in a cleaner way, with proper default values
- **Introduced `updateParam` helper function**: Created a reusable utility function that handles updating URL parameters consistently, automatically removing parameters when they match their default values to keep URLs clean
- **Updated filter change handlers**: Modified the `onChange` handlers for all three filters (search input, phase dropdown, status dropdown) to use the new `updateParam` function instead of inline logic
- **Removed redundant code**: Eliminated duplicate parameter-setting logic that was previously scattered across multiple filter handlers

## Implementation Details
- The `updateParam` function accepts a key, value, and default value, making it flexible for different filter types
- Parameters are only added to the URL when they differ from their defaults, keeping URLs clean and readable
- All three filters now follow the same pattern for state management and URL synchronization
- The phase filter now properly syncs with URL parameters (previously it didn't update the URL at all)

https://claude.ai/code/session_01J8ssj1bYrUGoDbTdg26Zng