### PR TITLE
Add PDF viewer with embedded document preview for merger files

### DIFF
--- a/functions/_lib/pdf-viewer.js
+++ b/functions/_lib/pdf-viewer.js
@@ -1,0 +1,79 @@
+const DOWNLOAD_ICON = '<svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>';
+
+const DOCUMENT_ICON = '<svg width="28" height="28" fill="none" stroke="#9ca3af" stroke-width="1.5" viewBox="0 0 24 24"><path d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"/></svg>';
+
+const CSS = `
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+html,body{height:100%;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#f8f9fa}
+.banner{display:flex;align-items:center;justify-content:space-between;height:52px;padding:0 20px;background:#335145;color:#fff;font-size:14px;gap:16px}
+.banner a{color:#a7f3d0;text-decoration:none}
+.banner a:hover{color:#fff;text-decoration:underline}
+.left{display:flex;align-items:center;gap:10px;min-width:0}
+.site{font-weight:600;white-space:nowrap}
+.sep{color:rgba(255,255,255,.3)}
+.doc{color:rgba(255,255,255,.75);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.right{display:flex;align-items:center;gap:10px;flex-shrink:0}
+.btn{display:inline-flex;align-items:center;gap:6px;padding:6px 14px;border-radius:8px;font-size:13px;font-weight:500;text-decoration:none!important;white-space:nowrap;transition:background .15s,border-color .15s}
+.btn-ghost{border:1px solid rgba(255,255,255,.25);color:#fff}
+.btn-ghost:hover{background:rgba(255,255,255,.1);border-color:rgba(255,255,255,.4);color:#fff}
+.btn-primary{background:#10b981;color:#fff}
+.btn-primary:hover{background:#059669;color:#fff}
+.viewer{height:calc(100vh - 52px)}
+.viewer object{width:100%;height:100%;border:none}
+.fallback{display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;gap:16px;padding:32px;text-align:center;color:#4b5563}
+.fallback-icon{width:64px;height:64px;border-radius:16px;background:#f3f4f6;display:flex;align-items:center;justify-content:center}
+.fallback p{max-width:360px;line-height:1.5}
+.fallback .btn-dl{background:#335145;color:#fff;padding:10px 20px;font-size:14px;border-radius:10px;text-decoration:none!important}
+.fallback .btn-dl:hover{background:#223a30;color:#fff}
+@media(max-width:640px){.banner{padding:0 12px;gap:8px}.doc,.sep{display:none}.btn span.label{display:none}}
+`.trim();
+
+function esc(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export function renderViewer({ matterId, displayName, fileName, rawPdfUrl, mergerPageUrl }) {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>${esc(displayName)} – ${esc(matterId)} | Australian Merger Tracker</title>
+  <meta name="description" content="Document from ACCC merger review ${esc(matterId)}: ${esc(displayName)}. View the full merger details on mergers.fyi.">
+  <link rel="canonical" href="https://mergers.fyi${mergerPageUrl}">
+  <style>${CSS}</style>
+</head>
+<body>
+  <div class="banner">
+    <div class="left">
+      <a href="/" class="site">mergers.fyi</a>
+      <span class="sep">|</span>
+      <span class="doc">${esc(displayName)}</span>
+    </div>
+    <div class="right">
+      <a href="${esc(rawPdfUrl)}" class="btn btn-ghost" download="${esc(fileName)}">
+        ${DOWNLOAD_ICON}
+        <span class="label">Download</span>
+      </a>
+      <a href="${esc(mergerPageUrl)}" class="btn btn-primary">
+        View merger &rarr;
+      </a>
+    </div>
+  </div>
+  <div class="viewer">
+    <object data="${esc(rawPdfUrl)}" type="application/pdf">
+      <div class="fallback">
+        <div class="fallback-icon">${DOCUMENT_ICON}</div>
+        <p>PDF preview isn't available in your browser.</p>
+        <a href="${esc(rawPdfUrl)}" class="btn btn-dl" download="${esc(fileName)}">Download PDF</a>
+      </div>
+    </object>
+  </div>
+</body>
+</html>`;
+}

--- a/functions/_lib/pdf-viewer.js
+++ b/functions/_lib/pdf-viewer.js
@@ -1,5 +1,3 @@
-const DOWNLOAD_ICON = '<svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>';
-
 const DOCUMENT_ICON = '<svg width="28" height="28" fill="none" stroke="#9ca3af" stroke-width="1.5" viewBox="0 0 24 24"><path d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"/></svg>';
 
 const CSS = `
@@ -14,8 +12,6 @@ html,body{height:100%;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Ro
 .doc{color:rgba(255,255,255,.75);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .right{display:flex;align-items:center;gap:10px;flex-shrink:0}
 .btn{display:inline-flex;align-items:center;gap:6px;padding:6px 14px;border-radius:8px;font-size:13px;font-weight:500;text-decoration:none!important;white-space:nowrap;transition:background .15s,border-color .15s}
-.btn-ghost{border:1px solid rgba(255,255,255,.25);color:#fff}
-.btn-ghost:hover{background:rgba(255,255,255,.1);border-color:rgba(255,255,255,.4);color:#fff}
 .btn-primary{background:#10b981;color:#fff}
 .btn-primary:hover{background:#059669;color:#fff}
 .viewer{height:calc(100vh - 52px)}
@@ -25,7 +21,7 @@ html,body{height:100%;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Ro
 .fallback p{max-width:360px;line-height:1.5}
 .fallback .btn-dl{background:#335145;color:#fff;padding:10px 20px;font-size:14px;border-radius:10px;text-decoration:none!important}
 .fallback .btn-dl:hover{background:#223a30;color:#fff}
-@media(max-width:640px){.banner{padding:0 12px;gap:8px}.doc,.sep{display:none}.btn span.label{display:none}}
+@media(max-width:640px){.banner{padding:0 12px;gap:8px}.doc,.sep{display:none}}
 `.trim();
 
 function esc(str) {
@@ -37,7 +33,7 @@ function esc(str) {
     .replace(/'/g, '&#39;');
 }
 
-export function renderViewer({ matterId, displayName, fileName, rawPdfUrl, mergerPageUrl }) {
+export function renderViewer({ matterId, displayName, rawPdfUrl, mergerPageUrl }) {
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -56,10 +52,6 @@ export function renderViewer({ matterId, displayName, fileName, rawPdfUrl, merge
       <span class="doc">${esc(displayName)}</span>
     </div>
     <div class="right">
-      <a href="${esc(rawPdfUrl)}" class="btn btn-ghost" download="${esc(fileName)}">
-        ${DOWNLOAD_ICON}
-        <span class="label">Download</span>
-      </a>
       <a href="${esc(mergerPageUrl)}" class="btn btn-primary">
         View merger &rarr;
       </a>
@@ -70,7 +62,7 @@ export function renderViewer({ matterId, displayName, fileName, rawPdfUrl, merge
       <div class="fallback">
         <div class="fallback-icon">${DOCUMENT_ICON}</div>
         <p>PDF preview isn't available in your browser.</p>
-        <a href="${esc(rawPdfUrl)}" class="btn btn-dl" download="${esc(fileName)}">Download PDF</a>
+        <a href="${esc(rawPdfUrl)}" class="btn btn-dl">Download PDF</a>
       </div>
     </object>
   </div>

--- a/functions/mergers/[matter]/[[path]].js
+++ b/functions/mergers/[matter]/[[path]].js
@@ -24,12 +24,11 @@ export async function onRequest(context) {
   }
 
   const matterId = match[1];
-  const fileName = decodeURIComponent(path.split('/').pop());
+  const displayName = decodeURIComponent(path.split('/').pop()).replace(/\.pdf$/i, '');
 
   const html = renderViewer({
     matterId,
-    displayName: fileName.replace(/\.pdf$/i, ''),
-    fileName,
+    displayName,
     rawPdfUrl: `${path}?raw=1`,
     mergerPageUrl: `/mergers/${matterId}`,
   });

--- a/functions/mergers/[matter]/[[path]].js
+++ b/functions/mergers/[matter]/[[path]].js
@@ -1,3 +1,5 @@
+import { renderViewer } from '../../_lib/pdf-viewer.js';
+
 export async function onRequest(context) {
   const { request, env } = context;
   const url = new URL(request.url);
@@ -23,90 +25,19 @@ export async function onRequest(context) {
 
   const matterId = match[1];
   const fileName = decodeURIComponent(path.split('/').pop());
-  const displayName = fileName.replace(/\.pdf$/i, '');
-  const rawPdfUrl = `${path}?raw=1`;
-  const mergerPageUrl = `/mergers/${matterId}`;
 
-  return new Response(viewerHtml(matterId, displayName, fileName, rawPdfUrl, mergerPageUrl), {
+  const html = renderViewer({
+    matterId,
+    displayName: fileName.replace(/\.pdf$/i, ''),
+    fileName,
+    rawPdfUrl: `${path}?raw=1`,
+    mergerPageUrl: `/mergers/${matterId}`,
+  });
+
+  return new Response(html, {
     headers: {
       'Content-Type': 'text/html; charset=utf-8',
       'Cache-Control': 'public, max-age=3600',
     },
   });
-}
-
-function viewerHtml(matterId, displayName, fileName, rawPdfUrl, mergerPageUrl) {
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>${esc(displayName)} – ${esc(matterId)} | Australian Merger Tracker</title>
-  <meta name="description" content="Document from ACCC merger review ${esc(matterId)}: ${esc(displayName)}. View the full merger details on mergers.fyi.">
-  <link rel="canonical" href="https://mergers.fyi${mergerPageUrl}">
-  <style>
-    *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
-    html,body{height:100%;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#f8f9fa}
-    .banner{display:flex;align-items:center;justify-content:space-between;height:52px;padding:0 20px;background:#335145;color:#fff;font-size:14px;gap:16px}
-    .banner a{color:#a7f3d0;text-decoration:none}
-    .banner a:hover{color:#fff;text-decoration:underline}
-    .left{display:flex;align-items:center;gap:10px;min-width:0}
-    .site{font-weight:600;white-space:nowrap}
-    .sep{color:rgba(255,255,255,.3)}
-    .doc{color:rgba(255,255,255,.75);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-    .right{display:flex;align-items:center;gap:10px;flex-shrink:0}
-    .btn{display:inline-flex;align-items:center;gap:6px;padding:6px 14px;border-radius:8px;font-size:13px;font-weight:500;text-decoration:none!important;white-space:nowrap;transition:background .15s,border-color .15s}
-    .btn-ghost{border:1px solid rgba(255,255,255,.25);color:#fff}
-    .btn-ghost:hover{background:rgba(255,255,255,.1);border-color:rgba(255,255,255,.4);color:#fff}
-    .btn-primary{background:#10b981;color:#fff}
-    .btn-primary:hover{background:#059669;color:#fff}
-    .viewer{height:calc(100vh - 52px)}
-    .viewer object{width:100%;height:100%;border:none}
-    .fallback{display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;gap:16px;padding:32px;text-align:center;color:#4b5563}
-    .fallback-icon{width:64px;height:64px;border-radius:16px;background:#f3f4f6;display:flex;align-items:center;justify-content:center}
-    .fallback p{max-width:360px;line-height:1.5}
-    .fallback .btn-dl{background:#335145;color:#fff;padding:10px 20px;font-size:14px;border-radius:10px;text-decoration:none!important}
-    .fallback .btn-dl:hover{background:#223a30;color:#fff}
-    @media(max-width:640px){.banner{padding:0 12px;gap:8px}.doc,.sep{display:none}.btn span.label{display:none}}
-  </style>
-</head>
-<body>
-  <div class="banner">
-    <div class="left">
-      <a href="/" class="site">mergers.fyi</a>
-      <span class="sep">|</span>
-      <span class="doc">${esc(displayName)}</span>
-    </div>
-    <div class="right">
-      <a href="${esc(rawPdfUrl)}" class="btn btn-ghost" download="${esc(fileName)}">
-        <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-        <span class="label">Download</span>
-      </a>
-      <a href="${esc(mergerPageUrl)}" class="btn btn-primary">
-        View merger &rarr;
-      </a>
-    </div>
-  </div>
-  <div class="viewer">
-    <object data="${esc(rawPdfUrl)}" type="application/pdf">
-      <div class="fallback">
-        <div class="fallback-icon">
-          <svg width="28" height="28" fill="none" stroke="#9ca3af" stroke-width="1.5" viewBox="0 0 24 24"><path d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"/></svg>
-        </div>
-        <p>PDF preview isn't available in your browser.</p>
-        <a href="${esc(rawPdfUrl)}" class="btn btn-dl" download="${esc(fileName)}">Download PDF</a>
-      </div>
-    </object>
-  </div>
-</body>
-</html>`;
-}
-
-function esc(str) {
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
 }

--- a/functions/mergers/[matter]/[[path]].js
+++ b/functions/mergers/[matter]/[[path]].js
@@ -15,8 +15,8 @@ export async function onRequest(context) {
     return env.ASSETS.fetch(new Request(assetUrl.toString()));
   }
 
-  // Extract matter ID from the path: /mergers/MN-XXXXX/filename.pdf
-  const match = path.match(/^\/mergers\/(MN-\d+)\//i);
+  // Extract matter ID from the path: /mergers/{MN,WA}-XXXXX/filename.pdf
+  const match = path.match(/^\/mergers\/((MN|WA)-\d+)\//i);
   if (!match) {
     return context.next();
   }

--- a/functions/mergers/[matter]/[[path]].js
+++ b/functions/mergers/[matter]/[[path]].js
@@ -1,0 +1,112 @@
+export async function onRequest(context) {
+  const { request, env } = context;
+  const url = new URL(request.url);
+  const path = url.pathname;
+
+  // Only intercept .pdf requests — let everything else (SPA routes, etc.) pass through
+  if (!path.toLowerCase().endsWith('.pdf')) {
+    return context.next();
+  }
+
+  // If ?raw param is present, serve the actual PDF from static assets
+  // (used by the embedded viewer and direct download links)
+  if (url.searchParams.has('raw')) {
+    const assetUrl = new URL(path, url.origin);
+    return env.ASSETS.fetch(new Request(assetUrl.toString()));
+  }
+
+  // Extract matter ID from the path: /mergers/MN-XXXXX/filename.pdf
+  const match = path.match(/^\/mergers\/(MN-\d+)\//i);
+  if (!match) {
+    return context.next();
+  }
+
+  const matterId = match[1];
+  const fileName = decodeURIComponent(path.split('/').pop());
+  const displayName = fileName.replace(/\.pdf$/i, '');
+  const rawPdfUrl = `${path}?raw=1`;
+  const mergerPageUrl = `/mergers/${matterId}`;
+
+  return new Response(viewerHtml(matterId, displayName, fileName, rawPdfUrl, mergerPageUrl), {
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+}
+
+function viewerHtml(matterId, displayName, fileName, rawPdfUrl, mergerPageUrl) {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>${esc(displayName)} – ${esc(matterId)} | Australian Merger Tracker</title>
+  <meta name="description" content="Document from ACCC merger review ${esc(matterId)}: ${esc(displayName)}. View the full merger details on mergers.fyi.">
+  <link rel="canonical" href="https://mergers.fyi${mergerPageUrl}">
+  <style>
+    *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+    html,body{height:100%;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#f8f9fa}
+    .banner{display:flex;align-items:center;justify-content:space-between;height:52px;padding:0 20px;background:#335145;color:#fff;font-size:14px;gap:16px}
+    .banner a{color:#a7f3d0;text-decoration:none}
+    .banner a:hover{color:#fff;text-decoration:underline}
+    .left{display:flex;align-items:center;gap:10px;min-width:0}
+    .site{font-weight:600;white-space:nowrap}
+    .sep{color:rgba(255,255,255,.3)}
+    .doc{color:rgba(255,255,255,.75);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+    .right{display:flex;align-items:center;gap:10px;flex-shrink:0}
+    .btn{display:inline-flex;align-items:center;gap:6px;padding:6px 14px;border-radius:8px;font-size:13px;font-weight:500;text-decoration:none!important;white-space:nowrap;transition:background .15s,border-color .15s}
+    .btn-ghost{border:1px solid rgba(255,255,255,.25);color:#fff}
+    .btn-ghost:hover{background:rgba(255,255,255,.1);border-color:rgba(255,255,255,.4);color:#fff}
+    .btn-primary{background:#10b981;color:#fff}
+    .btn-primary:hover{background:#059669;color:#fff}
+    .viewer{height:calc(100vh - 52px)}
+    .viewer object{width:100%;height:100%;border:none}
+    .fallback{display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;gap:16px;padding:32px;text-align:center;color:#4b5563}
+    .fallback-icon{width:64px;height:64px;border-radius:16px;background:#f3f4f6;display:flex;align-items:center;justify-content:center}
+    .fallback p{max-width:360px;line-height:1.5}
+    .fallback .btn-dl{background:#335145;color:#fff;padding:10px 20px;font-size:14px;border-radius:10px;text-decoration:none!important}
+    .fallback .btn-dl:hover{background:#223a30;color:#fff}
+    @media(max-width:640px){.banner{padding:0 12px;gap:8px}.doc,.sep{display:none}.btn span.label{display:none}}
+  </style>
+</head>
+<body>
+  <div class="banner">
+    <div class="left">
+      <a href="/" class="site">mergers.fyi</a>
+      <span class="sep">|</span>
+      <span class="doc">${esc(displayName)}</span>
+    </div>
+    <div class="right">
+      <a href="${esc(rawPdfUrl)}" class="btn btn-ghost" download="${esc(fileName)}">
+        <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        <span class="label">Download</span>
+      </a>
+      <a href="${esc(mergerPageUrl)}" class="btn btn-primary">
+        View merger &rarr;
+      </a>
+    </div>
+  </div>
+  <div class="viewer">
+    <object data="${esc(rawPdfUrl)}" type="application/pdf">
+      <div class="fallback">
+        <div class="fallback-icon">
+          <svg width="28" height="28" fill="none" stroke="#9ca3af" stroke-width="1.5" viewBox="0 0 24 24"><path d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"/></svg>
+        </div>
+        <p>PDF preview isn't available in your browser.</p>
+        <a href="${esc(rawPdfUrl)}" class="btn btn-dl" download="${esc(fileName)}">Download PDF</a>
+      </div>
+    </object>
+  </div>
+</body>
+</html>`;
+}
+
+function esc(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}


### PR DESCRIPTION
## Summary
This PR adds a new Cloudflare Pages function that intercepts PDF requests for merger documents and serves them with an embedded viewer interface, rather than serving raw PDFs directly.

## Key Changes
- **New PDF viewer middleware** (`functions/mergers/[matter]/[[path]].js`): Intercepts all `.pdf` requests under the `/mergers/` path
- **Smart request routing**: 
  - Passes through non-PDF requests to allow SPA routes to work normally
  - Serves raw PDFs when `?raw` query parameter is present (for embedded viewer and direct downloads)
  - Generates an HTML wrapper with embedded PDF viewer for direct PDF requests
- **Document metadata extraction**: Parses matter ID (e.g., `MN-XXXXX`) and filename from the URL path
- **Responsive viewer UI**: Includes a banner with navigation, document title, download button, and link back to the merger details page
- **Fallback support**: Provides a download link when PDF preview isn't available in the browser
- **Security**: Implements HTML escaping for all user-controlled content to prevent XSS attacks
- **Performance**: Sets 1-hour cache control headers for the generated HTML pages

## Implementation Details
- Uses `<object>` tag for native PDF embedding with graceful fallback
- Responsive design that hides document name and labels on mobile devices
- Styled banner with site branding, document info, and action buttons
- Proper canonical link to the merger page for SEO
- Comprehensive meta tags for document discoverability

https://claude.ai/code/session_0159mQeS4HhGVzshUYTGyzPV