### PR TITLE
Improve scrape workflow reliability with retry logic

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -61,3 +61,11 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       run: |
         gh workflow run extract.yml
+
+    - name: Retry workflow on failure (scheduled runs only)
+      if: failure() && github.event_name == 'schedule'
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        sleep 60
+        gh workflow run scrape.yml

--- a/scripts/scrape.sh
+++ b/scripts/scrape.sh
@@ -160,7 +160,7 @@ export -f fetch_matter_page
 echo "Downloading main register page from $REGISTER_URL..."
 
 # Retry logic with 30-second timeout per attempt
-MAX_RETRIES=3
+MAX_RETRIES=2
 RETRY_COUNT=0
 TIMEOUT=30
 
@@ -173,7 +173,7 @@ while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
     RETRY_COUNT=$((RETRY_COUNT + 1))
     if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
       echo "Download timed out or failed (attempt $RETRY_COUNT/$MAX_RETRIES). Retrying..."
-      sleep 2
+      sleep $TIMEOUT
     else
       echo "Failed to download main page after $MAX_RETRIES attempts"
       exit 1


### PR DESCRIPTION
## Summary
This PR enhances the reliability of the scrape workflow by implementing automatic retry mechanisms for both scheduled workflow failures and improved download retry logic.

## Key Changes
- **Workflow retry on failure**: Added a new step to the GitHub Actions workflow that automatically retries the scrape job after a 60-second delay when scheduled runs fail (scheduled runs only)
- **Optimized download retry logic**: 
  - Reduced `MAX_RETRIES` from 3 to 2 attempts for the main register page download
  - Increased retry delay from 2 seconds to 30 seconds (matching the timeout duration) to allow more time for recovery between attempts

## Implementation Details
- The workflow retry step only triggers on scheduled runs (`github.event_name == 'schedule'`) to avoid unnecessary retries during manual or pull request triggers
- The longer retry delay (30 seconds) aligns with the timeout value, giving the remote server adequate time to recover from transient failures
- The reduced retry count combined with longer delays should result in more efficient failure handling while maintaining reliability

https://claude.ai/code/session_01KeMd6T91bSEPRQL2xcUGNy