### PR TITLE
Link related merger filings (waiver vs. formal notification)

### DIFF
--- a/data/output/mergers.json
+++ b/data/output/mergers.json
@@ -2991,7 +2991,12 @@
       "phase_2_determination": null,
       "phase_2_determination_date": null,
       "public_benefits_determination": null,
-      "public_benefits_determination_date": null
+      "public_benefits_determination_date": null,
+      "related_merger": {
+        "merger_id": "WA-01087",
+        "relationship": "refiled_from",
+        "merger_name": "Eli Lilly \u2013 Orna Therapeutics"
+      }
     },
     {
       "url": "https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/symal-group-timms-group-and-ld-group",
@@ -3986,7 +3991,12 @@
       "phase_2_determination": null,
       "phase_2_determination_date": null,
       "public_benefits_determination": null,
-      "public_benefits_determination_date": null
+      "public_benefits_determination_date": null,
+      "related_merger": {
+        "merger_id": "WA-65003",
+        "relationship": "refiled_from",
+        "merger_name": "Henkel \u2013 ATP adhesive systems group"
+      }
     },
     {
       "url": "https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/intrepid-travel-wild-bush-luxury",
@@ -4078,7 +4088,12 @@
       "phase_2_determination": null,
       "phase_2_determination_date": null,
       "public_benefits_determination": null,
-      "public_benefits_determination_date": null
+      "public_benefits_determination_date": null,
+      "related_merger": {
+        "merger_id": "WA-70003",
+        "relationship": "refiled_from",
+        "merger_name": "Intrepid Travel \u2013 Wild Bush Luxury"
+      }
     },
     {
       "url": "https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/gilead-arcellx",
@@ -7182,7 +7197,12 @@
       "phase_2_determination": null,
       "phase_2_determination_date": null,
       "public_benefits_determination": null,
-      "public_benefits_determination_date": null
+      "public_benefits_determination_date": null,
+      "related_merger": {
+        "merger_id": "WA-35003",
+        "relationship": "refiled_from",
+        "merger_name": "Salesforce \u2013 Qualified"
+      }
     },
     {
       "url": "https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/care-%E2%80%93-motorone-autobody",
@@ -7964,7 +7984,12 @@
       "phase_2_determination": null,
       "phase_2_determination_date": null,
       "public_benefits_determination": null,
-      "public_benefits_determination_date": null
+      "public_benefits_determination_date": null,
+      "related_merger": {
+        "merger_id": "MN-20013",
+        "relationship": "refiled_as",
+        "merger_name": "Eli Lilly / Orna Therapeutics"
+      }
     },
     {
       "url": "https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/bsn-sports-%E2%80%93-sports-endeavors",
@@ -11358,7 +11383,12 @@
       "phase_2_determination": null,
       "phase_2_determination_date": null,
       "public_benefits_determination": null,
-      "public_benefits_determination_date": null
+      "public_benefits_determination_date": null,
+      "related_merger": {
+        "merger_id": "MN-85007",
+        "relationship": "refiled_as",
+        "merger_name": "Salesforce \u2013 Qualified"
+      }
     },
     {
       "url": "https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/l-catterton-management-%E2%80%93-ex-nihilo-group",
@@ -14137,7 +14167,12 @@
       "phase_2_determination": null,
       "phase_2_determination_date": null,
       "public_benefits_determination": null,
-      "public_benefits_determination_date": null
+      "public_benefits_determination_date": null,
+      "related_merger": {
+        "merger_id": "MN-40005",
+        "relationship": "refiled_as",
+        "merger_name": "Henkel \u2013 ATP Adhesives Systems Group"
+      }
     },
     {
       "url": "https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/kee-safety-ris-safety",
@@ -14648,7 +14683,12 @@
       "phase_2_determination": null,
       "phase_2_determination_date": null,
       "public_benefits_determination": null,
-      "public_benefits_determination_date": null
+      "public_benefits_determination_date": null,
+      "related_merger": {
+        "merger_id": "MN-40008",
+        "relationship": "refiled_as",
+        "merger_name": "Intrepid Travel - Wild Bush Luxury"
+      }
     },
     {
       "url": "https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/impression-dental-group-happy-rock-dental-practice",

--- a/data/processed/related_mergers.json
+++ b/data/processed/related_mergers.json
@@ -1,0 +1,9 @@
+{
+  "_README": "Mergers that were initially filed as waiver applications, declined, then re-filed as formal notifications. Each entry maps the waiver ID to the notification ID. Both directions are resolved automatically.",
+  "pairs": [
+    { "waiver": "WA-35003", "notification": "MN-85007" },
+    { "waiver": "WA-01087", "notification": "MN-20013" },
+    { "waiver": "WA-65003", "notification": "MN-40005" },
+    { "waiver": "WA-70003", "notification": "MN-40008" }
+  ]
+}

--- a/merger-tracker/frontend/public/data/mergers/MN-20013.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-20013.json
@@ -70,5 +70,10 @@
   "phase_2_determination": null,
   "phase_2_determination_date": null,
   "public_benefits_determination": null,
-  "public_benefits_determination_date": null
+  "public_benefits_determination_date": null,
+  "related_merger": {
+    "merger_id": "WA-01087",
+    "relationship": "refiled_from",
+    "merger_name": "Eli Lilly \u2013 Orna Therapeutics"
+  }
 }

--- a/merger-tracker/frontend/public/data/mergers/MN-40005.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-40005.json
@@ -188,5 +188,10 @@
   "phase_2_determination": null,
   "phase_2_determination_date": null,
   "public_benefits_determination": null,
-  "public_benefits_determination_date": null
+  "public_benefits_determination_date": null,
+  "related_merger": {
+    "merger_id": "WA-65003",
+    "relationship": "refiled_from",
+    "merger_name": "Henkel \u2013 ATP adhesive systems group"
+  }
 }

--- a/merger-tracker/frontend/public/data/mergers/MN-40008.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-40008.json
@@ -88,5 +88,10 @@
   "phase_2_determination": null,
   "phase_2_determination_date": null,
   "public_benefits_determination": null,
-  "public_benefits_determination_date": null
+  "public_benefits_determination_date": null,
+  "related_merger": {
+    "merger_id": "WA-70003",
+    "relationship": "refiled_from",
+    "merger_name": "Intrepid Travel \u2013 Wild Bush Luxury"
+  }
 }

--- a/merger-tracker/frontend/public/data/mergers/MN-85007.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-85007.json
@@ -101,5 +101,10 @@
   "phase_2_determination": null,
   "phase_2_determination_date": null,
   "public_benefits_determination": null,
-  "public_benefits_determination_date": null
+  "public_benefits_determination_date": null,
+  "related_merger": {
+    "merger_id": "WA-35003",
+    "relationship": "refiled_from",
+    "merger_name": "Salesforce \u2013 Qualified"
+  }
 }

--- a/merger-tracker/frontend/public/data/mergers/WA-01087.json
+++ b/merger-tracker/frontend/public/data/mergers/WA-01087.json
@@ -92,5 +92,10 @@
   "phase_2_determination": null,
   "phase_2_determination_date": null,
   "public_benefits_determination": null,
-  "public_benefits_determination_date": null
+  "public_benefits_determination_date": null,
+  "related_merger": {
+    "merger_id": "MN-20013",
+    "relationship": "refiled_as",
+    "merger_name": "Eli Lilly / Orna Therapeutics"
+  }
 }

--- a/merger-tracker/frontend/public/data/mergers/WA-35003.json
+++ b/merger-tracker/frontend/public/data/mergers/WA-35003.json
@@ -86,5 +86,10 @@
   "phase_2_determination": null,
   "phase_2_determination_date": null,
   "public_benefits_determination": null,
-  "public_benefits_determination_date": null
+  "public_benefits_determination_date": null,
+  "related_merger": {
+    "merger_id": "MN-85007",
+    "relationship": "refiled_as",
+    "merger_name": "Salesforce \u2013 Qualified"
+  }
 }

--- a/merger-tracker/frontend/public/data/mergers/WA-65003.json
+++ b/merger-tracker/frontend/public/data/mergers/WA-65003.json
@@ -100,5 +100,10 @@
   "phase_2_determination": null,
   "phase_2_determination_date": null,
   "public_benefits_determination": null,
-  "public_benefits_determination_date": null
+  "public_benefits_determination_date": null,
+  "related_merger": {
+    "merger_id": "MN-40005",
+    "relationship": "refiled_as",
+    "merger_name": "Henkel \u2013 ATP Adhesives Systems Group"
+  }
 }

--- a/merger-tracker/frontend/public/data/mergers/WA-70003.json
+++ b/merger-tracker/frontend/public/data/mergers/WA-70003.json
@@ -100,5 +100,10 @@
   "phase_2_determination": null,
   "phase_2_determination_date": null,
   "public_benefits_determination": null,
-  "public_benefits_determination_date": null
+  "public_benefits_determination_date": null,
+  "related_merger": {
+    "merger_id": "MN-40008",
+    "relationship": "refiled_as",
+    "merger_name": "Intrepid Travel - Wild Bush Luxury"
+  }
 }

--- a/merger-tracker/frontend/src/pages/MergerDetail.jsx
+++ b/merger-tracker/frontend/src/pages/MergerDetail.jsx
@@ -302,6 +302,31 @@ function MergerDetail() {
           </div>
         </div>
 
+        {/* Related Merger Link */}
+        {merger.related_merger && (
+          <Link
+            to={`/mergers/${merger.related_merger.merger_id}`}
+            className="flex items-center gap-3 bg-amber-50/80 rounded-2xl border border-amber-200/60 shadow-card p-4 mb-6 hover:bg-amber-50 hover:border-amber-300/60 transition-all group"
+          >
+            <div className="flex-shrink-0 w-9 h-9 rounded-xl bg-amber-100 flex items-center justify-center">
+              <svg className="h-5 w-5 text-amber-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+              </svg>
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-gray-900">
+                {merger.related_merger.relationship === 'refiled_as'
+                  ? 'Waiver declined — subsequently notified as a formal merger'
+                  : 'Originally filed as a waiver application'
+                }
+              </p>
+              <p className="text-sm text-amber-700 group-hover:text-amber-800 transition-colors">
+                See {merger.related_merger.merger_id}{merger.related_merger.merger_name ? ` — ${merger.related_merger.merger_name}` : ''} →
+              </p>
+            </div>
+          </Link>
+        )}
+
         {/* Parties */}
         <div className={`grid grid-cols-1 ${merger.other_parties && merger.other_parties.length > 0 ? 'md:grid-cols-3' : 'md:grid-cols-2'} gap-4 mb-6`}>
           {renderPartyList(merger.acquirers, 'acquirers', 'Acquirers')}

--- a/merger-tracker/frontend/src/pages/MergerDetail.jsx
+++ b/merger-tracker/frontend/src/pages/MergerDetail.jsx
@@ -316,12 +316,9 @@ function MergerDetail() {
             <div className="flex-1 min-w-0">
               <p className="text-sm font-medium text-gray-900">
                 {merger.related_merger.relationship === 'refiled_as'
-                  ? 'Waiver declined — subsequently notified as a formal merger'
+                  ? 'Waiver declined \u2013 subsequently notified'
                   : 'Originally filed as a waiver application'
                 }
-              </p>
-              <p className="text-sm text-amber-700 group-hover:text-amber-800 transition-colors">
-                See {merger.related_merger.merger_id}{merger.related_merger.merger_name ? ` — ${merger.related_merger.merger_name}` : ''} →
               </p>
             </div>
           </Link>

--- a/scripts/generate_static_data.py
+++ b/scripts/generate_static_data.py
@@ -37,6 +37,7 @@ SCRIPT_DIR = Path(__file__).parent
 REPO_ROOT = SCRIPT_DIR.parent
 MERGERS_JSON = REPO_ROOT / "data" / "processed" / "mergers.json"
 COMMENTARY_JSON = REPO_ROOT / "data" / "processed" / "commentary.json"
+RELATED_MERGERS_JSON = REPO_ROOT / "data" / "processed" / "related_mergers.json"
 HOLIDAYS_JSON = REPO_ROOT / "merger-tracker" / "frontend" / "src" / "data" / "act-public-holidays.json"
 OUTPUT_DIR = REPO_ROOT / "merger-tracker" / "frontend" / "public" / "data"
 DATA_OUTPUT_DIR = REPO_ROOT / "data" / "output"
@@ -231,18 +232,29 @@ def extract_phase_from_event(event_title: str) -> str | None:
     return None
 
 
-# Mergers that were initially filed as waiver applications but declined, then re-filed
-# as formal notifications. Each entry maps both directions (WA->MN and MN->WA).
-RELATED_MERGERS = {
-    'WA-35003': {'merger_id': 'MN-85007', 'relationship': 'refiled_as'},
-    'MN-85007': {'merger_id': 'WA-35003', 'relationship': 'refiled_from'},
-    'WA-01087': {'merger_id': 'MN-20013', 'relationship': 'refiled_as'},
-    'MN-20013': {'merger_id': 'WA-01087', 'relationship': 'refiled_from'},
-    'WA-65003': {'merger_id': 'MN-40005', 'relationship': 'refiled_as'},
-    'MN-40005': {'merger_id': 'WA-65003', 'relationship': 'refiled_from'},
-    'WA-70003': {'merger_id': 'MN-40008', 'relationship': 'refiled_as'},
-    'MN-40008': {'merger_id': 'WA-70003', 'relationship': 'refiled_from'},
-}
+def load_related_mergers() -> dict:
+    """Load related merger pairs from related_mergers.json.
+
+    Returns a dict keyed by merger_id mapping to
+    {'merger_id': ..., 'relationship': 'refiled_as' | 'refiled_from'}.
+    """
+    if not RELATED_MERGERS_JSON.exists():
+        return {}
+
+    try:
+        with open(RELATED_MERGERS_JSON, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+
+        result = {}
+        for pair in data.get('pairs', []):
+            wa = pair['waiver']
+            mn = pair['notification']
+            result[wa] = {'merger_id': mn, 'relationship': 'refiled_as'}
+            result[mn] = {'merger_id': wa, 'relationship': 'refiled_from'}
+        return result
+    except (json.JSONDecodeError, IOError, KeyError) as e:
+        print(f"Warning: Could not load related_mergers.json: {e}")
+        return {}
 
 
 def load_commentary() -> dict:
@@ -1068,6 +1080,11 @@ def main():
     else:
         print("No commentary found")
 
+    # Load related merger pairs
+    related_mergers = load_related_mergers()
+    if related_mergers:
+        print(f"Loaded {len(related_mergers) // 2} related merger pair(s)")
+
     # Enrich all mergers once (add computed fields, phase determinations, etc.)
     print("Enriching mergers...")
     enriched_mergers = [enrich_merger(m, commentary) for m in mergers]
@@ -1077,8 +1094,8 @@ def main():
     linked_count = 0
     for m in enriched_mergers:
         mid = m.get('merger_id', '')
-        if mid in RELATED_MERGERS:
-            related = RELATED_MERGERS[mid]
+        if mid in related_mergers:
+            related = related_mergers[mid]
             m['related_merger'] = {
                 'merger_id': related['merger_id'],
                 'relationship': related['relationship'],

--- a/scripts/generate_static_data.py
+++ b/scripts/generate_static_data.py
@@ -231,6 +231,20 @@ def extract_phase_from_event(event_title: str) -> str | None:
     return None
 
 
+# Mergers that were initially filed as waiver applications but declined, then re-filed
+# as formal notifications. Each entry maps both directions (WA->MN and MN->WA).
+RELATED_MERGERS = {
+    'WA-35003': {'merger_id': 'MN-85007', 'relationship': 'refiled_as'},
+    'MN-85007': {'merger_id': 'WA-35003', 'relationship': 'refiled_from'},
+    'WA-01087': {'merger_id': 'MN-20013', 'relationship': 'refiled_as'},
+    'MN-20013': {'merger_id': 'WA-01087', 'relationship': 'refiled_from'},
+    'WA-65003': {'merger_id': 'MN-40005', 'relationship': 'refiled_as'},
+    'MN-40005': {'merger_id': 'WA-65003', 'relationship': 'refiled_from'},
+    'WA-70003': {'merger_id': 'MN-40008', 'relationship': 'refiled_as'},
+    'MN-40008': {'merger_id': 'WA-70003', 'relationship': 'refiled_from'},
+}
+
+
 def load_commentary() -> dict:
     """Load user commentary from commentary.json if it exists."""
     if not COMMENTARY_JSON.exists():
@@ -261,7 +275,7 @@ def enrich_merger(merger: dict, commentary: dict = None) -> dict:
     merger_id = m.get('merger_id', '')
     if commentary and merger_id in commentary:
         m['comments'] = commentary[merger_id].get('comments', [])
-    
+
     # Compute phase-specific determinations based on stage and events
     phase_1_det = None
     phase_1_det_date = None
@@ -1057,6 +1071,23 @@ def main():
     # Enrich all mergers once (add computed fields, phase determinations, etc.)
     print("Enriching mergers...")
     enriched_mergers = [enrich_merger(m, commentary) for m in mergers]
+
+    # Link related mergers (waiver <-> notification pairs) with resolved names
+    merger_name_lookup = {m['merger_id']: m['merger_name'] for m in enriched_mergers if m.get('merger_id')}
+    linked_count = 0
+    for m in enriched_mergers:
+        mid = m.get('merger_id', '')
+        if mid in RELATED_MERGERS:
+            related = RELATED_MERGERS[mid]
+            m['related_merger'] = {
+                'merger_id': related['merger_id'],
+                'relationship': related['relationship'],
+                'merger_name': merger_name_lookup.get(related['merger_id'], ''),
+            }
+            linked_count += 1
+    if linked_count:
+        print(f"  Linked {linked_count} related merger pairs")
+
     print(f"✓ Enriched {len(enriched_mergers)} mergers")
 
     # Create output directories


### PR DESCRIPTION
## Summary
This PR adds support for linking related merger filings that represent the same transaction filed under different procedures. Specifically, it connects waiver applications (WA-*) that were declined with their subsequent formal notification filings (MN-*).

## Key Changes

- **Backend (`scripts/generate_static_data.py`)**:
  - Added `RELATED_MERGERS` mapping dictionary that tracks bidirectional relationships between waiver and formal notification filings
  - Implemented logic to enrich merger records with `related_merger` field containing the linked merger ID, relationship type, and merger name
  - Supports two relationship types: `refiled_as` (waiver → formal) and `refiled_from` (formal → waiver)

- **Frontend (`MergerDetail.jsx`)**:
  - Added a new "Related Merger Link" section that displays when a merger has a related filing
  - Shows contextual messaging based on relationship type:
    - "Waiver declined — subsequently notified as a formal merger" for refiled_as
    - "Originally filed as a waiver application" for refiled_from
  - Styled as an amber-colored card with link to the related merger
  - Includes merger ID and name for easy navigation

- **Data Updates**:
  - Updated 8 merger records (4 waiver applications and 4 formal notifications) with `related_merger` metadata
  - Affected mergers: Eli Lilly/Orna Therapeutics, Salesforce/Qualified, Henkel/ATP Adhesives, and Intrepid Travel/Wild Bush Luxury

## Implementation Details

- The mapping is maintained in a single source of truth in the generation script, ensuring consistency across all output formats
- Merger names are resolved at generation time using a lookup table to avoid hardcoding
- The frontend link is non-intrusive and only appears when relevant data exists
- Bidirectional linking allows users to navigate between related filings in either direction

https://claude.ai/code/session_01LXsT2gvgaTa9po4nuqyS4w