### PR TITLE
Remove alternate name from schema.org metadata

### DIFF
--- a/merger-tracker/frontend/index.html
+++ b/merger-tracker/frontend/index.html
@@ -50,7 +50,6 @@
       "@context": "https://schema.org",
       "@type": "WebSite",
       "name": "Australian Merger Tracker",
-      "alternateName": "mergers.fyi",
       "url": "https://mergers.fyi",
       "description": "Real-time database of Australian mergers reviewed by the ACCC. Search merger decisions, track review timelines, analyze industry trends, and explore public consultation documents.",
       "author": {


### PR DESCRIPTION
## Summary
Removed the `alternateName` field from the schema.org WebSite structured data in the HTML metadata.

## Changes
- Removed `"alternateName": "mergers.fyi"` from the JSON-LD schema.org WebSite definition in `index.html`

## Details
The primary URL `https://mergers.fyi` is already defined in the `url` field, making the alternate name redundant. This simplifies the schema.org metadata while maintaining all essential site information for search engines and other consumers of structured data.

https://claude.ai/code/session_01FbUnKsdF8yhyGNbeaL1JAT