### PR TITLE
Extract merger status constants to shared module

### DIFF
--- a/data/raw/acquisitions-register.html
+++ b/data/raw/acquisitions-register.html
@@ -2341,132 +2341,6 @@
     <div class="views-row">
 
 <div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-167953">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/rea-group-simplicity-loans-advisory">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  REA Group - Simplicity Loans &amp; Advisory
-</h3>
-</div>
-      
-<div  class="accc-collapsed-card__header-info">
-        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline under-assessment clearfix">
-    <h3 class="field__label">Acquisition status</h3>
-              <div class="field__item">Under assessment</div>
-          </div>
-
-<div  class="accc-collapsed-card__header-content">
-      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
-<div class="field__item">Notification</div>
-</div>
-  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
-    <h3 class="field__label">Case number</h3>
-              <div class="field__item">MN-65008</div>
-          </div>
-  <div class="field field--name-field-acquisition-stage field--type-list-string field--label-inline clearfix">
-    <h3 class="field__label">Stage</h3>
-              <div class="field__item">Phase 1 - initial assessment</div>
-          </div>
-  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
-    <h3 class="field__label">Effective notification date</h3>
-              <div class="field__item"><time datetime="2026-04-07T12:00:00Z" class="datetime">7 Apr 2026</time>
-</div>
-          </div>
-
-  </div>
-
-  </div>
-</a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167953" href="#card-167953">
-      <span>expandable trigger</span>
-    </a>
-  </div>
-  <div id="card-167953" role="region" aria-labelledby="heading-167953" class="accc-collapsed-card__body collapse">
-    
-<div >
-    <h3 class="border-bottom">About the acquisition</h3>
-      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Acquirer(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631293">
-      <span class="field_acccgov_name">
-            REA FINANCIAL SERVICES HOLDING CO. PTY LTD
-
-      </span>
-      <span>
-                        ABN -
-    38 649 505 386
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Target(s) or Vendor(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631295">
-      <span class="field_acccgov_name">
-            SIMPLICITY LOANS &amp; ADVISORY PTY LTD
-
-      </span>
-      <span>
-                        ABN -
-    98 616 763 878
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-  <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
-    <h3 class="field__label">ANZSIC code(s)</h3>
-          <div class="field__item">
-              6419  Other Auxiliary Finance and Investment Services              </div>
-      </div>
-  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
-    <h3 class="field__label">Description</h3>
-              <div class="field__item">
-<div class="read-more-wrapper">
-      <div class="summary-text">
-      <p lang="en-US">REA Financial Services Holding Co.</p>
-    </div>
-    <div class="full-text" style="display:none;">
-    <p lang="en-US">REA Financial Services Holding Co. Pty Ltd, as a subsidiary of REA Group Ltd (<strong>REA Group</strong>) (ASX:REA), proposes to acquire 70% of the shares in Simplicity Loans &amp; Advisory Pty Ltd (<strong>Simplicity Loans &amp; Advisory</strong>) (the&nbsp;<strong>Acquisition</strong>).</p>
-
-<p lang="en-US">REA Group provides digital advertising and mortgage brokering services through the following brands and platforms:</p>
-
-<ul>
-<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="eec12a4fcf2887f7e81f1f35a059a52ca" lang="en-US">
-<p>Mortgage Choice Pty Ltd and Smartline Operations Pty Ltd (<strong>Mortgage Choice</strong>) – mortgage broker offering residential mortgage broking services (homes and personal loans) and financial planning services. Mortgage Choice also acts as an aggregator connecting brokers seeking residential loans to a panel of lenders</p>
-</li>
-<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="ef8630c9cb8b53092012695419ec7e027" lang="en-US">
-<p>Simpology (32.9% interest held by REA Group) – e-lodgement platform used by brokers to submit loans to a range of lenders</p>
-</li>
-<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="e8498664ad9d3e9c9919595ee990f2d5c" lang="en-US">
-<p>Athena Home Loans (19.9% interest held by REA Group) – non-bank lender focusing on residential home loans</p>
-</li>
-<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="eea318d723cb95847f738d52424240899" lang="en-US">
-<p>Online property advertising platforms:&nbsp;realestate.com.au (residential property), realcommercial.com.au (commercial property), flatmates.com.au (share accommodation), Spacely (short-term commercial and co-working property), PropTrack (property data services and market insights) and 1Form (centralised platform for rental property applications)</p>
-</li>
-</ul>
-
-<p lang="en-US">Simplicity Loans &amp; Advisory is a boutique mortgage broker operating in Sydney, Melbourne and Brisbane specialising in commercial and developer mortgages.</p>
-
-<p lang="en-US">Simplicity Loans &amp; Advisory also operates Marketplace Finance Platform, a bilateral mortgage referral tool connecting third-party referrers (typically residential mortgage brokers with no commercial experience) with Simplicity Loans &amp; Advisory’s commercial mortgage brokers. Fulfilment of the loans occurs by Simplicity Loans &amp; Advisory employed brokers via aggregator panels or direct lender channels.</p>
-
-  </div>
-      <a href="#" class="read-toggle" data-expanded="true">read more</a>
-  </div></div>
-          </div>
-
-  </div>
-
-  </div>
-</div>
-
-</div>
-    <div class="views-row">
-
-<div  class="accc-collapsed-card contextual-region h-100">
   <div class="accc-collapsed-card__header" id="heading-167952">
   <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/journey-beyond-%E2%80%93-kakadu-crocodile-hotel">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
   Journey Beyond – Kakadu Crocodile Hotel
@@ -2589,6 +2463,132 @@
 <p>The Crocodile Hotel is a 110‑room hotel located in the township of Jabiru in Kakadu National Park. In addition to accommodation, its facilities include a restaurant, bar and an on‑site art gallery featuring local artwork.</p>
 
 <p>EAG and the Crocodile Hotel both operate in the touring services supply chain. Outback Spirit currently uses accommodation provided by the Crocodile Hotel on certain tours.</p>
+
+  </div>
+      <a href="#" class="read-toggle" data-expanded="true">read more</a>
+  </div></div>
+          </div>
+
+  </div>
+
+  </div>
+</div>
+
+</div>
+    <div class="views-row">
+
+<div  class="accc-collapsed-card contextual-region h-100">
+  <div class="accc-collapsed-card__header" id="heading-167953">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/rea-group-simplicity-loans-advisory">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  REA Group - Simplicity Loans &amp; Advisory
+</h3>
+</div>
+      
+<div  class="accc-collapsed-card__header-info">
+        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline under-assessment clearfix">
+    <h3 class="field__label">Acquisition status</h3>
+              <div class="field__item">Under assessment</div>
+          </div>
+
+<div  class="accc-collapsed-card__header-content">
+      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
+<div class="field__item">Notification</div>
+</div>
+  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
+    <h3 class="field__label">Case number</h3>
+              <div class="field__item">MN-65008</div>
+          </div>
+  <div class="field field--name-field-acquisition-stage field--type-list-string field--label-inline clearfix">
+    <h3 class="field__label">Stage</h3>
+              <div class="field__item">Phase 1 - initial assessment</div>
+          </div>
+  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
+    <h3 class="field__label">Effective notification date</h3>
+              <div class="field__item"><time datetime="2026-04-07T12:00:00Z" class="datetime">7 Apr 2026</time>
+</div>
+          </div>
+
+  </div>
+
+  </div>
+</a>
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167953" href="#card-167953">
+      <span>expandable trigger</span>
+    </a>
+  </div>
+  <div id="card-167953" role="region" aria-labelledby="heading-167953" class="accc-collapsed-card__body collapse">
+    
+<div >
+    <h3 class="border-bottom">About the acquisition</h3>
+      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Acquirer(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631293">
+      <span class="field_acccgov_name">
+            REA FINANCIAL SERVICES HOLDING CO. PTY LTD
+
+      </span>
+      <span>
+                        ABN -
+    38 649 505 386
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Target(s) or Vendor(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631295">
+      <span class="field_acccgov_name">
+            SIMPLICITY LOANS &amp; ADVISORY PTY LTD
+
+      </span>
+      <span>
+                        ABN -
+    98 616 763 878
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+  <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
+    <h3 class="field__label">ANZSIC code(s)</h3>
+          <div class="field__item">
+              6419  Other Auxiliary Finance and Investment Services              </div>
+      </div>
+  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
+    <h3 class="field__label">Description</h3>
+              <div class="field__item">
+<div class="read-more-wrapper">
+      <div class="summary-text">
+      <p lang="en-US">REA Financial Services Holding Co.</p>
+    </div>
+    <div class="full-text" style="display:none;">
+    <p lang="en-US">REA Financial Services Holding Co. Pty Ltd, as a subsidiary of REA Group Ltd (<strong>REA Group</strong>) (ASX:REA), proposes to acquire 70% of the shares in Simplicity Loans &amp; Advisory Pty Ltd (<strong>Simplicity Loans &amp; Advisory</strong>) (the&nbsp;<strong>Acquisition</strong>).</p>
+
+<p lang="en-US">REA Group provides digital advertising and mortgage brokering services through the following brands and platforms:</p>
+
+<ul>
+<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="eec12a4fcf2887f7e81f1f35a059a52ca" lang="en-US">
+<p>Mortgage Choice Pty Ltd and Smartline Operations Pty Ltd (<strong>Mortgage Choice</strong>) – mortgage broker offering residential mortgage broking services (homes and personal loans) and financial planning services. Mortgage Choice also acts as an aggregator connecting brokers seeking residential loans to a panel of lenders</p>
+</li>
+<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="ef8630c9cb8b53092012695419ec7e027" lang="en-US">
+<p>Simpology (32.9% interest held by REA Group) – e-lodgement platform used by brokers to submit loans to a range of lenders</p>
+</li>
+<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="e8498664ad9d3e9c9919595ee990f2d5c" lang="en-US">
+<p>Athena Home Loans (19.9% interest held by REA Group) – non-bank lender focusing on residential home loans</p>
+</li>
+<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="eea318d723cb95847f738d52424240899" lang="en-US">
+<p>Online property advertising platforms:&nbsp;realestate.com.au (residential property), realcommercial.com.au (commercial property), flatmates.com.au (share accommodation), Spacely (short-term commercial and co-working property), PropTrack (property data services and market insights) and 1Form (centralised platform for rental property applications)</p>
+</li>
+</ul>
+
+<p lang="en-US">Simplicity Loans &amp; Advisory is a boutique mortgage broker operating in Sydney, Melbourne and Brisbane specialising in commercial and developer mortgages.</p>
+
+<p lang="en-US">Simplicity Loans &amp; Advisory also operates Marketplace Finance Platform, a bilateral mortgage referral tool connecting third-party referrers (typically residential mortgage brokers with no commercial experience) with Simplicity Loans &amp; Advisory’s commercial mortgage brokers. Fulfilment of the loans occurs by Simplicity Loans &amp; Advisory employed brokers via aggregator panels or direct lender channels.</p>
 
   </div>
       <a href="#" class="read-toggle" data-expanded="true">read more</a>

--- a/merger-tracker/frontend/src/components/StatusBadge.jsx
+++ b/merger-tracker/frontend/src/components/StatusBadge.jsx
@@ -1,19 +1,25 @@
+import { MERGER_STATUS, STATUS_COLORS, DEFAULT_STATUS_STYLE } from '../constants/mergerStatus';
+
 function StatusBadge({ status, determination }) {
   const getStatusStyle = () => {
-    if (determination === 'Approved') {
-      return 'bg-emerald-50 text-emerald-700 border-emerald-200/60';
-    } else if (determination === 'Declined' || determination === 'Not approved') {
-      return 'bg-red-50 text-red-700 border-red-200/60';
-    } else if (determination === 'Referred to phase 2') {
-      return 'bg-amber-50 text-amber-700 border-amber-200/60';
-    } else if (status === 'Under assessment') {
-      return 'bg-primary/5 text-primary border-primary/20';
-    } else if (status === 'Assessment suspended') {
-      return 'bg-orange-50 text-orange-700 border-orange-200/60';
-    } else if (status === 'Assessment completed') {
-      return 'bg-gray-50 text-gray-600 border-gray-200/60';
+    // Determinations take precedence over statuses; 'Declined' and 'Not approved'
+    // share the same red palette (both map to the same STATUS_COLORS entry).
+    if (
+      determination === MERGER_STATUS.APPROVED ||
+      determination === MERGER_STATUS.DECLINED ||
+      determination === MERGER_STATUS.NOT_APPROVED ||
+      determination === MERGER_STATUS.REFERRED_TO_PHASE_2
+    ) {
+      return STATUS_COLORS[determination];
     }
-    return 'bg-gray-50 text-gray-600 border-gray-200/60';
+    if (
+      status === MERGER_STATUS.UNDER_ASSESSMENT ||
+      status === MERGER_STATUS.ASSESSMENT_SUSPENDED ||
+      status === MERGER_STATUS.ASSESSMENT_COMPLETED
+    ) {
+      return STATUS_COLORS[status];
+    }
+    return DEFAULT_STATUS_STYLE;
   };
 
   const displayText = determination || status;

--- a/merger-tracker/frontend/src/constants/mergerStatus.js
+++ b/merger-tracker/frontend/src/constants/mergerStatus.js
@@ -1,0 +1,131 @@
+/**
+ * Canonical ACCC merger status, determination, and phase labels.
+ *
+ * These strings mirror the values published by the ACCC public register and
+ * must match what appears in the generated JSON data pipeline output
+ * (see scripts/constants/merger_status.py for the Python counterpart).
+ * Renaming any value here would invalidate data in public/data/*.json.
+ *
+ * Source of truth:
+ *   https://www.accc.gov.au/public-registers/mergers-registers
+ */
+
+// Values that appear in merger.status and merger.accc_determination.
+export const MERGER_STATUS = {
+  // merger.status
+  UNDER_ASSESSMENT: 'Under assessment',
+  ASSESSMENT_SUSPENDED: 'Assessment suspended',
+  ASSESSMENT_COMPLETED: 'Assessment completed',
+
+  // merger.accc_determination
+  APPROVED: 'Approved',
+  NOT_APPROVED: 'Not approved',
+  DECLINED: 'Declined',
+  NOT_OPPOSED: 'Not opposed',
+  REFERRED_TO_PHASE_2: 'Referred to phase 2',
+};
+
+// Values that appear in merger.stage.
+export const PHASES = {
+  PHASE_1: 'Phase 1',
+  PHASE_2: 'Phase 2',
+  PUBLIC_BENEFITS: 'Public Benefits',
+  WAIVER: 'Waiver',
+};
+
+// Fallback Tailwind classes for StatusBadge when no specific status matches.
+export const DEFAULT_STATUS_STYLE = 'bg-gray-50 text-gray-600 border-gray-200/60';
+
+// StatusBadge: status/determination → Tailwind classes.
+// Determinations take precedence over statuses in StatusBadge (see component).
+export const STATUS_COLORS = {
+  [MERGER_STATUS.APPROVED]: 'bg-emerald-50 text-emerald-700 border-emerald-200/60',
+  [MERGER_STATUS.DECLINED]: 'bg-red-50 text-red-700 border-red-200/60',
+  [MERGER_STATUS.NOT_APPROVED]: 'bg-red-50 text-red-700 border-red-200/60',
+  [MERGER_STATUS.REFERRED_TO_PHASE_2]: 'bg-amber-50 text-amber-700 border-amber-200/60',
+  [MERGER_STATUS.UNDER_ASSESSMENT]: 'bg-primary/5 text-primary border-primary/20',
+  [MERGER_STATUS.ASSESSMENT_SUSPENDED]: 'bg-orange-50 text-orange-700 border-orange-200/60',
+  [MERGER_STATUS.ASSESSMENT_COMPLETED]: DEFAULT_STATUS_STYLE,
+};
+
+// Digest.jsx color keys — correspond to the Tailwind color names declared in
+// tailwind.config.js (see the `new-merger`, `cleared`, `declined`, `phase-1`,
+// `phase-2` extensions under theme.extend.colors).
+export const DIGEST_COLOR_KEYS = {
+  NEW_MERGER: 'new-merger',
+  CLEARED: 'cleared',
+  DECLINED: 'declined',
+  PHASE_1: 'phase-1',
+  PHASE_2: 'phase-2',
+};
+
+// Digest.jsx: color key → grouped Tailwind classes used across section headers,
+// summary cards, and table rows. Full class names are required so Tailwind's
+// scanner can detect them at build time (dynamic interpolation gets purged).
+export const DIGEST_COLOR_CLASSES = {
+  [DIGEST_COLOR_KEYS.NEW_MERGER]: {
+    borderLeft: 'border-l-new-merger',
+    borderLight: 'border-new-merger-light/20',
+    headerBg: 'from-new-merger-pale/50',
+    emptyText: 'text-new-merger/70',
+    text: 'text-new-merger',
+    hoverText: 'hover:text-new-merger-dark',
+    cardFrom: 'from-new-merger-pale',
+    cardTo: 'to-new-merger-pale/50',
+    cardBorder: 'border-new-merger-light/30',
+    groupHoverText: 'group-hover:text-new-merger-dark',
+    labelText: 'text-new-merger-dark/80',
+  },
+  [DIGEST_COLOR_KEYS.CLEARED]: {
+    borderLeft: 'border-l-cleared',
+    borderLight: 'border-cleared-light/20',
+    headerBg: 'from-cleared-pale/50',
+    emptyText: 'text-cleared/70',
+    text: 'text-cleared',
+    hoverText: 'hover:text-cleared-dark',
+    cardFrom: 'from-cleared-pale',
+    cardTo: 'to-cleared-pale/50',
+    cardBorder: 'border-cleared-light/30',
+    groupHoverText: 'group-hover:text-cleared-dark',
+    labelText: 'text-cleared-dark/80',
+  },
+  [DIGEST_COLOR_KEYS.DECLINED]: {
+    borderLeft: 'border-l-declined',
+    borderLight: 'border-declined-light/20',
+    headerBg: 'from-declined-pale/50',
+    emptyText: 'text-declined/70',
+    text: 'text-declined',
+    hoverText: 'hover:text-declined-dark',
+    cardFrom: 'from-declined-pale',
+    cardTo: 'to-declined-pale/50',
+    cardBorder: 'border-declined-light/30',
+    groupHoverText: 'group-hover:text-declined-dark',
+    labelText: 'text-declined-dark/80',
+  },
+  [DIGEST_COLOR_KEYS.PHASE_1]: {
+    borderLeft: 'border-l-phase-1',
+    borderLight: 'border-phase-1-light/20',
+    headerBg: 'from-phase-1-pale/50',
+    emptyText: 'text-phase-1/70',
+    text: 'text-phase-1',
+    hoverText: 'hover:text-phase-1-dark',
+    cardFrom: 'from-phase-1-pale',
+    cardTo: 'to-phase-1-pale/50',
+    cardBorder: 'border-phase-1-light/30',
+    groupHoverText: 'group-hover:text-phase-1-dark',
+    labelText: 'text-phase-1-dark/80',
+  },
+  [DIGEST_COLOR_KEYS.PHASE_2]: {
+    borderLeft: 'border-l-phase-2',
+    borderLight: 'border-phase-2-light/20',
+    headerBg: 'from-phase-2-pale/50',
+    emptyText: 'text-phase-2/70',
+    text: 'text-phase-2',
+    hoverText: 'hover:text-phase-2-dark',
+    cardFrom: 'from-phase-2-pale',
+    cardTo: 'to-phase-2-pale/50',
+    cardBorder: 'border-phase-2-light/30',
+    groupHoverText: 'group-hover:text-phase-2-dark',
+    labelText: 'text-phase-2-dark/80',
+  },
+};

--- a/merger-tracker/frontend/src/pages/Digest.jsx
+++ b/merger-tracker/frontend/src/pages/Digest.jsx
@@ -8,76 +8,11 @@ import SEO from '../components/SEO';
 import { API_ENDPOINTS, SUBSCRIBE_ENDPOINT, TURNSTILE_SITE_KEY } from '../config';
 import { formatDate } from '../utils/dates';
 import { dataCache } from '../utils/dataCache';
-
-// Full class names so Tailwind's scanner can detect them at build time.
-// Dynamic interpolation like `text-${colorKey}` gets purged.
-const COLOR_CLASSES = {
-  'new-merger': {
-    borderLeft: 'border-l-new-merger',
-    borderLight: 'border-new-merger-light/20',
-    headerBg: 'from-new-merger-pale/50',
-    emptyText: 'text-new-merger/70',
-    text: 'text-new-merger',
-    hoverText: 'hover:text-new-merger-dark',
-    cardFrom: 'from-new-merger-pale',
-    cardTo: 'to-new-merger-pale/50',
-    cardBorder: 'border-new-merger-light/30',
-    groupHoverText: 'group-hover:text-new-merger-dark',
-    labelText: 'text-new-merger-dark/80',
-  },
-  'cleared': {
-    borderLeft: 'border-l-cleared',
-    borderLight: 'border-cleared-light/20',
-    headerBg: 'from-cleared-pale/50',
-    emptyText: 'text-cleared/70',
-    text: 'text-cleared',
-    hoverText: 'hover:text-cleared-dark',
-    cardFrom: 'from-cleared-pale',
-    cardTo: 'to-cleared-pale/50',
-    cardBorder: 'border-cleared-light/30',
-    groupHoverText: 'group-hover:text-cleared-dark',
-    labelText: 'text-cleared-dark/80',
-  },
-  'declined': {
-    borderLeft: 'border-l-declined',
-    borderLight: 'border-declined-light/20',
-    headerBg: 'from-declined-pale/50',
-    emptyText: 'text-declined/70',
-    text: 'text-declined',
-    hoverText: 'hover:text-declined-dark',
-    cardFrom: 'from-declined-pale',
-    cardTo: 'to-declined-pale/50',
-    cardBorder: 'border-declined-light/30',
-    groupHoverText: 'group-hover:text-declined-dark',
-    labelText: 'text-declined-dark/80',
-  },
-  'phase-1': {
-    borderLeft: 'border-l-phase-1',
-    borderLight: 'border-phase-1-light/20',
-    headerBg: 'from-phase-1-pale/50',
-    emptyText: 'text-phase-1/70',
-    text: 'text-phase-1',
-    hoverText: 'hover:text-phase-1-dark',
-    cardFrom: 'from-phase-1-pale',
-    cardTo: 'to-phase-1-pale/50',
-    cardBorder: 'border-phase-1-light/30',
-    groupHoverText: 'group-hover:text-phase-1-dark',
-    labelText: 'text-phase-1-dark/80',
-  },
-  'phase-2': {
-    borderLeft: 'border-l-phase-2',
-    borderLight: 'border-phase-2-light/20',
-    headerBg: 'from-phase-2-pale/50',
-    emptyText: 'text-phase-2/70',
-    text: 'text-phase-2',
-    hoverText: 'hover:text-phase-2-dark',
-    cardFrom: 'from-phase-2-pale',
-    cardTo: 'to-phase-2-pale/50',
-    cardBorder: 'border-phase-2-light/30',
-    groupHoverText: 'group-hover:text-phase-2-dark',
-    labelText: 'text-phase-2-dark/80',
-  },
-};
+import {
+  DIGEST_COLOR_KEYS,
+  DIGEST_COLOR_CLASSES as COLOR_CLASSES,
+  MERGER_STATUS,
+} from '../constants/mergerStatus';
 
 const scrollToTop = () => {
   window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -393,11 +328,11 @@ function Digest() {
   const dateRange = formatDateRange(digest.period_start, digest.period_end);
 
   const summaryCards = [
-    { id: 'new-mergers', colorKey: 'new-merger', count: digest.new_deals_notified.length, label: 'New deals notified' },
-    { id: 'mergers-approved', colorKey: 'cleared', count: digest.deals_cleared.length, label: 'Deals cleared' },
-    { id: 'mergers-declined', colorKey: 'declined', count: digest.deals_declined.length, label: 'Deals declined' },
-    { id: 'ongoing-phase-1', colorKey: 'phase-1', count: digest.ongoing_phase_1.length, label: 'Ongoing phase 1' },
-    { id: 'ongoing-phase-2', colorKey: 'phase-2', count: digest.ongoing_phase_2.length, label: 'Ongoing phase 2' },
+    { id: 'new-mergers', colorKey: DIGEST_COLOR_KEYS.NEW_MERGER, count: digest.new_deals_notified.length, label: 'New deals notified' },
+    { id: 'mergers-approved', colorKey: DIGEST_COLOR_KEYS.CLEARED, count: digest.deals_cleared.length, label: 'Deals cleared' },
+    { id: 'mergers-declined', colorKey: DIGEST_COLOR_KEYS.DECLINED, count: digest.deals_declined.length, label: 'Deals declined' },
+    { id: 'ongoing-phase-1', colorKey: DIGEST_COLOR_KEYS.PHASE_1, count: digest.ongoing_phase_1.length, label: 'Ongoing phase 1' },
+    { id: 'ongoing-phase-2', colorKey: DIGEST_COLOR_KEYS.PHASE_2, count: digest.ongoing_phase_2.length, label: 'Ongoing phase 2' },
   ];
 
   return (
@@ -445,12 +380,12 @@ function Digest() {
             id="new-mergers"
             title="New mergers"
             emptyMessage="No new mergers this week"
-            colorKey="new-merger"
+            colorKey={DIGEST_COLOR_KEYS.NEW_MERGER}
             mergers={digest.new_deals_notified}
             columns={['Merger', 'Notification date', 'Summary']}
             renderRow={(merger) => (
               <tr key={merger.merger_id} className="relative hover:bg-new-merger-pale/40 transition-colors">
-                <MergerNameCell merger={merger} colorKey="new-merger" />
+                <MergerNameCell merger={merger} colorKey={DIGEST_COLOR_KEYS.NEW_MERGER} />
                 <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600">
                   {merger.effective_notification_datetime
                     ? formatDate(merger.effective_notification_datetime)
@@ -471,18 +406,18 @@ function Digest() {
             id="mergers-approved"
             title="Mergers approved"
             emptyMessage="No mergers approved this week"
-            colorKey="cleared"
+            colorKey={DIGEST_COLOR_KEYS.CLEARED}
             mergers={digest.deals_cleared}
             columns={['Merger', 'Determination date', 'Determination']}
             renderRow={(merger) => (
               <tr key={merger.merger_id} className="relative hover:bg-cleared-pale/40 transition-colors">
-                <MergerNameCell merger={merger} colorKey="cleared" />
+                <MergerNameCell merger={merger} colorKey={DIGEST_COLOR_KEYS.CLEARED} />
                 <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600">
                   {merger.determination_publication_date
                     ? formatDate(merger.determination_publication_date)
                     : 'N/A'}
                 </td>
-                <DeterminationCell merger={merger} colorKey="cleared" defaultDetermination="Approved" getDeterminationPdf={getDeterminationPdf} />
+                <DeterminationCell merger={merger} colorKey={DIGEST_COLOR_KEYS.CLEARED} defaultDetermination={MERGER_STATUS.APPROVED} getDeterminationPdf={getDeterminationPdf} />
               </tr>
             )}
           />
@@ -491,18 +426,18 @@ function Digest() {
             id="mergers-declined"
             title="Mergers declined"
             emptyMessage="No mergers declined this week"
-            colorKey="declined"
+            colorKey={DIGEST_COLOR_KEYS.DECLINED}
             mergers={digest.deals_declined}
             columns={['Merger', 'Determination date', 'Determination']}
             renderRow={(merger) => (
               <tr key={merger.merger_id} className="relative hover:bg-declined-pale/40 transition-colors">
-                <MergerNameCell merger={merger} colorKey="declined" />
+                <MergerNameCell merger={merger} colorKey={DIGEST_COLOR_KEYS.DECLINED} />
                 <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600">
                   {merger.determination_publication_date
                     ? formatDate(merger.determination_publication_date)
                     : 'N/A'}
                 </td>
-                <DeterminationCell merger={merger} colorKey="declined" defaultDetermination="Not approved" getDeterminationPdf={getDeterminationPdf} />
+                <DeterminationCell merger={merger} colorKey={DIGEST_COLOR_KEYS.DECLINED} defaultDetermination={MERGER_STATUS.NOT_APPROVED} getDeterminationPdf={getDeterminationPdf} />
               </tr>
             )}
           />
@@ -511,12 +446,12 @@ function Digest() {
             id="ongoing-phase-1"
             title="Ongoing - phase 1 - initial assessment"
             emptyMessage="No ongoing phase 1 mergers"
-            colorKey="phase-1"
+            colorKey={DIGEST_COLOR_KEYS.PHASE_1}
             mergers={digest.ongoing_phase_1}
             columns={['Merger', 'Notification date', 'Determination due date', 'Summary']}
             renderRow={(merger) => (
               <tr key={merger.merger_id} className="relative hover:bg-phase-1-pale/40 transition-colors">
-                <MergerNameCell merger={merger} colorKey="phase-1" />
+                <MergerNameCell merger={merger} colorKey={DIGEST_COLOR_KEYS.PHASE_1} />
                 <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600">
                   {merger.effective_notification_datetime
                     ? formatDate(merger.effective_notification_datetime)
@@ -542,12 +477,12 @@ function Digest() {
             id="ongoing-phase-2"
             title="Ongoing - phase 2 - detailed assessment"
             emptyMessage="No ongoing phase 2 mergers"
-            colorKey="phase-2"
+            colorKey={DIGEST_COLOR_KEYS.PHASE_2}
             mergers={digest.ongoing_phase_2}
             columns={['Merger', 'Notification date', 'Determination due date', 'Summary']}
             renderRow={(merger) => (
               <tr key={merger.merger_id} className="relative hover:bg-phase-2-pale/40 transition-colors">
-                <MergerNameCell merger={merger} colorKey="phase-2" />
+                <MergerNameCell merger={merger} colorKey={DIGEST_COLOR_KEYS.PHASE_2} />
                 <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600">
                   {merger.effective_notification_datetime
                     ? formatDate(merger.effective_notification_datetime)

--- a/merger-tracker/frontend/src/pages/Mergers.jsx
+++ b/merger-tracker/frontend/src/pages/Mergers.jsx
@@ -11,6 +11,7 @@ import { dataCache } from '../utils/dataCache';
 import { useTracking } from '../context/TrackingContext';
 import { useDebounce } from '../hooks/useDebounce';
 import { buildSearchIndex, searchMergers, clearSearchIndex } from '../utils/searchIndex';
+import { PHASES } from '../constants/mergerStatus';
 
 const SORT_FIELDS = [
   { value: 'notification', label: 'Notification date' },
@@ -187,9 +188,9 @@ function Mergers() {
     }
 
     if (phaseFilter === 'phase1') {
-      filtered = filtered.filter((m) => m.stage && m.stage.includes('Phase 1'));
+      filtered = filtered.filter((m) => m.stage && m.stage.includes(PHASES.PHASE_1));
     } else if (phaseFilter === 'phase2') {
-      filtered = filtered.filter((m) => m.stage && m.stage.includes('Phase 2'));
+      filtered = filtered.filter((m) => m.stage && m.stage.includes(PHASES.PHASE_2));
     } else if (phaseFilter === 'waivers') {
       filtered = filtered.filter((m) => m.is_waiver);
     }
@@ -378,9 +379,9 @@ function Mergers() {
                     aria-label="Filter by merger phase"
                   >
                     <option value="all">All phases</option>
-                    <option value="phase1">Phase 1</option>
-                    <option value="phase2">Phase 2</option>
-                    <option value="waivers">Waiver</option>
+                    <option value="phase1">{PHASES.PHASE_1}</option>
+                    <option value="phase2">{PHASES.PHASE_2}</option>
+                    <option value="waivers">{PHASES.WAIVER}</option>
                   </select>
                 </div>
                 <div>

--- a/scripts/constants/merger_status.py
+++ b/scripts/constants/merger_status.py
@@ -1,0 +1,33 @@
+"""
+Canonical ACCC merger status, determination, and phase labels.
+
+These strings mirror the values published by the ACCC public register and
+must match what appears in the generated JSON data consumed by the frontend
+(see merger-tracker/frontend/src/constants/mergerStatus.js for the JS
+counterpart). Renaming any value here would invalidate data in
+public/data/*.json.
+
+Source of truth:
+  https://www.accc.gov.au/public-registers/mergers-registers
+"""
+
+# Values that appear in merger['status'].
+UNDER_ASSESSMENT = 'Under assessment'
+ASSESSMENT_SUSPENDED = 'Assessment suspended'
+ASSESSMENT_COMPLETED = 'Assessment completed'
+
+# Values that appear in merger['accc_determination'] (and phase-specific
+# determinations: phase_1_determination, phase_2_determination, etc.).
+APPROVED = 'Approved'
+NOT_APPROVED = 'Not approved'
+DECLINED = 'Declined'
+NOT_OPPOSED = 'Not opposed'
+REFERRED_TO_PHASE_2 = 'Referred to phase 2'
+
+# Values that appear in merger['stage'].
+PHASE_1 = 'Phase 1'
+PHASE_2 = 'Phase 2'
+PUBLIC_BENEFITS = 'Public Benefits'
+WAIVER = 'Waiver'
+
+PHASES = [PHASE_1, PHASE_2, PUBLIC_BENEFITS, WAIVER]

--- a/scripts/cutoff.py
+++ b/scripts/cutoff.py
@@ -15,6 +15,7 @@ import os
 import sys
 from datetime import datetime, timedelta
 from date_utils import parse_iso_datetime
+from constants import merger_status
 
 # Default cutoff period after determination/waiver decision
 CUTOFF_WEEKS = 3
@@ -24,7 +25,7 @@ def is_waiver_merger(merger: dict) -> bool:
     """Check if a merger is a waiver application."""
     merger_id = merger.get('merger_id', '')
     stage = merger.get('stage', '')
-    return merger_id.startswith('WA-') or 'Waiver' in stage
+    return merger_id.startswith('WA-') or merger_status.WAIVER in stage
 
 
 def get_cutoff_date(merger: dict, cutoff_weeks: int = CUTOFF_WEEKS) -> datetime:
@@ -46,7 +47,7 @@ def get_cutoff_date(merger: dict, cutoff_weeks: int = CUTOFF_WEEKS) -> datetime:
 
     # For regular notifications: only cut off if approved
     determination = merger.get('accc_determination', '')
-    if determination == 'Approved':
+    if determination == merger_status.APPROVED:
         return determination_date + timedelta(weeks=cutoff_weeks)
 
     # Not approved or no determination - keep processing

--- a/scripts/generate_static_data.py
+++ b/scripts/generate_static_data.py
@@ -28,6 +28,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from collections import defaultdict
 
+from constants import merger_status
 from cutoff import is_waiver_merger
 from date_utils import parse_iso_datetime
 from normalization import normalize_determination
@@ -220,16 +221,16 @@ def extract_phase_from_event(event_title: str) -> str | None:
     """Extract phase information from event title."""
     if not event_title:
         return None
-    if 'Phase 1' in event_title:
-        return 'Phase 1'
-    elif 'Phase 2' in event_title:
-        return 'Phase 2'
-    elif 'Public Benefits' in event_title or 'public benefits' in event_title:
-        return 'Public Benefits'
-    elif 'Waiver' in event_title or 'waiver' in event_title:
-        return 'Waiver'
+    if merger_status.PHASE_1 in event_title:
+        return merger_status.PHASE_1
+    elif merger_status.PHASE_2 in event_title:
+        return merger_status.PHASE_2
+    elif merger_status.PUBLIC_BENEFITS in event_title or 'public benefits' in event_title:
+        return merger_status.PUBLIC_BENEFITS
+    elif merger_status.WAIVER in event_title or 'waiver' in event_title:
+        return merger_status.WAIVER
     elif 'notified' in event_title:
-        return 'Phase 1'  # Notification always starts Phase 1
+        return merger_status.PHASE_1  # Notification always starts Phase 1
     return None
 
 
@@ -314,19 +315,19 @@ def enrich_merger(merger: dict, commentary: dict = None, questionnaire_data: dic
     for event in m.get('events', []):
         title = event.get('title', '')
         if 'subject to Phase 2 review' in title:
-            phase_1_det = 'Referred to phase 2'
+            phase_1_det = merger_status.REFERRED_TO_PHASE_2
             phase_1_det_date = event.get('date')
             break
 
     if m.get('accc_determination') and m.get('determination_publication_date'):
-        stage = m.get('stage', 'Phase 1')
+        stage = m.get('stage', merger_status.PHASE_1)
         det = m['accc_determination']
         det_date = m['determination_publication_date']
 
-        if 'Phase 1' in stage:
+        if merger_status.PHASE_1 in stage:
             phase_1_det = det
             phase_1_det_date = det_date
-        elif 'Phase 2' in stage:
+        elif merger_status.PHASE_2 in stage:
             phase_2_det = det
             phase_2_det_date = det_date
         elif 'Public' in stage or 'Benefits' in stage:
@@ -348,7 +349,7 @@ def enrich_merger(merger: dict, commentary: dict = None, questionnaire_data: dic
         'competition concern' in event.get('title', '').lower()
         for event in m.get('events', [])
     )
-    if stage and 'Phase 2' in stage and phase2_end and not notice_already_issued:
+    if stage and merger_status.PHASE_2 in stage and phase2_end and not notice_already_issued:
         try:
             phase2_end_date = parse_iso_datetime(phase2_end)
             if phase2_end_date is None:
@@ -620,7 +621,7 @@ def generate_stats_json(enriched_mergers: list) -> dict:
                 determination_events.append({
                     "merger_id": merger_id,
                     "merger_name": merger_name,
-                    "determination": "Referred to phase 2",
+                    "determination": merger_status.REFERRED_TO_PHASE_2,
                     "determination_date": event.get('date'),
                     "page_modified_datetime": page_modified,
                     "determination_type": "phase_transition",
@@ -873,7 +874,7 @@ def generate_upcoming_events_json(enriched_mergers: list, days_ahead: int = 60) 
             continue
 
         # Skip if assessment is suspended (no active determination period)
-        if m.get('status') == 'Assessment suspended':
+        if m.get('status') == merger_status.ASSESSMENT_SUSPENDED:
             continue
 
         # Skip waiver mergers (they don't have determination periods) - using pre-enriched field
@@ -912,7 +913,7 @@ def generate_upcoming_events_json(enriched_mergers: list, days_ahead: int = 60) 
         # Phase 2 BD 1 is derived by subtracting 89 BDs from end_of_determination_period
         # (BD 90 of Phase 2), not from the date the referral notice was issued (which may
         # have been issued before Phase 1's determination period fully expired).
-        if stage and 'Phase 2' in stage:
+        if stage and merger_status.PHASE_2 in stage:
             notice_already_issued = any(
                 'competition concern' in event.get('title', '').lower()
                 for event in m.get('events', [])
@@ -994,7 +995,7 @@ def generate_analysis_json(enriched_mergers: list) -> dict:
 
         # Include 'Referred to phase 2' mergers using the date the phase 2 notice was issued
         if not end:
-            if phase_1_det == 'Referred to phase 2' and m.get('phase_1_determination_date'):
+            if phase_1_det == merger_status.REFERRED_TO_PHASE_2 and m.get('phase_1_determination_date'):
                 end = m['phase_1_determination_date']
             else:
                 continue

--- a/scripts/normalization.py
+++ b/scripts/normalization.py
@@ -6,6 +6,8 @@ scripts in the data processing pipeline to ensure consistent behavior and
 avoid code duplication.
 """
 
+from constants import merger_status
+
 
 def normalize_determination(determination: str) -> str | None:
     """
@@ -42,13 +44,13 @@ def normalize_determination(determination: str) -> str | None:
 
     # Normalize common patterns
     # IMPORTANT: Check for "Not approved" BEFORE "Approved" to avoid substring match
-    if 'Not approved' in determination or 'not approved' in determination:
-        return 'Not approved'
-    elif 'Approved' in determination or 'approved' in determination:
-        return 'Approved'
-    elif 'Declined' in determination or 'declined' in determination:
-        return 'Declined'
-    elif 'Not opposed' in determination or 'not opposed' in determination:
-        return 'Not opposed'
+    if merger_status.NOT_APPROVED in determination or 'not approved' in determination:
+        return merger_status.NOT_APPROVED
+    elif merger_status.APPROVED in determination or 'approved' in determination:
+        return merger_status.APPROVED
+    elif merger_status.DECLINED in determination or 'declined' in determination:
+        return merger_status.DECLINED
+    elif merger_status.NOT_OPPOSED in determination or 'not opposed' in determination:
+        return merger_status.NOT_OPPOSED
 
     return determination


### PR DESCRIPTION
## Summary
Centralizes merger status, determination, and phase labels into a shared constants module that is imported by both the frontend and backend. This eliminates duplication and ensures consistency across the codebase.

## Key Changes
- **New shared constants module**: Created `scripts/constants/merger_status.py` with canonical ACCC merger status values (e.g., `UNDER_ASSESSMENT`, `APPROVED`, `PHASE_1`, etc.)
- **Frontend constants file**: Created `merger-tracker/frontend/src/constants/mergerStatus.js` mirroring the Python module, including:
  - `MERGER_STATUS` enum for status and determination values
  - `PHASES` enum for phase labels
  - `STATUS_COLORS` mapping for StatusBadge styling
  - `DIGEST_COLOR_KEYS` and `DIGEST_COLOR_CLASSES` for Digest component theming
- **Updated Digest.jsx**: Replaced hardcoded color key strings with `DIGEST_COLOR_KEYS` constants and imported color classes from the new constants module
- **Updated StatusBadge.jsx**: Replaced hardcoded status/determination strings with `MERGER_STATUS` constants and `STATUS_COLORS` mapping
- **Updated Mergers.jsx**: Replaced hardcoded phase strings with `PHASES` constants
- **Updated backend scripts**: Modified `generate_static_data.py`, `normalization.py`, and `cutoff.py` to import and use constants from `scripts/constants/merger_status.py`

## Implementation Details
- Constants are defined once and imported everywhere, reducing the risk of inconsistencies
- Full Tailwind class names are preserved in `DIGEST_COLOR_CLASSES` to ensure Tailwind's build-time scanner can detect them (avoiding dynamic class name purging)
- The Python and JavaScript constant values are identical to maintain data consistency between frontend and backend
- Comments document that these are the canonical values published by the ACCC public register and must match the generated JSON data pipeline output

https://claude.ai/code/session_01WKPayGkXURbt4vSFouSrhu