### PR TITLE
Refactor UpcomingEventsTable: simplify days remaining display

### DIFF
--- a/merger-tracker/frontend/src/components/UpcomingEventsTable.jsx
+++ b/merger-tracker/frontend/src/components/UpcomingEventsTable.jsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { formatDate, getDaysRemaining, getBusinessDaysRemaining } from '../utils/dates';
+import { formatDate, getDaysRemaining } from '../utils/dates';
 
 function UpcomingEventsTable({ events }) {
   if (!events || events.length === 0) {
@@ -51,19 +51,12 @@ function UpcomingEventsTable({ events }) {
               >
                 Merger
               </th>
-              <th
-                scope="col"
-                className="px-5 sm:px-6 py-3.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-              >
-                Days remaining
-              </th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-50">
             {events.map((event, idx) => {
               const daysRemaining = getDaysRemaining(event.date);
-              const businessDaysRemaining = getBusinessDaysRemaining(event.date);
-              const isUrgent = daysRemaining !== null && daysRemaining <= 7;
+              const isUrgent = daysRemaining !== null && daysRemaining <= 3;
 
               return (
                 <tr
@@ -71,8 +64,17 @@ function UpcomingEventsTable({ events }) {
                   className="relative hover:bg-gray-100/70 transition-colors"
                 >
                   {/* Combined cell - mobile only */}
-                  <td className="sm:hidden px-5 py-4 whitespace-nowrap text-sm text-gray-900">
-                    <div className="pl-2.5">{formatDate(event.date)}</div>
+                  <td className="sm:hidden px-5 py-4 whitespace-nowrap text-sm">
+                    <div className="pl-2.5">
+                      <div className={`font-medium ${isUrgent ? 'text-red-700' : 'text-gray-900'}`}>
+                        {daysRemaining === 0
+                          ? 'Today'
+                          : daysRemaining === 1
+                          ? '1 day'
+                          : `${daysRemaining} days`}
+                      </div>
+                      <div className="text-xs text-gray-400 mt-0.5">{formatDate(event.date)}</div>
+                    </div>
                     <span
                       className={`inline-flex items-center px-2.5 py-0.5 rounded-lg text-xs font-semibold mt-1 border ${
                         event.type === 'consultation_due'
@@ -86,8 +88,15 @@ function UpcomingEventsTable({ events }) {
                     </span>
                   </td>
                   {/* Separate cells - desktop only */}
-                  <td className="hidden sm:table-cell px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                    {formatDate(event.date)}
+                  <td className="hidden sm:table-cell px-5 sm:px-6 py-4 whitespace-nowrap text-sm">
+                    <div className={`font-medium ${isUrgent ? 'text-red-700' : 'text-gray-900'}`}>
+                      {daysRemaining === 0
+                        ? 'Today'
+                        : daysRemaining === 1
+                        ? '1 day'
+                        : `${daysRemaining} days`}
+                    </div>
+                    <div className="text-xs text-gray-400 mt-0.5">{formatDate(event.date)}</div>
                   </td>
                   <td className="hidden sm:table-cell px-5 sm:px-6 py-4 whitespace-nowrap text-sm">
                     <span
@@ -113,30 +122,6 @@ function UpcomingEventsTable({ events }) {
                     <div className="text-xs text-gray-400 mt-0.5">
                       {event.merger_id} · {event.stage}
                     </div>
-                  </td>
-                  <td className="px-5 sm:px-6 py-4 text-sm">
-                    {daysRemaining !== null && businessDaysRemaining !== null && (
-                      <div>
-                        <span
-                          className={`font-medium ${
-                            isUrgent ? 'text-red-700' : 'text-gray-900'
-                          }`}
-                        >
-                          {daysRemaining === 0
-                            ? 'Today'
-                            : daysRemaining === 1
-                            ? '1 day'
-                            : `${daysRemaining} days`}
-                        </span>
-                        <div className="text-xs text-gray-400 mt-0.5">
-                          {businessDaysRemaining === 0
-                            ? 'Today'
-                            : businessDaysRemaining === 1
-                            ? '1 business day'
-                            : `${businessDaysRemaining} business days`}
-                        </div>
-                      </div>
-                    )}
                   </td>
                 </tr>
               );


### PR DESCRIPTION
## Summary
Simplified the upcoming events table by removing the separate "Days remaining" column and consolidating the days remaining information into the date cell. This improves the mobile experience and reduces visual clutter while maintaining all essential information.

## Key Changes
- Removed the `getBusinessDaysRemaining` utility function import and its usage
- Deleted the dedicated "Days remaining" table column header and cell
- Consolidated days remaining display into the date cell for both mobile and desktop views
- Updated urgency threshold from 7 days to 3 days
- Enhanced date cell styling with:
  - Days remaining displayed as primary information (bold, red when urgent)
  - Formatted date shown as secondary information (smaller, gray text)
  - Improved visual hierarchy and readability

## Implementation Details
- The days remaining logic now appears in both the mobile-only and desktop-only date cells to maintain consistent behavior across breakpoints
- Removed business days calculation entirely, keeping only calendar days
- Applied conditional red text styling (`text-red-700`) when `isUrgent` is true (≤3 days remaining)
- Maintained all event type badges and merger information display

https://claude.ai/code/session_01F1Z95MqD1Y6KjsMGP7LM7R