### PR TITLE
Serve raw PDFs directly to mobile browsers

### DIFF
--- a/functions/mergers/[matter]/[[path]].js
+++ b/functions/mergers/[matter]/[[path]].js
@@ -17,6 +17,14 @@ export async function onRequest(context) {
     return env.ASSETS.fetch(new Request(assetUrl.toString()));
   }
 
+  // Mobile browsers (Android, iPhone, iPod) don't support inline PDF rendering
+  // via <object> tags — serve the raw PDF directly instead of the viewer wrapper
+  const ua = request.headers.get('User-Agent') || '';
+  if (/Android|iPhone|iPod/i.test(ua)) {
+    const assetUrl = new URL(path, url.origin);
+    return env.ASSETS.fetch(new Request(assetUrl.toString()));
+  }
+
   // Extract matter ID from the path: /mergers/{MN,WA}-XXXXX/filename.pdf
   const match = path.match(/^\/mergers\/((MN|WA)-\d+)\//i);
   if (!match) {


### PR DESCRIPTION
## Summary
Added mobile browser detection to serve PDF files directly instead of rendering them through the viewer wrapper, since mobile browsers don't support inline PDF rendering via `<object>` tags.

## Key Changes
- Added User-Agent detection for mobile browsers (Android, iPhone, iPod)
- When a mobile browser is detected, the raw PDF is served directly from assets instead of being wrapped in the viewer interface
- This prevents rendering issues and provides a better user experience on mobile devices

## Implementation Details
- Uses a regex pattern to detect common mobile User-Agent strings: `/Android|iPhone|iPod/i`
- Falls back gracefully if the User-Agent header is missing (defaults to empty string)
- Maintains the existing asset fetching mechanism for direct PDF delivery

https://claude.ai/code/session_01N5p6EfbVFDojhwfeLSXexb