### PR TITLE
Add percentage display to chart tooltips

### DIFF
--- a/merger-tracker/frontend/src/pages/Dashboard.jsx
+++ b/merger-tracker/frontend/src/pages/Dashboard.jsx
@@ -149,6 +149,15 @@ function Dashboard() {
           },
         },
       },
+      tooltip: {
+        callbacks: {
+          label: (item) => {
+            const total = item.dataset.data.reduce((sum, val) => sum + val, 0);
+            const pct = total > 0 ? Math.round((item.parsed / total) * 100) : 0;
+            return ` ${item.parsed} (${pct}%)`;
+          },
+        },
+      },
     },
   };
 


### PR DESCRIPTION
## Summary
Enhanced the dashboard chart tooltips to display both absolute values and percentages for better data visualization and user understanding.

## Key Changes
- Added tooltip configuration with custom label callback to the chart options
- Calculates the percentage of each data point relative to the total dataset sum
- Displays tooltip in format: `value (percentage%)` (e.g., "42 (35%)")
- Includes safety check to prevent division by zero when total is 0

## Implementation Details
- The tooltip callback iterates through the dataset to compute the total sum
- Percentage is rounded to the nearest integer for cleaner display
- Falls back to 0% when total is 0 to avoid NaN values

https://claude.ai/code/session_01UoZnpB6sCXidqWbuVrxJFM