### PR TITLE
Add caching to Dashboard data fetches to prevent redundant API calls

### DIFF
--- a/merger-tracker/frontend/src/pages/Dashboard.jsx
+++ b/merger-tracker/frontend/src/pages/Dashboard.jsx
@@ -40,8 +40,13 @@ function Dashboard() {
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    fetchStats();
-    fetchUpcomingEvents();
+    // Only fetch if not already cached
+    if (!dataCache.has('dashboard-stats')) {
+      fetchStats();
+    }
+    if (!dataCache.has('dashboard-events')) {
+      fetchUpcomingEvents();
+    }
 
     // Mark items as seen when page is about to unload or component unmounts
     const handleBeforeUnload = () => {


### PR DESCRIPTION
## Summary
Implemented caching logic for Dashboard data fetches to avoid redundant API calls when the component mounts or re-renders.

## Key Changes
- Added conditional checks using `dataCache` before fetching dashboard stats and upcoming events
- Stats are only fetched if `'dashboard-stats'` is not already in the cache
- Upcoming events are only fetched if `'dashboard-events'` is not already in the cache

## Implementation Details
The caching logic leverages an existing `dataCache` object to track which data has already been fetched. This prevents unnecessary API calls during component lifecycle events, improving performance and reducing server load. The cache keys (`'dashboard-stats'` and `'dashboard-events'`) are used to independently manage the fetch state of each data type.

https://claude.ai/code/session_01XsuFj1Cy5q5uatxqdcP5Wk