### PR TITLE
Add actions write permission to convert workflow

### DIFF
--- a/.github/workflows/convert.yml
+++ b/.github/workflows/convert.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   convert:


### PR DESCRIPTION
## Summary
Updated the GitHub Actions workflow permissions to include write access for the `actions` scope in addition to the existing `contents` write permission.

## Changes
- Added `actions: write` permission to the `convert` workflow

## Details
This permission change allows the workflow to have write access to GitHub Actions resources, which may be necessary for operations such as creating or updating workflow runs, artifacts, or other Actions-related resources during the conversion process.

https://claude.ai/code/session_01FqCatd5eAqKHeTZwFyfQfV