### PR TITLE
Fix WA-70011 first sentence truncation in waiver explanation

### DIFF
--- a/data/raw/acquisitions-register.html
+++ b/data/raw/acquisitions-register.html
@@ -2853,126 +2853,6 @@
     <div class="views-row">
 
 <div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-167970">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/swiss-re-qbe-insurances-trade-credit-and-surety-business">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  Swiss Re - QBE Insurance&#039;s Trade Credit and Surety business
-</h3>
-</div>
-      
-<div  class="accc-collapsed-card__header-info">
-        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline under-assessment clearfix">
-    <h3 class="field__label">Acquisition status</h3>
-              <div class="field__item">Under assessment</div>
-          </div>
-
-<div  class="accc-collapsed-card__header-content">
-      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
-<div class="field__item">Notification</div>
-</div>
-  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
-    <h3 class="field__label">Case number</h3>
-              <div class="field__item">MN-40015</div>
-          </div>
-  <div class="field field--name-field-acquisition-stage field--type-list-string field--label-inline clearfix">
-    <h3 class="field__label">Stage</h3>
-              <div class="field__item">Phase 1 - initial assessment</div>
-          </div>
-  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
-    <h3 class="field__label">Effective notification date</h3>
-              <div class="field__item"><time datetime="2026-04-10T12:00:00Z" class="datetime">10 Apr 2026</time>
-</div>
-          </div>
-
-  </div>
-
-  </div>
-</a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167970" href="#card-167970">
-      <span>expandable trigger</span>
-    </a>
-  </div>
-  <div id="card-167970" role="region" aria-labelledby="heading-167970" class="accc-collapsed-card__body collapse">
-    
-<div >
-    <h3 class="border-bottom">About the acquisition</h3>
-      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Acquirer(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631343">
-      <span class="field_acccgov_name">
-            Swiss Re International SE
-
-      </span>
-      <span>
-                      B134553
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Target(s) or Vendor(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631344">
-      <span class="field_acccgov_name">
-            QBE Insurance Holdings Pty Limited
-
-      </span>
-      <span>
-                        ABN -
-    69 146 960 438
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-  <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
-    <h3 class="field__label">ANZSIC code(s)</h3>
-          <div class="field__item">
-              6322  General Insurance              </div>
-      </div>
-  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
-    <h3 class="field__label">Description</h3>
-              <div class="field__item">
-<div class="read-more-wrapper">
-      <div class="summary-text">
-      <p>Swiss Re International SE (<strong>Swiss Re</strong>) proposes to acquire certain assets from QBE Insurance Holdings Pty Ltd (<strong>QBE</strong>) relating to its Credit &amp; Surety business (</p>
-    </div>
-    <div class="full-text" style="display:none;">
-    <p>Swiss Re International SE (<strong>Swiss Re</strong>) proposes to acquire certain assets from QBE Insurance Holdings Pty Ltd (<strong>QBE</strong>) relating to its Credit &amp; Surety business (<strong>QBE’s TC&amp;S Business</strong>), including data, employees and renewal rights (the <strong>Acquisition</strong>).&nbsp;</p>
-
-<p>Swiss Re provides insurance, reinsurance and risk transfer solutions to mid to large-sized corporate customers. In Australia, Swiss Re provides a range of property and casualty insurance products, including non-payment insurance for banks, surety bonds and claims management services.</p>
-
-<p class="ListBulletTable">QBE is an Australian-based provider of a broad range of insurance and reinsurance products to personal, business, corporate and institutional customers. QBE’s TC&amp;S Business provides:</p>
-
-<ul>
-<li class="ck-list-marker-font-size" data-list-item-id="e87bdd06c811d68d67b21ea7b39b8947f">
-<p class="ListBulletTable">non‑payment insurance (also known as trade finance insurance) which insures commercial banks and financial institutions against the risk of counterparties’ non‑payment of loans, guarantees or letters of credit.</p>
-</li>
-<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="e43985244079748f7a1e1801203017be1">
-<p class="ListBulletTable">trade credit insurance which insures corporate customers against the risk of non-payment of trade receivables arising from credit sales.</p>
-</li>
-<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="ed52e9e938beefe848f5a75022d28cd23">
-<p class="ListBulletTable">surety bonds which involve providing a financial guarantee that a party will fulfill a contractual, statutory, or financial obligation with the insurer committing to intervene if the insured party fails to do so.</p>
-</li>
-</ul>
-
-  </div>
-      <a href="#" class="read-toggle" data-expanded="true">read more</a>
-  </div></div>
-          </div>
-
-  </div>
-
-  </div>
-</div>
-
-</div>
-    <div class="views-row">
-
-<div  class="accc-collapsed-card contextual-region h-100">
   <div class="accc-collapsed-card__header" id="heading-167986">
   <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/dubai-aerospace-enterprise-macquarie-airfinance">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
   Dubai Aerospace Enterprise - Macquarie AirFinance
@@ -3211,6 +3091,126 @@
 <p>Norsan is a small family-owned supplier of three residential aged care services operating in certain parts of metropolitan Melbourne and outer Melbourne suburbs. Norsan is also a registered provider of residential care services under the ACA.</p>
 
 <p>Both Estia and Norsan are providers of residential aged care services in certain areas within, and in the outer suburbs of metropolitan Melbourne.</p>
+
+  </div>
+      <a href="#" class="read-toggle" data-expanded="true">read more</a>
+  </div></div>
+          </div>
+
+  </div>
+
+  </div>
+</div>
+
+</div>
+    <div class="views-row">
+
+<div  class="accc-collapsed-card contextual-region h-100">
+  <div class="accc-collapsed-card__header" id="heading-167970">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/swiss-re-qbe-insurances-trade-credit-and-surety-business">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  Swiss Re - QBE Insurance&#039;s Trade Credit and Surety business
+</h3>
+</div>
+      
+<div  class="accc-collapsed-card__header-info">
+        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline under-assessment clearfix">
+    <h3 class="field__label">Acquisition status</h3>
+              <div class="field__item">Under assessment</div>
+          </div>
+
+<div  class="accc-collapsed-card__header-content">
+      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
+<div class="field__item">Notification</div>
+</div>
+  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
+    <h3 class="field__label">Case number</h3>
+              <div class="field__item">MN-40015</div>
+          </div>
+  <div class="field field--name-field-acquisition-stage field--type-list-string field--label-inline clearfix">
+    <h3 class="field__label">Stage</h3>
+              <div class="field__item">Phase 1 - initial assessment</div>
+          </div>
+  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
+    <h3 class="field__label">Effective notification date</h3>
+              <div class="field__item"><time datetime="2026-04-10T12:00:00Z" class="datetime">10 Apr 2026</time>
+</div>
+          </div>
+
+  </div>
+
+  </div>
+</a>
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167970" href="#card-167970">
+      <span>expandable trigger</span>
+    </a>
+  </div>
+  <div id="card-167970" role="region" aria-labelledby="heading-167970" class="accc-collapsed-card__body collapse">
+    
+<div >
+    <h3 class="border-bottom">About the acquisition</h3>
+      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Acquirer(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631343">
+      <span class="field_acccgov_name">
+            Swiss Re International SE
+
+      </span>
+      <span>
+                      B134553
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Target(s) or Vendor(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631344">
+      <span class="field_acccgov_name">
+            QBE Insurance Holdings Pty Limited
+
+      </span>
+      <span>
+                        ABN -
+    69 146 960 438
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+  <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
+    <h3 class="field__label">ANZSIC code(s)</h3>
+          <div class="field__item">
+              6322  General Insurance              </div>
+      </div>
+  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
+    <h3 class="field__label">Description</h3>
+              <div class="field__item">
+<div class="read-more-wrapper">
+      <div class="summary-text">
+      <p>Swiss Re International SE (<strong>Swiss Re</strong>) proposes to acquire certain assets from QBE Insurance Holdings Pty Ltd (<strong>QBE</strong>) relating to its Credit &amp; Surety business (</p>
+    </div>
+    <div class="full-text" style="display:none;">
+    <p>Swiss Re International SE (<strong>Swiss Re</strong>) proposes to acquire certain assets from QBE Insurance Holdings Pty Ltd (<strong>QBE</strong>) relating to its Credit &amp; Surety business (<strong>QBE’s TC&amp;S Business</strong>), including data, employees and renewal rights (the <strong>Acquisition</strong>).&nbsp;</p>
+
+<p>Swiss Re provides insurance, reinsurance and risk transfer solutions to mid to large-sized corporate customers. In Australia, Swiss Re provides a range of property and casualty insurance products, including non-payment insurance for banks, surety bonds and claims management services.</p>
+
+<p class="ListBulletTable">QBE is an Australian-based provider of a broad range of insurance and reinsurance products to personal, business, corporate and institutional customers. QBE’s TC&amp;S Business provides:</p>
+
+<ul>
+<li class="ck-list-marker-font-size" data-list-item-id="e87bdd06c811d68d67b21ea7b39b8947f">
+<p class="ListBulletTable">non‑payment insurance (also known as trade finance insurance) which insures commercial banks and financial institutions against the risk of counterparties’ non‑payment of loans, guarantees or letters of credit.</p>
+</li>
+<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="e43985244079748f7a1e1801203017be1">
+<p class="ListBulletTable">trade credit insurance which insures corporate customers against the risk of non-payment of trade receivables arising from credit sales.</p>
+</li>
+<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="ed52e9e938beefe848f5a75022d28cd23">
+<p class="ListBulletTable">surety bonds which involve providing a financial guarantee that a party will fulfill a contractual, statutory, or financial obligation with the insurer committing to intervene if the insured party fails to do so.</p>
+</li>
+</ul>
 
   </div>
       <a href="#" class="read-toggle" data-expanded="true">read more</a>
@@ -6793,6 +6793,178 @@ The Acquirers are part of the MA Marina Fund, managed by entities held by MA Fin
     <div class="views-row">
 
 <div  class="accc-collapsed-card contextual-region h-100">
+  <div class="accc-collapsed-card__header" id="heading-167989">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/lighthouse-precise-services-group">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  Lighthouse - Precise Services Group
+</h3>
+</div>
+      
+<div  class="accc-collapsed-card__header-info">
+        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
+    <h3 class="field__label">Acquisition status</h3>
+              <div class="field__item">Assessment completed</div>
+          </div>
+
+<div  class="accc-collapsed-card__header-content">
+      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
+<div class="field__item">Waiver</div>
+</div>
+  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
+    <h3 class="field__label">Case number</h3>
+              <div class="field__item">WA-95010</div>
+          </div>
+  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
+    <h3 class="field__label">Waiver application date</h3>
+              <div class="field__item"><time datetime="2026-03-23T12:00:00Z" class="datetime">23 Mar 2026</time>
+</div>
+          </div>
+
+  </div>
+
+  </div>
+</a>
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167989" href="#card-167989">
+      <span>expandable trigger</span>
+    </a>
+  </div>
+  <div id="card-167989" role="region" aria-labelledby="heading-167989" class="accc-collapsed-card__body collapse">
+    
+<div >
+    <h3 class="border-bottom">About the acquisition</h3>
+      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Acquirer(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631373">
+      <span class="field_acccgov_name">
+            LIGHTHOUSE SERVICE PARTNERS BIDCO PTY LTD
+
+      </span>
+      <span>
+                        ABN -
+    91 685 113 197
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Target(s) or Vendor(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631377">
+      <span class="field_acccgov_name">
+            PRECISE TRADE SERVICES PTY LTD
+
+      </span>
+      <span>
+                        ABN -
+    48 167 424 562
+
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631378">
+      <span class="field_acccgov_name">
+            SA Pipe Relining Pty. Ltd.
+
+      </span>
+      <span>
+                        ABN -
+    89 125 590 276
+
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631379">
+      <span class="field_acccgov_name">
+            PRECISE PLUMBING PTY LTD
+
+      </span>
+      <span>
+                        ABN -
+    22 096 631 202
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-other-parties field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Other party(ies)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631375">
+      <span class="field_acccgov_name">
+            LIGHTHOUSE SERVICE PARTNERS HOLDCO PTY LTD
+
+      </span>
+      <span>
+                        ABN -
+    66 685 112 216
+
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631376">
+      <span class="field_acccgov_name">
+            KEN HALL HOLDINGS PTY LTD
+
+      </span>
+      <span>
+                        ABN -
+    27 619 501 236
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+  <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
+    <h3 class="field__label">ANZSIC code(s)</h3>
+          <div class="field__item">
+              3231  Plumbing Services;           3232  Electrical Services;           3233  Air Conditioning and Heating Services;           3242  Carpentry Services              </div>
+      </div>
+  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
+    <h3 class="field__label">Description</h3>
+              <div class="field__item">
+<div class="read-more-wrapper">
+      <div class="summary-text">
+      <p>Lighthouse Service Partners Holdco Pty Ltd, through its subsidiary Lighthouse Service Partners Bidco Pty Ltd (together, <strong>Lighthouse</strong>), proposes to acquire 100% of the issued share ca</p>
+    </div>
+    <div class="full-text" style="display:none;">
+    <p>Lighthouse Service Partners Holdco Pty Ltd, through its subsidiary Lighthouse Service Partners Bidco Pty Ltd (together, <strong>Lighthouse</strong>), proposes to acquire 100% of the issued share capital in Precise Plumbing Pty Ltd (<strong>Precise Plumbing</strong>), SA Pipe Relining Pty Ltd (<strong>SAPR</strong>) and Precise Trade Services Pty Ltd (<strong>PTS</strong>) (together, <strong>Precise Services Group</strong>) from its current shareholders.</p>
+
+<p>Lighthouse’s investment structure focuses on acquisitions and investments in home services businesses across plumbing, heating ventilation and air conditioning (HVAC), electrical and related trades in Australia (together, <strong>“integrated building services”</strong>). Lighthouse is ultimately owned by Alpine Investors, a private equity firm headquartered in San Francisco, California.</p>
+
+<p>Lighthouse owns Ken Hall Holdings Pty Ltd which operates in the Greater Adelaide region and predominantly provides residential integrated building services, including plumbing, electrical, HVAC, roofing, tiling, bathroom renovations, handyman services, and related home maintenance services.</p>
+
+<p>The Precise Services Group companies provide trade services to residential and commercial customers across the Greater Adelaide region, including:</p>
+
+<ul>
+<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="e0f3481a85070b5da456179d546d407c4">
+<p>Precise Plumbing provides integrated building services to predominantly residential customers in respect of plumbing, electrical, HVAC, bathroom renovations and handyman services; and</p>
+</li>
+<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="e83601067c2718e563979c42447ce9b62">
+<p>SAPR provides plumbing services to residential and commercial customers and specialises in pipe relining.</p>
+</li>
+<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="e6bd88b1eaa405d2fa8529b97e479626a">
+<p>PTS is a shared service entity which is a cost centre for PPE and SAPR</p>
+</li>
+</ul>
+
+  </div>
+      <a href="#" class="read-toggle" data-expanded="true">read more</a>
+  </div></div>
+          </div>
+
+  </div>
+
+  </div>
+</div>
+
+</div>
+    <div class="views-row">
+
+<div  class="accc-collapsed-card contextual-region h-100">
   <div class="accc-collapsed-card__header" id="heading-167819">
   <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/intrepid-travel-wild-bush-luxury">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
   Intrepid Travel - Wild Bush Luxury
@@ -7057,178 +7229,6 @@ The Acquirers are part of the MA Marina Fund, managed by entities held by MA Fin
     <p>The acquirer, Idemitsu, is a Japanese company oil-refining and marketing company. It has been involved in the development, production, and sale of coal at several mines in Australia. Idemitsu currently operates the Boggabri Coal Mine in NSW. Idemitsu has invested in lithium and vanadium development companies, renewables and acquired a fuel oil retail business.&nbsp;</p>
 
 <p>MidOcean Energy is a global liquid natural gas (LNG) platform formed and managed by EIG Partners in 2023. In Australia, MidOcean holds minority interests in the Queensland Curtis LNG Project, Gorgon LNG Project and Pluto LNG Project. These projects are involved in the extraction and production of natural gas and LNG.</p>
-
-  </div>
-      <a href="#" class="read-toggle" data-expanded="true">read more</a>
-  </div></div>
-          </div>
-
-  </div>
-
-  </div>
-</div>
-
-</div>
-    <div class="views-row">
-
-<div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-167989">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/lighthouse-precise-services-group">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  Lighthouse - Precise Services Group
-</h3>
-</div>
-      
-<div  class="accc-collapsed-card__header-info">
-        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
-    <h3 class="field__label">Acquisition status</h3>
-              <div class="field__item">Assessment completed</div>
-          </div>
-
-<div  class="accc-collapsed-card__header-content">
-      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
-<div class="field__item">Waiver</div>
-</div>
-  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
-    <h3 class="field__label">Case number</h3>
-              <div class="field__item">WA-95010</div>
-          </div>
-  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
-    <h3 class="field__label">Waiver application date</h3>
-              <div class="field__item"><time datetime="2026-03-23T12:00:00Z" class="datetime">23 Mar 2026</time>
-</div>
-          </div>
-
-  </div>
-
-  </div>
-</a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167989" href="#card-167989">
-      <span>expandable trigger</span>
-    </a>
-  </div>
-  <div id="card-167989" role="region" aria-labelledby="heading-167989" class="accc-collapsed-card__body collapse">
-    
-<div >
-    <h3 class="border-bottom">About the acquisition</h3>
-      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Acquirer(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631373">
-      <span class="field_acccgov_name">
-            LIGHTHOUSE SERVICE PARTNERS BIDCO PTY LTD
-
-      </span>
-      <span>
-                        ABN -
-    91 685 113 197
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Target(s) or Vendor(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631377">
-      <span class="field_acccgov_name">
-            PRECISE TRADE SERVICES PTY LTD
-
-      </span>
-      <span>
-                        ABN -
-    48 167 424 562
-
-              </span>
-    </div>
-  </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631378">
-      <span class="field_acccgov_name">
-            SA Pipe Relining Pty. Ltd.
-
-      </span>
-      <span>
-                        ABN -
-    89 125 590 276
-
-              </span>
-    </div>
-  </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631379">
-      <span class="field_acccgov_name">
-            PRECISE PLUMBING PTY LTD
-
-      </span>
-      <span>
-                        ABN -
-    22 096 631 202
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-other-parties field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Other party(ies)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631375">
-      <span class="field_acccgov_name">
-            LIGHTHOUSE SERVICE PARTNERS HOLDCO PTY LTD
-
-      </span>
-      <span>
-                        ABN -
-    66 685 112 216
-
-              </span>
-    </div>
-  </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631376">
-      <span class="field_acccgov_name">
-            KEN HALL HOLDINGS PTY LTD
-
-      </span>
-      <span>
-                        ABN -
-    27 619 501 236
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-  <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
-    <h3 class="field__label">ANZSIC code(s)</h3>
-          <div class="field__item">
-              3231  Plumbing Services;           3232  Electrical Services;           3233  Air Conditioning and Heating Services;           3242  Carpentry Services              </div>
-      </div>
-  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
-    <h3 class="field__label">Description</h3>
-              <div class="field__item">
-<div class="read-more-wrapper">
-      <div class="summary-text">
-      <p>Lighthouse Service Partners Holdco Pty Ltd, through its subsidiary Lighthouse Service Partners Bidco Pty Ltd (together, <strong>Lighthouse</strong>), proposes to acquire 100% of the issued share ca</p>
-    </div>
-    <div class="full-text" style="display:none;">
-    <p>Lighthouse Service Partners Holdco Pty Ltd, through its subsidiary Lighthouse Service Partners Bidco Pty Ltd (together, <strong>Lighthouse</strong>), proposes to acquire 100% of the issued share capital in Precise Plumbing Pty Ltd (<strong>Precise Plumbing</strong>), SA Pipe Relining Pty Ltd (<strong>SAPR</strong>) and Precise Trade Services Pty Ltd (<strong>PTS</strong>) (together, <strong>Precise Services Group</strong>) from its current shareholders.</p>
-
-<p>Lighthouse’s investment structure focuses on acquisitions and investments in home services businesses across plumbing, heating ventilation and air conditioning (HVAC), electrical and related trades in Australia (together, <strong>“integrated building services”</strong>). Lighthouse is ultimately owned by Alpine Investors, a private equity firm headquartered in San Francisco, California.</p>
-
-<p>Lighthouse owns Ken Hall Holdings Pty Ltd which operates in the Greater Adelaide region and predominantly provides residential integrated building services, including plumbing, electrical, HVAC, roofing, tiling, bathroom renovations, handyman services, and related home maintenance services.</p>
-
-<p>The Precise Services Group companies provide trade services to residential and commercial customers across the Greater Adelaide region, including:</p>
-
-<ul>
-<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="e0f3481a85070b5da456179d546d407c4">
-<p>Precise Plumbing provides integrated building services to predominantly residential customers in respect of plumbing, electrical, HVAC, bathroom renovations and handyman services; and</p>
-</li>
-<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="e83601067c2718e563979c42447ce9b62">
-<p>SAPR provides plumbing services to residential and commercial customers and specialises in pipe relining.</p>
-</li>
-<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="e6bd88b1eaa405d2fa8529b97e479626a">
-<p>PTS is a shared service entity which is a cost centre for PPE and SAPR</p>
-</li>
-</ul>
 
   </div>
       <a href="#" class="read-toggle" data-expanded="true">read more</a>

--- a/data/raw/matters/WA-05005.html
+++ b/data/raw/matters/WA-05005.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="IBWM Pty Ltd (IBWM), a subsidiary of Ironbark Investment Partners Pty Ltd (Ironbark), will acquire 40% of the shares on issue in Viola Group Holdings Pty Ltd (Viola Group). Viola Group is the parent company of Viola Finance Pty Ltd, Viola Private Holdings Pty Ltd, Viola Services Pty Ltd and Viola Private Wealth Pty Ltd (Viola). Ironbark has a business division which provides financial advice to retail and wholesale clients. Viola Group focuses on private wealth and high net worth clients." />
-<link rel="shortlink" href="https://www.accc.gov.au/node/167962" />
 <link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/ironbark-investment-in-viola-private-wealth" />
+<link rel="shortlink" href="https://www.accc.gov.au/node/167962" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/merger-tracker/frontend/src/components/WaiverExplanationSection.jsx
+++ b/merger-tracker/frontend/src/components/WaiverExplanationSection.jsx
@@ -21,7 +21,7 @@ function cleanExplanation(text) {
     const lastChar = before.slice(-1);
 
     if (lastChar === '-') return '';
-    if (after.startsWith('•')) return '\n\n';
+    if (after.startsWith('•')) return /[a-zA-Z]/.test(lastChar) ? ' ' : '\n\n';
     if (/^[a-z]\./.test(after)) return '\n\n';
     if ((lastChar === '.' || lastChar === ')') && /^[A-Z]/.test(after)) return '\n\n';
     return ' ';


### PR DESCRIPTION
In WA-70011 the boilerplate intro sentence ends with "and\n• had regard
to the factors..." — the bullet is a mid-sentence continuation, not a new
list item. cleanExplanation was inserting \n\n before any •, which split
the boilerplate across two paragraphs. The filter removed the first half
("In making this...application and") but left the bullet as the first
displayed paragraph, which after bullet-stripping rendered as the
fragment "had regard to the factors...".

Fix: when • follows a letter character (mid-sentence), join with a space
instead of a paragraph break. Bullets after : or . (sentence boundaries)
continue to create paragraph breaks as before.

https://claude.ai/code/session_01GsAruM1F5oZ7CERbeXMmAB