### PR TITLE
Remove stats dependency from Dashboard useEffect cleanup

### DIFF
--- a/merger-tracker/frontend/src/pages/Dashboard.jsx
+++ b/merger-tracker/frontend/src/pages/Dashboard.jsx
@@ -54,7 +54,7 @@ function Dashboard() {
       markCurrentItemsAsSeen();
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
-  }, [stats]);
+  }, []);
 
   const markCurrentItemsAsSeen = () => {
     if (!stats) return;


### PR DESCRIPTION
## Summary
Removed the `stats` dependency from the useEffect cleanup function in the Dashboard component, changing it to run only once on mount.

## Key Changes
- Modified the dependency array of the useEffect hook from `[stats]` to `[]`
- This ensures the cleanup function (which removes the 'beforeunload' event listener) only runs once when the component unmounts, rather than re-running whenever the `stats` object changes

## Implementation Details
The effect sets up a 'beforeunload' event listener and returns a cleanup function that removes it. By removing `stats` from the dependency array, the effect will no longer re-execute when stats updates occur, preventing unnecessary event listener registration/deregistration cycles. The `markCurrentItemsAsSeen()` function called within the effect already has a null check for stats, so it safely handles cases where stats may not be available.

https://claude.ai/code/session_01JT2yW3v1sv2jzKChDA7EwJ