### PR TITLE
Add phase 2 referral tracking to weekly digest

### DIFF
--- a/merger-tracker/frontend/src/constants/mergerStatus.js
+++ b/merger-tracker/frontend/src/constants/mergerStatus.js
@@ -55,6 +55,7 @@ export const DIGEST_COLOR_KEYS = {
   NEW_MERGER: 'new-merger',
   CLEARED: 'cleared',
   DECLINED: 'declined',
+  PHASE_2_REFERRAL: 'phase-2-referral',
   PHASE_1: 'phase-1',
   PHASE_2: 'phase-2',
 };
@@ -101,6 +102,19 @@ export const DIGEST_COLOR_CLASSES = {
     cardBorder: 'border-declined-light/30',
     groupHoverText: 'group-hover:text-declined-dark',
     labelText: 'text-declined-dark/80',
+  },
+  [DIGEST_COLOR_KEYS.PHASE_2_REFERRAL]: {
+    borderLeft: 'border-l-phase-2-referral',
+    borderLight: 'border-phase-2-referral-light/20',
+    headerBg: 'from-phase-2-referral-pale/50',
+    emptyText: 'text-phase-2-referral/70',
+    text: 'text-phase-2-referral',
+    hoverText: 'hover:text-phase-2-referral-dark',
+    cardFrom: 'from-phase-2-referral-pale',
+    cardTo: 'to-phase-2-referral-pale/50',
+    cardBorder: 'border-phase-2-referral-light/30',
+    groupHoverText: 'group-hover:text-phase-2-referral-dark',
+    labelText: 'text-phase-2-referral-dark/80',
   },
   [DIGEST_COLOR_KEYS.PHASE_1]: {
     borderLeft: 'border-l-phase-1',

--- a/merger-tracker/frontend/src/pages/Digest.jsx
+++ b/merger-tracker/frontend/src/pages/Digest.jsx
@@ -312,6 +312,7 @@ function Digest() {
   const summaryCards = [
     { id: 'new-mergers', colorKey: DIGEST_COLOR_KEYS.NEW_MERGER, count: digest.new_deals_notified.length, label: 'New deals notified' },
     { id: 'mergers-approved', colorKey: DIGEST_COLOR_KEYS.CLEARED, count: digest.deals_cleared.length, label: 'Deals cleared' },
+    { id: 'mergers-referred', colorKey: DIGEST_COLOR_KEYS.PHASE_2_REFERRAL, count: (digest.deals_referred_to_phase_2 || []).length, label: 'Referred to phase 2' },
     { id: 'mergers-declined', colorKey: DIGEST_COLOR_KEYS.DECLINED, count: digest.deals_declined.length, label: 'Deals declined' },
     { id: 'ongoing-phase-1', colorKey: DIGEST_COLOR_KEYS.PHASE_1, count: digest.ongoing_phase_1.length, label: 'Ongoing phase 1' },
     { id: 'ongoing-phase-2', colorKey: DIGEST_COLOR_KEYS.PHASE_2, count: digest.ongoing_phase_2.length, label: 'Ongoing phase 2' },
@@ -338,7 +339,7 @@ function Digest() {
         <DigestSignup />
 
         {/* Summary Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-4 mb-8">
+        <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-6 gap-4 mb-8">
           {summaryCards.map(({ id, colorKey, count, label }) => {
             const c = COLOR_CLASSES[colorKey];
             return (
@@ -400,6 +401,26 @@ function Digest() {
                     : 'N/A'}
                 </td>
                 <DeterminationCell merger={merger} colorKey={DIGEST_COLOR_KEYS.CLEARED} defaultDetermination={MERGER_STATUS.APPROVED} getDeterminationPdf={getDeterminationPdf} />
+              </tr>
+            )}
+          />
+
+          <DigestSection
+            id="mergers-referred"
+            title="Mergers referred to phase 2"
+            emptyMessage="No mergers referred to phase 2 this week"
+            colorKey={DIGEST_COLOR_KEYS.PHASE_2_REFERRAL}
+            mergers={digest.deals_referred_to_phase_2 || []}
+            columns={['Merger', 'Referral date', 'Determination']}
+            renderRow={(merger) => (
+              <tr key={merger.merger_id} className="relative hover:bg-phase-2-referral-pale/40 transition-colors">
+                <MergerNameCell merger={merger} colorKey={DIGEST_COLOR_KEYS.PHASE_2_REFERRAL} />
+                <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                  {merger.phase_1_determination_date
+                    ? formatDate(merger.phase_1_determination_date)
+                    : 'N/A'}
+                </td>
+                <DeterminationCell merger={merger} colorKey={DIGEST_COLOR_KEYS.PHASE_2_REFERRAL} defaultDetermination={MERGER_STATUS.REFERRED_TO_PHASE_2} getDeterminationPdf={getDeterminationPdf} />
               </tr>
             )}
           />

--- a/merger-tracker/frontend/tailwind.config.js
+++ b/merger-tracker/frontend/tailwind.config.js
@@ -50,6 +50,12 @@ export default {
           dark: '#3A3372',
           pale: '#E8E5F3',
         },
+        'phase-2-referral': {
+          DEFAULT: '#d97706',
+          light: '#f59e0b',
+          dark: '#b45309',
+          pale: '#fef3c7',
+        },
       },
       boxShadow: {
         'glass': '0 8px 32px 0 rgba(31, 38, 135, 0.07)',

--- a/scripts/generate_weekly_digest.py
+++ b/scripts/generate_weekly_digest.py
@@ -5,6 +5,7 @@ Generate a weekly digest of ACCC merger activity.
 This script creates a summary showing:
 - New deals notified (but not yet determined) in the last week
 - Deals cleared in the last week
+- Deals referred to phase 2 in the last week
 - Deals declined/not approved in the last week
 - Ongoing phase 1 deals
 - Ongoing phase 2 deals
@@ -36,6 +37,7 @@ from typing import Dict, List, Any, Optional, Set
 from constants import merger_status
 from date_utils import parse_iso_datetime
 from merger_filters import filter_active, load_mergers
+from static_data.enrichment import enrich_merger
 
 
 OUTPUT_PATH = (
@@ -223,6 +225,7 @@ def create_merger_summary(merger: Dict[str, Any]) -> Dict[str, Any]:
         'status': merger.get('status'),
         'is_waiver': merger.get('is_waiver', False),
         'phase_1_determination': merger.get('phase_1_determination'),
+        'phase_1_determination_date': merger.get('phase_1_determination_date'),
         'phase_2_determination': merger.get('phase_2_determination'),
         'merger_description': truncated_description,
         'events': merger.get('events', []),
@@ -245,7 +248,7 @@ def generate_weekly_digest(
             week's digest are not repeated. Defaults to reading the
             currently-on-disk digest.json.
     """
-    mergers = filter_active(load_mergers())
+    mergers = filter_active([enrich_merger(m) for m in load_mergers()])
 
     # Get the Monday-Sunday week range in Australian time (for display) and
     # the widened lookback window that actually drives inclusion.
@@ -256,6 +259,7 @@ def generate_weekly_digest(
         previous_digest = load_previous_digest(resolve_previous_digest_path(period_start))
     already_notified = bucket_ids(previous_digest, 'new_deals_notified')
     already_cleared = bucket_ids(previous_digest, 'deals_cleared')
+    already_referred = bucket_ids(previous_digest, 'deals_referred_to_phase_2')
     already_declined = bucket_ids(previous_digest, 'deals_declined')
 
     sydney_tz = ZoneInfo('Australia/Sydney')
@@ -267,6 +271,7 @@ def generate_weekly_digest(
         'period_end': period_end.isoformat(),
         'new_deals_notified': [],
         'deals_cleared': [],
+        'deals_referred_to_phase_2': [],
         'deals_declined': [],
         'ongoing_phase_1': [],
         'ongoing_phase_2': [],
@@ -305,6 +310,12 @@ def generate_weekly_digest(
                 if merger_id not in already_declined:
                     digest['deals_declined'].append(create_merger_summary(merger))
 
+        phase_1_determination_date = merger.get('phase_1_determination_date')
+        if (phase_1_determination == merger_status.REFERRED_TO_PHASE_2 and
+            is_in_week_range(phase_1_determination_date, lookback_start, period_end) and
+            merger_id not in already_referred):
+            digest['deals_referred_to_phase_2'].append(create_merger_summary(merger))
+
         # Ongoing phase 1/2 lists are always a current snapshot, not a
         # week-scoped activity list, so dedup does not apply.
         if (status == merger_status.UNDER_ASSESSMENT and
@@ -320,9 +331,12 @@ def generate_weekly_digest(
         key=lambda x: x.get('effective_notification_datetime') or ''
     )
 
-    # Sort cleared and declined by determination date (ascending)
+    # Sort cleared, referred, and declined by determination date (ascending)
     digest['deals_cleared'].sort(
         key=lambda x: x.get('determination_publication_date') or ''
+    )
+    digest['deals_referred_to_phase_2'].sort(
+        key=lambda x: x.get('phase_1_determination_date') or ''
     )
     digest['deals_declined'].sort(
         key=lambda x: x.get('determination_publication_date') or ''
@@ -366,6 +380,7 @@ def main():
     print(f"\nSummary:")
     print(f"  New deals notified (last week): {len(digest['new_deals_notified'])}")
     print(f"  Deals cleared (last week): {len(digest['deals_cleared'])}")
+    print(f"  Deals referred to phase 2 (last week): {len(digest['deals_referred_to_phase_2'])}")
     print(f"  Deals declined (last week): {len(digest['deals_declined'])}")
     print(f"  Ongoing phase 1 deals: {len(digest['ongoing_phase_1'])}")
     print(f"  Ongoing phase 2 deals: {len(digest['ongoing_phase_2'])}")


### PR DESCRIPTION
## Summary
This PR adds support for tracking and displaying mergers referred to phase 2 in the weekly digest. Previously, the digest only showed new deals, cleared deals, and declined deals. Now it includes a dedicated section for deals that received a phase 1 determination of referral to phase 2.

## Key Changes

- **Backend (generate_weekly_digest.py)**:
  - Added `deals_referred_to_phase_2` list to digest output
  - Implemented logic to identify mergers referred to phase 2 within the week range
  - Added deduplication to avoid re-reporting previously referred deals
  - Included `phase_1_determination_date` in merger summaries for sorting
  - Sort referred deals by phase 1 determination date

- **Frontend (Digest.jsx)**:
  - Added new summary card for "Referred to phase 2" count
  - Updated grid layout from 5 to 6 columns to accommodate new card
  - Created new `DigestSection` component displaying referred mergers with:
    - Merger name
    - Referral date (phase 1 determination date)
    - Determination status
  - Integrated with existing color theming system

- **Constants & Styling**:
  - Added `PHASE_2_REFERRAL` color key to `DIGEST_COLOR_KEYS`
  - Defined complete color class set for phase 2 referral styling
  - Added Tailwind color palette for phase 2 referral (amber/orange tones: #d97706)

## Implementation Details

- The referral detection uses the same week-range logic as other digest categories
- Deduplication prevents the same referral from appearing in multiple weekly digests
- The referral date displayed is the `phase_1_determination_date` field
- Color scheme uses amber/orange tones to visually distinguish referrals from other statuses

https://claude.ai/code/session_012AP7y56B1Bc6oVAr4fAtbg