### PR TITLE
Reorder waiver section and improve bullet point handling

### DIFF
--- a/merger-tracker/frontend/src/components/WaiverExplanationSection.jsx
+++ b/merger-tracker/frontend/src/components/WaiverExplanationSection.jsx
@@ -69,7 +69,7 @@ function WaiverExplanationSection({ events }) {
 
   const determinationEvent = eventsArr.find(e => e.is_determination_event && e.url_gh);
 
-  const paragraphs = cleanExplanation(explanationDetails)
+  const rawParagraphs = cleanExplanation(explanationDetails)
     .split('\n\n')
     .map(p => p.trim())
     .filter(p =>
@@ -77,6 +77,13 @@ function WaiverExplanationSection({ events }) {
       !p.startsWith('In making this notification waiver determination, the Australian Competition and Consumer Commission') &&
       !p.startsWith('For more information about the ACCC')
     );
+
+  // If the very first paragraph is a bullet point, strip the bullet and treat it as plain text.
+  if (rawParagraphs.length > 0 && rawParagraphs[0].startsWith('•')) {
+    rawParagraphs[0] = rawParagraphs[0].replace(/^•\s*/, '');
+  }
+
+  const paragraphs = rawParagraphs;
 
   const segments = groupSegments(paragraphs);
 

--- a/merger-tracker/frontend/src/pages/MergerDetail.jsx
+++ b/merger-tracker/frontend/src/pages/MergerDetail.jsx
@@ -299,6 +299,11 @@ function MergerDetail() {
           </Link>
         )}
 
+        {/* Waiver explanation */}
+        {merger.is_waiver && (
+          <WaiverExplanationSection events={merger.events} />
+        )}
+
         {/* Parties */}
         <div className={`grid grid-cols-1 ${merger.other_parties && merger.other_parties.length > 0 ? 'md:grid-cols-3' : 'md:grid-cols-2'} gap-4 mb-6`}>
           {renderPartyList(merger.acquirers, 'acquirers', 'Acquirers')}
@@ -323,11 +328,6 @@ function MergerDetail() {
         {/* Questionnaire */}
         {merger.has_questionnaire && (
           <QuestionnaireSection mergerId={merger.merger_id} events={merger.events} />
-        )}
-
-        {/* Waiver explanation */}
-        {merger.is_waiver && (
-          <WaiverExplanationSection events={merger.events} />
         )}
 
         {/* Commentary */}


### PR DESCRIPTION
## Summary
This PR reorders the waiver explanation section to appear earlier in the merger detail view and improves the formatting of bullet points in waiver explanations.

## Key Changes
- **Reordered sections**: Moved `WaiverExplanationSection` to appear before the `QuestionnaireSection` in the merger detail page, improving the logical flow of information presentation
- **Improved bullet point handling**: Added logic to detect and strip leading bullet points from the first paragraph of waiver explanations, treating them as plain text instead of list items for better readability

## Implementation Details
- The waiver explanation section now renders immediately after the merger link section and before the parties grid
- In `WaiverExplanationSection.jsx`, the first paragraph is checked for a leading bullet character (`•`), and if found, the bullet is removed while preserving the text content
- This ensures that opening statements in waiver explanations are displayed as regular paragraphs rather than bullet points

https://claude.ai/code/session_01L8Vouv7jaoHjBmBD9ZBKh3