### PR TITLE
Add middle-click support to open merger details in new tab

### DIFF
--- a/merger-tracker/frontend/src/pages/Mergers.jsx
+++ b/merger-tracker/frontend/src/pages/Mergers.jsx
@@ -511,6 +511,7 @@ function Mergers() {
                 tabIndex={0}
                 aria-label={`View merger details for ${merger.merger_name}`}
                 onClick={() => navigate(`/mergers/${merger.merger_id}`)}
+                onMouseDown={(e) => { if (e.button === 1) e.preventDefault(); }}
                 onAuxClick={(e) => {
                   if (e.button === 1) window.open(`/mergers/${merger.merger_id}`, '_blank');
                 }}

--- a/merger-tracker/frontend/src/pages/Mergers.jsx
+++ b/merger-tracker/frontend/src/pages/Mergers.jsx
@@ -511,6 +511,9 @@ function Mergers() {
                 tabIndex={0}
                 aria-label={`View merger details for ${merger.merger_name}`}
                 onClick={() => navigate(`/mergers/${merger.merger_id}`)}
+                onAuxClick={(e) => {
+                  if (e.button === 1) window.open(`/mergers/${merger.merger_id}`, '_blank');
+                }}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter' || e.key === ' ') {
                     e.preventDefault();


### PR DESCRIPTION
## Summary
Added support for middle-click (auxiliary click) functionality on merger detail rows, allowing users to open merger details in a new browser tab.

## Key Changes
- Added `onAuxClick` event handler to merger row element that detects middle-click (button code 1)
- When middle-clicked, the merger details page opens in a new tab using `window.open()` with `'_blank'` target
- Complements existing left-click navigation and keyboard accessibility features

## Implementation Details
- The handler checks `e.button === 1` to specifically target middle-click events
- Uses the same merger detail route (`/mergers/${merger.merger_id}`) as the primary click handler
- Maintains consistency with standard web browser conventions where middle-click opens links in new tabs

https://claude.ai/code/session_015Zmk3rkdpUW52crGxbgyH4