### PR TITLE
Fix sub-issue linking to use database IDs instead of issue numbers

### DIFF
--- a/.github/workflows/detect-duplicates.yml
+++ b/.github/workflows/detect-duplicates.yml
@@ -96,37 +96,38 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          SUB_NUMS=""
+          SUB_IDS=""
           COUNT=$(jq '.sub_issues | length' issue_content.json)
 
           for i in $(seq 0 $((COUNT - 1))); do
             TITLE=$(jq -r ".sub_issues[$i].title" issue_content.json)
             BODY=$(jq -r ".sub_issues[$i].body" issue_content.json)
-            NUM=$(gh issue create \
+            # gh issue create prints the issue URL; extract the number from it
+            URL=$(gh issue create \
               --title "$TITLE" \
               --body "$BODY" \
-              --label "duplicate-events" \
-              --json number \
-              --jq '.number')
-            SUB_NUMS="$SUB_NUMS $NUM"
-            echo "Created sub-issue #$NUM: $TITLE"
+              --label "duplicate-events")
+            NUM=$(basename "$URL")
+            # Sub-issue linking requires the database id, not the issue number
+            ID=$(gh api "repos/$GITHUB_REPOSITORY/issues/$NUM" --jq '.id')
+            SUB_IDS="$SUB_IDS $ID"
+            echo "Created sub-issue #$NUM (id=$ID): $TITLE"
           done
 
           MAIN_TITLE=$(jq -r '.main_issue.title' issue_content.json)
           MAIN_BODY=$(jq -r '.main_issue.body' issue_content.json)
-          MAIN_NUM=$(gh issue create \
+          MAIN_URL=$(gh issue create \
             --title "$MAIN_TITLE" \
             --body "$MAIN_BODY" \
-            --label "duplicate-events" \
-            --json number \
-            --jq '.number')
+            --label "duplicate-events")
+          MAIN_NUM=$(basename "$MAIN_URL")
           echo "Created main issue #$MAIN_NUM"
 
-          for SUB_NUM in $SUB_NUMS; do
+          for SUB_ID in $SUB_IDS; do
             gh api "repos/$GITHUB_REPOSITORY/issues/$MAIN_NUM/sub_issues" \
               --method POST \
-              -F sub_issue_id="$SUB_NUM" \
-              || echo "Warning: could not attach sub-issue #$SUB_NUM as a sub-issue (feature may not be enabled on this repo)"
+              -F sub_issue_id="$SUB_ID" \
+              || echo "Warning: could not attach sub-issue id=$SUB_ID (feature may not be enabled on this repo)"
           done
 
       - name: Close all duplicate-events issues when resolved


### PR DESCRIPTION
## Summary
Updated the duplicate detection workflow to correctly link sub-issues using their database IDs rather than issue numbers, which is required by the GitHub API for sub-issue operations.

## Key Changes
- Changed variable naming from `SUB_NUMS` to `SUB_IDS` to reflect that database IDs are now being collected instead of issue numbers
- Modified `gh issue create` calls to parse the returned URL instead of using the `--json number` flag
- Added API call to fetch the database ID (`id` field) for each created sub-issue, which is required for sub-issue linking
- Updated the sub-issue attachment loop to use the database IDs (`SUB_ID`) instead of issue numbers when calling the sub-issues API endpoint
- Improved error messages to clarify that IDs (not issue numbers) are being used for sub-issue operations
- Added clarifying comment explaining why database IDs are needed for sub-issue linking

## Implementation Details
The GitHub API's sub-issue linking endpoint requires the database ID of an issue, not its number. The workflow now:
1. Creates each sub-issue and extracts the issue number from the returned URL
2. Queries the GitHub API to retrieve the database ID for that issue number
3. Uses the database ID when linking sub-issues to the main issue

https://claude.ai/code/session_014cRo1jChtxz2PNQyawrJNR