### PR TITLE
Optimize GitHub issue creation by using --json flag

### DIFF
--- a/.github/workflows/detect-duplicates.yml
+++ b/.github/workflows/detect-duplicates.yml
@@ -102,25 +102,27 @@ jobs:
           for i in $(seq 0 $((COUNT - 1))); do
             TITLE=$(jq -r ".sub_issues[$i].title" issue_content.json)
             BODY=$(jq -r ".sub_issues[$i].body" issue_content.json)
-            # gh issue create prints the issue URL; extract the number from it
-            URL=$(gh issue create \
+            # Use --json to get both number and database id in one call,
+            # avoiding a separate gh api lookup that can transiently 404.
+            RESULT=$(gh issue create \
               --title "$TITLE" \
               --body "$BODY" \
-              --label "duplicate-events")
-            NUM=$(basename "$URL")
-            # Sub-issue linking requires the database id, not the issue number
-            ID=$(gh api "repos/$GITHUB_REPOSITORY/issues/$NUM" --jq '.id')
+              --label "duplicate-events" \
+              --json id,number)
+            NUM=$(echo "$RESULT" | jq -r '.number')
+            ID=$(echo "$RESULT" | jq -r '.id')
             SUB_IDS="$SUB_IDS $ID"
             echo "Created sub-issue #$NUM (id=$ID): $TITLE"
           done
 
           MAIN_TITLE=$(jq -r '.main_issue.title' issue_content.json)
           MAIN_BODY=$(jq -r '.main_issue.body' issue_content.json)
-          MAIN_URL=$(gh issue create \
+          MAIN_RESULT=$(gh issue create \
             --title "$MAIN_TITLE" \
             --body "$MAIN_BODY" \
-            --label "duplicate-events")
-          MAIN_NUM=$(basename "$MAIN_URL")
+            --label "duplicate-events" \
+            --json number)
+          MAIN_NUM=$(echo "$MAIN_RESULT" | jq -r '.number')
           echo "Created main issue #$MAIN_NUM"
 
           for SUB_ID in $SUB_IDS; do


### PR DESCRIPTION
## Summary
Refactored the GitHub CLI issue creation commands to use the `--json` flag for retrieving issue metadata, eliminating the need for separate API calls and improving reliability.

## Key Changes
- Modified sub-issue creation to use `gh issue create --json id,number` instead of parsing the URL and making a separate `gh api` call to fetch the issue ID
- Updated main issue creation to use `gh issue create --json number` for consistency
- Changed result parsing from `basename "$URL"` to `jq` extraction from JSON output
- Removed the transient `gh api` lookup that could occasionally fail with a 404 error

## Implementation Details
- The `--json` flag allows retrieving both the issue number and database ID in a single command invocation
- Results are now parsed using `jq` to extract the `number` and `id` fields from the JSON response
- This change reduces the number of GitHub API calls and eliminates a potential race condition where the newly created issue might not be immediately available for lookup
- The refactoring maintains the same functionality while improving robustness and performance

https://claude.ai/code/session_0125D2btES3iMJKgL8pGpaNe