### PR TITLE
Add styling for "Assessment suspended" status badge

### DIFF
--- a/merger-tracker/frontend/src/components/StatusBadge.jsx
+++ b/merger-tracker/frontend/src/components/StatusBadge.jsx
@@ -6,6 +6,8 @@ function StatusBadge({ status, determination }) {
       return 'bg-red-50 text-red-700 border-red-200/60';
     } else if (status === 'Under assessment') {
       return 'bg-primary/5 text-primary border-primary/20';
+    } else if (status === 'Assessment suspended') {
+      return 'bg-orange-50 text-orange-700 border-orange-200/60';
     } else if (status === 'Assessment completed') {
       return 'bg-gray-50 text-gray-600 border-gray-200/60';
     }


### PR DESCRIPTION
## Summary
Added visual styling support for the "Assessment suspended" status in the StatusBadge component.

## Key Changes
- Added a new conditional branch to handle the "Assessment suspended" status
- Applied orange-themed styling (bg-orange-50, text-orange-700, border-orange-200/60) to visually distinguish suspended assessments from other statuses

## Implementation Details
The new status case is positioned between "Under assessment" and "Assessment completed" in the conditional chain, maintaining logical grouping of assessment-related statuses. The orange color scheme provides clear visual differentiation to indicate a paused or suspended state.

https://claude.ai/code/session_01EpdutZTgfxdAthFm5ttzAg