### PR TITLE
Add clear button to search input field

### DIFF
--- a/merger-tracker/frontend/src/pages/Mergers.jsx
+++ b/merger-tracker/frontend/src/pages/Mergers.jsx
@@ -179,12 +179,26 @@ function Mergers() {
               <input
                 type="text"
                 id="search"
-                className="w-full pl-10 pr-3 py-2.5 bg-gray-50 border border-gray-200 rounded-xl text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary focus:bg-white transition-all"
+                className={`w-full pl-10 py-2.5 bg-gray-50 border border-gray-200 rounded-xl text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary focus:bg-white transition-all ${
+                  searchTerm ? 'pr-10' : 'pr-3'
+                }`}
                 placeholder="Search mergers, companies, or industries..."
                 aria-label="Search mergers, companies, or industries"
                 value={searchTerm}
                 onChange={(e) => updateParam('q', e.target.value, '')}
               />
+              {searchTerm && (
+                <button
+                  onClick={() => updateParam('q', '', '')}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
+                  aria-label="Clear search"
+                  type="button"
+                >
+                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" strokeWidth="2" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              )}
             </div>
             <button
               onClick={() => setFiltersOpen(!filtersOpen)}


### PR DESCRIPTION
## Summary
Added a clear button to the search input field that appears when a search term is entered, allowing users to quickly reset their search without manually deleting the text.

## Changes
- Modified search input styling to conditionally adjust right padding (`pr-10` when search term exists, `pr-3` otherwise) to accommodate the clear button
- Added a new clear button that:
  - Only renders when `searchTerm` has a value
  - Positioned absolutely on the right side of the input field
  - Displays an X icon (SVG) with hover state styling
  - Clears the search by calling `updateParam('q', '', '')`
  - Includes proper accessibility attributes (`aria-label`, `type="button"`)

## Implementation Details
- Used conditional className binding to dynamically adjust padding based on search term presence
- Clear button uses smooth color transitions on hover for better UX
- SVG icon is properly sized (4x4) and uses `currentColor` for consistent styling
- Button is vertically centered using flexbox positioning (`top-1/2 -translate-y-1/2`)

https://claude.ai/code/session_01PNyfY82BbBGYRd4vgZUSUp