### PR TITLE
Persist filter state when navigating to merger details

### DIFF
--- a/merger-tracker/frontend/src/pages/MergerDetail.jsx
+++ b/merger-tracker/frontend/src/pages/MergerDetail.jsx
@@ -17,6 +17,8 @@ function MergerDetail() {
   const [expandedParties, setExpandedParties] = useState({});
   const { isTracked, toggleTracking } = useTracking();
   const tracked = isTracked(id);
+  const savedParams = sessionStorage.getItem('mergers_filter_params');
+  const backToMergers = savedParams ? `/mergers?${savedParams}` : '/mergers';
 
   useEffect(() => {
     fetchMerger();
@@ -106,7 +108,7 @@ function MergerDetail() {
           </p>
           <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
             <Link
-              to="/mergers"
+              to={backToMergers}
               className="inline-flex items-center px-5 py-2.5 text-sm font-medium rounded-xl text-white bg-primary hover:bg-primary-dark transition-colors shadow-sm"
               aria-label="Return to all mergers list"
             >
@@ -189,7 +191,7 @@ function MergerDetail() {
       <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8 animate-fade-in">
         {/* Back button */}
         <Link
-          to="/mergers"
+          to={backToMergers}
           className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-primary mb-5 transition-colors"
           aria-label="Return to all mergers list"
         >

--- a/merger-tracker/frontend/src/pages/Mergers.jsx
+++ b/merger-tracker/frontend/src/pages/Mergers.jsx
@@ -76,6 +76,8 @@ function Mergers() {
     if ((status !== 'all' || phase !== 'all' || tracked) && window.matchMedia('(min-width: 768px)').matches) {
       setFiltersOpen(true);
     }
+    // Persist filter state so it survives navigation to detail pages and back
+    sessionStorage.setItem('mergers_filter_params', searchParams.toString());
   }, [searchParams]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
This PR improves the user experience by preserving filter and search parameters when navigating from the mergers list to a merger detail page and back. Previously, users would lose their applied filters when returning to the list.

## Key Changes
- **Mergers.jsx**: Added logic to persist the current filter parameters (status, phase, search, tracking) to `sessionStorage` whenever the search parameters change
- **MergerDetail.jsx**: Modified back navigation links to use the saved filter parameters instead of always returning to the base `/mergers` route, allowing users to return to their filtered view

## Implementation Details
- Filter state is stored in `sessionStorage` under the key `mergers_filter_params` as a URL query string
- The back button on the detail page checks for saved parameters and constructs the appropriate return URL
- If no saved parameters exist (e.g., direct navigation to detail page), it falls back to the base `/mergers` route
- This approach uses browser session storage, so the filter state is cleared when the browser tab/session ends, preventing stale filter data across sessions

https://claude.ai/code/session_01KmC95vrNtdPX6JgJ4Dn8DM