### PR TITLE
Reduce verbose logging and improve error reporting

### DIFF
--- a/scripts/extract_mergers.py
+++ b/scripts/extract_mergers.py
@@ -169,15 +169,11 @@ def download_attachment(merger_id, attachment_url, event_title=None):
             if filename is None:
                 print(f"Warning: Unsafe filename could not be sanitized: {original_filename}", file=sys.stderr)
                 return None
-            if filename != original_filename:
-                print(f"Note: Sanitized filename '{original_filename}' -> '{filename}'", file=sys.stderr)
 
         local_filepath = os.path.join(attachment_dir, filename)
 
         # Check if the file already exists before downloading
         if not os.path.exists(local_filepath):
-            print(f"Downloading new attachment for {merger_id}: {filename}", file=sys.stderr)
-
             # Download the file
             response = requests.get(attachment_url, stream=True)
             response.raise_for_status()  # Raise an exception for bad status codes
@@ -186,7 +182,6 @@ def download_attachment(merger_id, attachment_url, event_title=None):
             with open(local_filepath, 'wb') as f_out:
                 for chunk in response.iter_content(chunk_size=8192):
                     f_out.write(chunk)
-            print(f"Saved to {local_filepath}", file=sys.stderr)
 
         # Check if this is a determination PDF and parse it
         is_determination = (
@@ -196,10 +191,8 @@ def download_attachment(merger_id, attachment_url, event_title=None):
         )
 
         if is_determination and os.path.exists(local_filepath):
-            print(f"Parsing determination PDF: {filename}", file=sys.stderr)
             try:
                 determination_data = parse_determination_pdf(local_filepath)
-                print(f"Successfully parsed determination PDF: {filename}", file=sys.stderr)
             except Exception as e:
                 print(f"Error parsing determination PDF {filename}: {e}", file=sys.stderr)
                 determination_data = None
@@ -239,7 +232,6 @@ def parse_merger_file(filepath, existing_merger_data=None):
                       or None if parsing fails.
     """
     try:
-        print(f"Processing file: {filepath}...", file=sys.stderr)
         with open(filepath, 'r', encoding='utf-8') as f:
             html_content = f.read()
 
@@ -604,9 +596,6 @@ def enrich_with_questionnaire_data(mergers_data):
                     iso_date = q_data['deadline_iso']
                     consultation_datetime = f"{iso_date}T12:00:00Z"
                     merger['consultation_response_due_date'] = consultation_datetime
-
-                    print(f"Updated {matter_id} with consultation date: {consultation_datetime}",
-                          file=sys.stderr)
                     updates_made += 1
 
         if updates_made > 0:


### PR DESCRIPTION
## Summary
This PR reduces excessive logging output throughout the codebase and improves error reporting by consolidating status messages and providing better summary information.

## Key Changes

**scripts/scrape.sh:**
- Removed verbose per-file logging statements (e.g., "Fetching:", "Cleaning") to reduce noise
- Changed error messages to stderr with clearer formatting (`FAILED: <url>`)
- Refactored `clean_html()` to collect all files first and report aggregate statistics instead of per-file messages
- Enhanced parallel fetch error handling to capture and report failed URLs with a summary count
- Added success/failure summary output showing how many pages were successfully fetched vs. failed

**scripts/extract_mergers.py:**
- Removed debug-level logging for filename sanitization notes
- Removed per-file download progress messages
- Removed per-file PDF parsing status messages
- Removed file processing start messages
- Removed consultation date update confirmation messages

## Implementation Details
- Error messages are now consistently directed to stderr
- Summary statistics are provided at the end of operations instead of per-item logging
- The parallel fetch operation now properly captures stderr from failed commands and provides a consolidated report
- Logging is now focused on actionable information rather than verbose progress tracking

https://claude.ai/code/session_01MLVTaajUEVqASMhx1N6wXm