### PR TITLE
Fix date validation in utility functions using isValid()

### DIFF
--- a/merger-tracker/frontend/src/utils/__tests__/dates.test.js
+++ b/merger-tracker/frontend/src/utils/__tests__/dates.test.js
@@ -114,10 +114,7 @@ describe('calculateBusinessDays', () => {
     expect(calculateBusinessDays(undefined, undefined)).toBeNull();
   });
 
-  // BUG: parseISO() returns an Invalid Date object rather than throwing for
-  // unparseable input, so the catch block never fires and the function
-  // returns 0 (or NaN) instead of null. Tracking for a follow-up PR.
-  it.skip('returns null for unparseable strings', () => {
+  it('returns null for unparseable strings', () => {
     expect(calculateBusinessDays('not a date', '2025-06-13')).toBeNull();
   });
 });
@@ -154,9 +151,7 @@ describe('getBusinessDaysRemaining', () => {
     expect(getBusinessDaysRemaining('')).toBeNull();
   });
 
-  // BUG: parseISO() does not throw on unparseable input, so this falls through
-  // to calculateBusinessDays() and returns 0 instead of null. See follow-up.
-  it.skip('returns null for an unparseable date string', () => {
+  it('returns null for an unparseable date string', () => {
     expect(getBusinessDaysRemaining('garbage')).toBeNull();
   });
 });
@@ -199,9 +194,7 @@ describe('calculateDuration', () => {
     expect(calculateDuration('2025-06-10', null)).toBeNull();
   });
 
-  // BUG: parseISO() returns Invalid Date instead of throwing, so
-  // differenceInDays() returns NaN and the catch never fires.
-  it.skip('returns null for an unparseable input', () => {
+  it('returns null for an unparseable input', () => {
     expect(calculateDuration('nope', '2025-06-20')).toBeNull();
   });
 });
@@ -230,9 +223,7 @@ describe('getDaysRemaining', () => {
     expect(getDaysRemaining(null)).toBeNull();
   });
 
-  // BUG: parseISO() returns Invalid Date instead of throwing, so the
-  // function falls through to `days > 0 ? days : 0` and returns 0.
-  it.skip('returns null for an unparseable string', () => {
+  it('returns null for an unparseable string', () => {
     expect(getDaysRemaining('nonsense')).toBeNull();
   });
 });

--- a/merger-tracker/frontend/src/utils/dates.js
+++ b/merger-tracker/frontend/src/utils/dates.js
@@ -1,4 +1,4 @@
-import { format, parseISO, differenceInDays, addDays, getDay } from 'date-fns';
+import { format, parseISO, differenceInDays, addDays, getDay, isValid } from 'date-fns';
 import actPublicHolidays from '../data/act-public-holidays.json';
 
 // Build a Set of public holiday dates for fast lookup
@@ -63,6 +63,8 @@ export const calculateBusinessDays = (startDate, endDate) => {
     const start = typeof startDate === 'string' ? parseISO(startDate) : startDate;
     const end = typeof endDate === 'string' ? parseISO(endDate) : endDate;
 
+    if (!isValid(start) || !isValid(end)) return null;
+
     let businessDays = 0;
     // Start from the day after start — application date is day 0
     let currentDate = addDays(new Date(start), 1);
@@ -89,6 +91,7 @@ export const getBusinessDaysRemaining = (endDate) => {
   if (!endDate) return null;
   try {
     const end = parseISO(endDate);
+    if (!isValid(end)) return null;
     const today = new Date();
     today.setHours(0, 0, 0, 0);
 
@@ -112,7 +115,10 @@ export const formatDate = (dateString) => {
 export const calculateDuration = (startDate, endDate) => {
   if (!startDate || !endDate) return null;
   try {
-    return differenceInDays(parseISO(endDate), parseISO(startDate));
+    const start = parseISO(startDate);
+    const end = parseISO(endDate);
+    if (!isValid(start) || !isValid(end)) return null;
+    return differenceInDays(end, start);
   } catch {
     return null;
   }
@@ -121,7 +127,9 @@ export const calculateDuration = (startDate, endDate) => {
 export const getDaysRemaining = (endDate) => {
   if (!endDate) return null;
   try {
-    const days = differenceInDays(parseISO(endDate), new Date());
+    const parsed = parseISO(endDate);
+    if (!isValid(parsed)) return null;
+    const days = differenceInDays(parsed, new Date());
     return days > 0 ? days : 0;
   } catch {
     return null;


### PR DESCRIPTION
## Summary
Fixed date parsing validation issues in date utility functions by adding explicit `isValid()` checks from date-fns. Previously, `parseISO()` would return Invalid Date objects instead of throwing errors, causing functions to return incorrect values (0 or NaN) instead of null for unparseable input.

## Key Changes
- Imported `isValid` from date-fns library
- Added `isValid()` checks after `parseISO()` calls in four utility functions:
  - `calculateBusinessDays()`: Validates both start and end dates
  - `getBusinessDaysRemaining()`: Validates end date
  - `calculateDuration()`: Validates both start and end dates
  - `getDaysRemaining()`: Validates end date
- Refactored `calculateDuration()` to store parsed dates in variables before validation for clarity
- Unskipped four previously skipped tests that now pass with proper validation in place

## Implementation Details
The fix addresses a known limitation where `date-fns` `parseISO()` returns an Invalid Date object rather than throwing an exception for unparseable input. By explicitly checking `isValid()` on parsed dates, functions now correctly return `null` for invalid input instead of propagating Invalid Date objects through calculations, which would result in NaN or 0 values.

https://claude.ai/code/session_01WTe2x5Kp2nGQzAfGbvW49r