### PR TITLE
Reduce spurious diffs in acquisitions register scraping

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -75,7 +75,16 @@ jobs:
           if git diff --staged --quiet; then
             echo "changed=false" >> $GITHUB_OUTPUT
           else
-            echo "changed=true" >> $GITHUB_OUTPUT
+            # acquisitions-register.html alone isn't worth committing: any meaningful
+            # change (new merger, status update) is also reflected in individual matter
+            # pages. Unstage it if it's the only thing that changed.
+            non_register=$(git diff --staged --name-only | grep -v "^data/raw/acquisitions-register\.html$" | wc -l)
+            if [ "$non_register" -gt 0 ]; then
+              echo "changed=true" >> $GITHUB_OUTPUT
+            else
+              git restore --staged data/raw/acquisitions-register.html
+              echo "changed=false" >> $GITHUB_OUTPUT
+            fi
           fi
 
       # --- Extract (first pass) ---

--- a/data/raw/acquisitions-register.html
+++ b/data/raw/acquisitions-register.html
@@ -32,8 +32,8 @@
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
 <meta name="dcterms.audience" content="Business,Industry" />
-<meta name="dcterms.modified" content="2026-01-19T11:12:21+11:00" />
 <meta name="dcterms.created" content="2025-04-15T11:28:41+10:00" />
+<meta name="dcterms.modified" content="2026-01-19T11:12:21+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />
@@ -2853,6 +2853,278 @@
     <div class="views-row">
 
 <div  class="accc-collapsed-card contextual-region h-100">
+  <div class="accc-collapsed-card__header" id="heading-168028">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/signant-actigraph">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  Signant - ActiGraph
+</h3>
+</div>
+      
+<div  class="accc-collapsed-card__header-info">
+        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
+    <h3 class="field__label">Acquisition status</h3>
+              <div class="field__item">Assessment completed</div>
+          </div>
+
+<div  class="accc-collapsed-card__header-content">
+      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
+<div class="field__item">Waiver</div>
+</div>
+  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
+    <h3 class="field__label">Case number</h3>
+              <div class="field__item">WA-45011</div>
+          </div>
+  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
+    <h3 class="field__label">Waiver application date</h3>
+              <div class="field__item"><time datetime="2026-04-10T12:00:00Z" class="datetime">10 Apr 2026</time>
+</div>
+          </div>
+
+  </div>
+
+  </div>
+</a>
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-168028" href="#card-168028">
+      <span>expandable trigger</span>
+    </a>
+  </div>
+  <div id="card-168028" role="region" aria-labelledby="heading-168028" class="accc-collapsed-card__body collapse">
+    
+<div >
+    <h3 class="border-bottom">About the acquisition</h3>
+      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Acquirer(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631438">
+      <span class="field_acccgov_name">
+            Signant Health Holding Corp.
+
+      </span>
+      <span>
+                      Delaware File Number - 5354678
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Target(s) or Vendor(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631444">
+      <span class="field_acccgov_name">
+            ActiGraph Holdings, LLC
+
+      </span>
+      <span>
+                      Delaware File Number - 7952013
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-other-parties field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Other party(ies)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631440">
+      <span class="field_acccgov_name">
+            ActiGraph India Private Limited
+
+      </span>
+      <span>
+                      India CIN - U72900KA2023FTC169807
+
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631441">
+      <span class="field_acccgov_name">
+            Genstar BI Gen Holdings Cayman, L.P.
+
+      </span>
+      <span>
+                      Cayman Islands Reference Number - 1754174
+
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631442">
+      <span class="field_acccgov_name">
+            ActiGraph, LLC
+
+      </span>
+      <span>
+                      EIN - 56-2443729
+
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631443">
+      <span class="field_acccgov_name">
+            Buccaneer Holdco Limited
+
+      </span>
+      <span>
+                      UK Company Number - 11463144
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+  <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
+    <h3 class="field__label">ANZSIC code(s)</h3>
+          <div class="field__item">
+              6240  Financial Asset Investing;           6925  Scientific Testing and Analysis Services              </div>
+      </div>
+  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
+    <h3 class="field__label">Description</h3>
+              <div class="field__item">
+<div class="read-more-wrapper">
+      <div class="summary-text">
+      <p>Signant Health Holding Corp (<strong>Signant</strong>) proposes to acquire 100% of the shares in ActiGraph Holdings, LLC (together with its subsidiaries, <strong>ActiGraph</strong>).&nbsp;</p>
+    </div>
+    <div class="full-text" style="display:none;">
+    <p>Signant Health Holding Corp (<strong>Signant</strong>) proposes to acquire 100% of the shares in ActiGraph Holdings, LLC (together with its subsidiaries, <strong>ActiGraph</strong>).&nbsp;</p>
+
+<p>Signant is a US-based evidence generation company that provides services used in clinical trials. Signant does not have a physical presence in Australia but provides electronic clinical outcome assessments (<strong>eCOA</strong>), clinical trial randomisation and supply management (<strong>RTSM</strong>) services, and supplementary clinical trial professional services. Signant supplies these services to both contract research organisations (<strong>CROs</strong>) and directly to pharmaceutical and biotechnology companies.&nbsp;</p>
+
+<p>Ametris (formerly ActiGraph) is a US-based provider of digital health technology (<strong>DHT</strong>) for clinical trials, specialising in wearables – in particular, wrist-worn wearables and other sensors – which track biovitals and other digital endpoints for patients participating in clinical trials. Ametris does not have a physical presence in Australia but supplies its DHT products in Australia for non-commercial academic research.&nbsp;</p>
+
+  </div>
+      <a href="#" class="read-toggle" data-expanded="true">read more</a>
+  </div></div>
+          </div>
+
+  </div>
+
+  </div>
+</div>
+
+</div>
+    <div class="views-row">
+
+<div  class="accc-collapsed-card contextual-region h-100">
+  <div class="accc-collapsed-card__header" id="heading-167970">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/swiss-re-qbe-insurances-trade-credit-and-surety-business">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  Swiss Re - QBE Insurance&#039;s Trade Credit and Surety business
+</h3>
+</div>
+      
+<div  class="accc-collapsed-card__header-info">
+        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline under-assessment clearfix">
+    <h3 class="field__label">Acquisition status</h3>
+              <div class="field__item">Under assessment</div>
+          </div>
+
+<div  class="accc-collapsed-card__header-content">
+      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
+<div class="field__item">Notification</div>
+</div>
+  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
+    <h3 class="field__label">Case number</h3>
+              <div class="field__item">MN-40015</div>
+          </div>
+  <div class="field field--name-field-acquisition-stage field--type-list-string field--label-inline clearfix">
+    <h3 class="field__label">Stage</h3>
+              <div class="field__item">Phase 1 - initial assessment</div>
+          </div>
+  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
+    <h3 class="field__label">Effective notification date</h3>
+              <div class="field__item"><time datetime="2026-04-10T12:00:00Z" class="datetime">10 Apr 2026</time>
+</div>
+          </div>
+
+  </div>
+
+  </div>
+</a>
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167970" href="#card-167970">
+      <span>expandable trigger</span>
+    </a>
+  </div>
+  <div id="card-167970" role="region" aria-labelledby="heading-167970" class="accc-collapsed-card__body collapse">
+    
+<div >
+    <h3 class="border-bottom">About the acquisition</h3>
+      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Acquirer(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631343">
+      <span class="field_acccgov_name">
+            Swiss Re International SE
+
+      </span>
+      <span>
+                      B134553
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Target(s) or Vendor(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631344">
+      <span class="field_acccgov_name">
+            QBE Insurance Holdings Pty Limited
+
+      </span>
+      <span>
+                        ABN -
+    69 146 960 438
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+  <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
+    <h3 class="field__label">ANZSIC code(s)</h3>
+          <div class="field__item">
+              6322  General Insurance              </div>
+      </div>
+  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
+    <h3 class="field__label">Description</h3>
+              <div class="field__item">
+<div class="read-more-wrapper">
+      <div class="summary-text">
+      <p>Swiss Re International SE (<strong>Swiss Re</strong>) proposes to acquire certain assets from QBE Insurance Holdings Pty Ltd (<strong>QBE</strong>) relating to its Credit &amp; Surety business (</p>
+    </div>
+    <div class="full-text" style="display:none;">
+    <p>Swiss Re International SE (<strong>Swiss Re</strong>) proposes to acquire certain assets from QBE Insurance Holdings Pty Ltd (<strong>QBE</strong>) relating to its Credit &amp; Surety business (<strong>QBE’s TC&amp;S Business</strong>), including data, employees and renewal rights (the <strong>Acquisition</strong>).&nbsp;</p>
+
+<p>Swiss Re provides insurance, reinsurance and risk transfer solutions to mid to large-sized corporate customers. In Australia, Swiss Re provides a range of property and casualty insurance products, including non-payment insurance for banks, surety bonds and claims management services.</p>
+
+<p class="ListBulletTable">QBE is an Australian-based provider of a broad range of insurance and reinsurance products to personal, business, corporate and institutional customers. QBE’s TC&amp;S Business provides:</p>
+
+<ul>
+<li class="ck-list-marker-font-size" data-list-item-id="e87bdd06c811d68d67b21ea7b39b8947f">
+<p class="ListBulletTable">non‑payment insurance (also known as trade finance insurance) which insures commercial banks and financial institutions against the risk of counterparties’ non‑payment of loans, guarantees or letters of credit.</p>
+</li>
+<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="e43985244079748f7a1e1801203017be1">
+<p class="ListBulletTable">trade credit insurance which insures corporate customers against the risk of non-payment of trade receivables arising from credit sales.</p>
+</li>
+<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="ed52e9e938beefe848f5a75022d28cd23">
+<p class="ListBulletTable">surety bonds which involve providing a financial guarantee that a party will fulfill a contractual, statutory, or financial obligation with the insurer committing to intervene if the insured party fails to do so.</p>
+</li>
+</ul>
+
+  </div>
+      <a href="#" class="read-toggle" data-expanded="true">read more</a>
+  </div></div>
+          </div>
+
+  </div>
+
+  </div>
+</div>
+
+</div>
+    <div class="views-row">
+
+<div  class="accc-collapsed-card contextual-region h-100">
   <div class="accc-collapsed-card__header" id="heading-167986">
   <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/dubai-aerospace-enterprise-macquarie-airfinance">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
   Dubai Aerospace Enterprise - Macquarie AirFinance
@@ -3106,9 +3378,9 @@
     <div class="views-row">
 
 <div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-167970">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/swiss-re-qbe-insurances-trade-credit-and-surety-business">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  Swiss Re - QBE Insurance&#039;s Trade Credit and Surety business
+  <div class="accc-collapsed-card__header" id="heading-167958">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/eli-lilly-orna-therapeutics">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  Eli Lilly / Orna Therapeutics
 </h3>
 </div>
       
@@ -3124,7 +3396,7 @@
 </div>
   <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
     <h3 class="field__label">Case number</h3>
-              <div class="field__item">MN-40015</div>
+              <div class="field__item">MN-20013</div>
           </div>
   <div class="field field--name-field-acquisition-stage field--type-list-string field--label-inline clearfix">
     <h3 class="field__label">Stage</h3>
@@ -3132,7 +3404,7 @@
           </div>
   <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
     <h3 class="field__label">Effective notification date</h3>
-              <div class="field__item"><time datetime="2026-04-10T12:00:00Z" class="datetime">10 Apr 2026</time>
+              <div class="field__item"><time datetime="2026-04-08T12:00:00Z" class="datetime">8 Apr 2026</time>
 </div>
           </div>
 
@@ -3140,24 +3412,24 @@
 
   </div>
 </a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167970" href="#card-167970">
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167958" href="#card-167958">
       <span>expandable trigger</span>
     </a>
   </div>
-  <div id="card-167970" role="region" aria-labelledby="heading-167970" class="accc-collapsed-card__body collapse">
+  <div id="card-167958" role="region" aria-labelledby="heading-167958" class="accc-collapsed-card__body collapse">
     
 <div >
     <h3 class="border-bottom">About the acquisition</h3>
       <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
   <h3 class="field__label">Acquirer(s)</h3>
       <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631343">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631305">
       <span class="field_acccgov_name">
-            Swiss Re International SE
+            Eli Lilly and Company
 
       </span>
       <span>
-                      B134553
+                      IRS Employer Identification Number - 35-0470950
 
               </span>
     </div>
@@ -3167,130 +3439,12 @@
 <div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
   <h3 class="field__label">Target(s) or Vendor(s)</h3>
       <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631344">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631308">
       <span class="field_acccgov_name">
-            QBE Insurance Holdings Pty Limited
+            Orna Therapeutics Holdings, LLC
 
       </span>
       <span>
-                        ABN -
-    69 146 960 438
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-  <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
-    <h3 class="field__label">ANZSIC code(s)</h3>
-          <div class="field__item">
-              6322  General Insurance              </div>
-      </div>
-  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
-    <h3 class="field__label">Description</h3>
-              <div class="field__item">
-<div class="read-more-wrapper">
-      <div class="summary-text">
-      <p>Swiss Re International SE (<strong>Swiss Re</strong>) proposes to acquire certain assets from QBE Insurance Holdings Pty Ltd (<strong>QBE</strong>) relating to its Credit &amp; Surety business (</p>
-    </div>
-    <div class="full-text" style="display:none;">
-    <p>Swiss Re International SE (<strong>Swiss Re</strong>) proposes to acquire certain assets from QBE Insurance Holdings Pty Ltd (<strong>QBE</strong>) relating to its Credit &amp; Surety business (<strong>QBE’s TC&amp;S Business</strong>), including data, employees and renewal rights (the <strong>Acquisition</strong>).&nbsp;</p>
-
-<p>Swiss Re provides insurance, reinsurance and risk transfer solutions to mid to large-sized corporate customers. In Australia, Swiss Re provides a range of property and casualty insurance products, including non-payment insurance for banks, surety bonds and claims management services.</p>
-
-<p class="ListBulletTable">QBE is an Australian-based provider of a broad range of insurance and reinsurance products to personal, business, corporate and institutional customers. QBE’s TC&amp;S Business provides:</p>
-
-<ul>
-<li class="ck-list-marker-font-size" data-list-item-id="e87bdd06c811d68d67b21ea7b39b8947f">
-<p class="ListBulletTable">non‑payment insurance (also known as trade finance insurance) which insures commercial banks and financial institutions against the risk of counterparties’ non‑payment of loans, guarantees or letters of credit.</p>
-</li>
-<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="e43985244079748f7a1e1801203017be1">
-<p class="ListBulletTable">trade credit insurance which insures corporate customers against the risk of non-payment of trade receivables arising from credit sales.</p>
-</li>
-<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="ed52e9e938beefe848f5a75022d28cd23">
-<p class="ListBulletTable">surety bonds which involve providing a financial guarantee that a party will fulfill a contractual, statutory, or financial obligation with the insurer committing to intervene if the insured party fails to do so.</p>
-</li>
-</ul>
-
-  </div>
-      <a href="#" class="read-toggle" data-expanded="true">read more</a>
-  </div></div>
-          </div>
-
-  </div>
-
-  </div>
-</div>
-
-</div>
-    <div class="views-row">
-
-<div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-168028">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/signant-actigraph">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  Signant - ActiGraph
-</h3>
-</div>
-      
-<div  class="accc-collapsed-card__header-info">
-        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
-    <h3 class="field__label">Acquisition status</h3>
-              <div class="field__item">Assessment completed</div>
-          </div>
-
-<div  class="accc-collapsed-card__header-content">
-      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
-<div class="field__item">Waiver</div>
-</div>
-  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
-    <h3 class="field__label">Case number</h3>
-              <div class="field__item">WA-45011</div>
-          </div>
-  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
-    <h3 class="field__label">Waiver application date</h3>
-              <div class="field__item"><time datetime="2026-04-10T12:00:00Z" class="datetime">10 Apr 2026</time>
-</div>
-          </div>
-
-  </div>
-
-  </div>
-</a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-168028" href="#card-168028">
-      <span>expandable trigger</span>
-    </a>
-  </div>
-  <div id="card-168028" role="region" aria-labelledby="heading-168028" class="accc-collapsed-card__body collapse">
-    
-<div >
-    <h3 class="border-bottom">About the acquisition</h3>
-      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Acquirer(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631438">
-      <span class="field_acccgov_name">
-            Signant Health Holding Corp.
-
-      </span>
-      <span>
-                      Delaware File Number - 5354678
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Target(s) or Vendor(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631444">
-      <span class="field_acccgov_name">
-            ActiGraph Holdings, LLC
-
-      </span>
-      <span>
-                      Delaware File Number - 7952013
-
               </span>
     </div>
   </li>
@@ -3299,47 +3453,21 @@
 <div class="field field--name-field-acccgov-other-parties field--type-entity-reference-revisions field--label-inline clearfix">
   <h3 class="field__label">Other party(ies)</h3>
       <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631440">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631306">
       <span class="field_acccgov_name">
-            ActiGraph India Private Limited
+            Shareholder Representative Services, LLC
 
       </span>
       <span>
-                      India CIN - U72900KA2023FTC169807
-
               </span>
     </div>
   </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631441">
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631307">
       <span class="field_acccgov_name">
-            Genstar BI Gen Holdings Cayman, L.P.
+            BLJX Acquisition, LLC
 
       </span>
       <span>
-                      Cayman Islands Reference Number - 1754174
-
-              </span>
-    </div>
-  </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631442">
-      <span class="field_acccgov_name">
-            ActiGraph, LLC
-
-      </span>
-      <span>
-                      EIN - 56-2443729
-
-              </span>
-    </div>
-  </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631443">
-      <span class="field_acccgov_name">
-            Buccaneer Holdco Limited
-
-      </span>
-      <span>
-                      UK Company Number - 11463144
-
               </span>
     </div>
   </li>
@@ -3348,21 +3476,21 @@
   <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
     <h3 class="field__label">ANZSIC code(s)</h3>
           <div class="field__item">
-              6240  Financial Asset Investing;           6925  Scientific Testing and Analysis Services              </div>
+              1841  Human Pharmaceutical and Medicinal Product Manufacturing;           6910  Scientific Research Services              </div>
       </div>
   <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
     <h3 class="field__label">Description</h3>
               <div class="field__item">
 <div class="read-more-wrapper">
       <div class="summary-text">
-      <p>Signant Health Holding Corp (<strong>Signant</strong>) proposes to acquire 100% of the shares in ActiGraph Holdings, LLC (together with its subsidiaries, <strong>ActiGraph</strong>).&nbsp;</p>
+      <p>Eli Lilly and Company (<strong>Eli Lilly</strong>) proposes to acquire 100% of the issued shares in Orna Therapeutics Holdings, LLC (<strong>Orna Therapeutics</strong>) (the <strong>Acquisition</strong></p>
     </div>
     <div class="full-text" style="display:none;">
-    <p>Signant Health Holding Corp (<strong>Signant</strong>) proposes to acquire 100% of the shares in ActiGraph Holdings, LLC (together with its subsidiaries, <strong>ActiGraph</strong>).&nbsp;</p>
+    <p>Eli Lilly and Company (<strong>Eli Lilly</strong>) proposes to acquire 100% of the issued shares in Orna Therapeutics Holdings, LLC (<strong>Orna Therapeutics</strong>) (the <strong>Acquisition</strong>).&nbsp;</p>
 
-<p>Signant is a US-based evidence generation company that provides services used in clinical trials. Signant does not have a physical presence in Australia but provides electronic clinical outcome assessments (<strong>eCOA</strong>), clinical trial randomisation and supply management (<strong>RTSM</strong>) services, and supplementary clinical trial professional services. Signant supplies these services to both contract research organisations (<strong>CROs</strong>) and directly to pharmaceutical and biotechnology companies.&nbsp;</p>
+<p>Eli Lilly is a US-based pharmaceutical company, which discovers, develops, manufactures and markets human pharmaceutical products for various therapeutic areas, including diabetes, oncology, immunology and neuroscience. Eli Lilly is headquartered in Indianapolis, US and is publicly listed on the New York Stock Exchange. Eli Lilly has an Australian subsidiary that registers and markets medicine in Australia.</p>
 
-<p>Ametris (formerly ActiGraph) is a US-based provider of digital health technology (<strong>DHT</strong>) for clinical trials, specialising in wearables – in particular, wrist-worn wearables and other sensors – which track biovitals and other digital endpoints for patients participating in clinical trials. Ametris does not have a physical presence in Australia but supplies its DHT products in Australia for non-commercial academic research.&nbsp;</p>
+<p>Orna Therapeutics is a US-based pre-clinical biotechnology company developing a new class of engineered circular RNA (oRNA) therapeutics and immune tropic lipid nanoparticles (LNP) delivery technologies for the treatment of autoimmune disorders, and cancer conditions. Orna Therapeutics has a pipeline consisting of two pre-clinical in vivo&nbsp;Chimeric Antigen Receptor T-cell (CAR-T) therapies, designed to treat B cell-driven autoimmune diseases.</p>
 
   </div>
       <a href="#" class="read-toggle" data-expanded="true">read more</a>
@@ -3506,33 +3634,29 @@
     <div class="views-row">
 
 <div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-167958">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/eli-lilly-orna-therapeutics">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  Eli Lilly / Orna Therapeutics
+  <div class="accc-collapsed-card__header" id="heading-168049">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/infosys-%E2%80%93-optimum-healthcare-it">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  Infosys – Optimum Healthcare IT
 </h3>
 </div>
       
 <div  class="accc-collapsed-card__header-info">
-        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline under-assessment clearfix">
+        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
     <h3 class="field__label">Acquisition status</h3>
-              <div class="field__item">Under assessment</div>
+              <div class="field__item">Assessment completed</div>
           </div>
 
 <div  class="accc-collapsed-card__header-content">
       <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
-<div class="field__item">Notification</div>
+<div class="field__item">Waiver</div>
 </div>
   <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
     <h3 class="field__label">Case number</h3>
-              <div class="field__item">MN-20013</div>
-          </div>
-  <div class="field field--name-field-acquisition-stage field--type-list-string field--label-inline clearfix">
-    <h3 class="field__label">Stage</h3>
-              <div class="field__item">Phase 1 - initial assessment</div>
+              <div class="field__item">WA-40014</div>
           </div>
   <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
-    <h3 class="field__label">Effective notification date</h3>
-              <div class="field__item"><time datetime="2026-04-08T12:00:00Z" class="datetime">8 Apr 2026</time>
+    <h3 class="field__label">Waiver application date</h3>
+              <div class="field__item"><time datetime="2026-04-07T12:00:00Z" class="datetime">7 Apr 2026</time>
 </div>
           </div>
 
@@ -3540,25 +3664,23 @@
 
   </div>
 </a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167958" href="#card-167958">
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-168049" href="#card-168049">
       <span>expandable trigger</span>
     </a>
   </div>
-  <div id="card-167958" role="region" aria-labelledby="heading-167958" class="accc-collapsed-card__body collapse">
+  <div id="card-168049" role="region" aria-labelledby="heading-168049" class="accc-collapsed-card__body collapse">
     
 <div >
     <h3 class="border-bottom">About the acquisition</h3>
       <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
   <h3 class="field__label">Acquirer(s)</h3>
       <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631305">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631509">
       <span class="field_acccgov_name">
-            Eli Lilly and Company
+            Infosys Nova Holdings LLC
 
       </span>
       <span>
-                      IRS Employer Identification Number - 35-0470950
-
               </span>
     </div>
   </li>
@@ -3567,12 +3689,24 @@
 <div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
   <h3 class="field__label">Target(s) or Vendor(s)</h3>
       <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631308">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631514">
       <span class="field_acccgov_name">
-            Orna Therapeutics Holdings, LLC
+            Optimum Achieve Holdings, Inc
 
       </span>
       <span>
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631515">
+      <span class="field_acccgov_name">
+            OPTIMUM HEALTHCARE IT PTY LTD
+
+      </span>
+      <span>
+                        ABN -
+    53 689 795 702
+
               </span>
     </div>
   </li>
@@ -3581,21 +3715,15 @@
 <div class="field field--name-field-acccgov-other-parties field--type-entity-reference-revisions field--label-inline clearfix">
   <h3 class="field__label">Other party(ies)</h3>
       <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631306">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631513">
       <span class="field_acccgov_name">
-            Shareholder Representative Services, LLC
+            INFOSYS TECHNOLOGIES LIMITED
 
       </span>
       <span>
-              </span>
-    </div>
-  </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631307">
-      <span class="field_acccgov_name">
-            BLJX Acquisition, LLC
+                        ABN -
+    52 090 591 209
 
-      </span>
-      <span>
               </span>
     </div>
   </li>
@@ -3604,21 +3732,23 @@
   <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
     <h3 class="field__label">ANZSIC code(s)</h3>
           <div class="field__item">
-              1841  Human Pharmaceutical and Medicinal Product Manufacturing;           6910  Scientific Research Services              </div>
+              7000  Computer System Design and Related Services              </div>
       </div>
   <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
     <h3 class="field__label">Description</h3>
               <div class="field__item">
 <div class="read-more-wrapper">
       <div class="summary-text">
-      <p>Eli Lilly and Company (<strong>Eli Lilly</strong>) proposes to acquire 100% of the issued shares in Orna Therapeutics Holdings, LLC (<strong>Orna Therapeutics</strong>) (the <strong>Acquisition</strong></p>
+      <p>Infosys Nova Holdings LLC proposes to acquire Optimum Achieve Holdings, Inc including Optimum’s subsidiary, Optimum Healthcare IT Pty Ltd.</p>
     </div>
     <div class="full-text" style="display:none;">
-    <p>Eli Lilly and Company (<strong>Eli Lilly</strong>) proposes to acquire 100% of the issued shares in Orna Therapeutics Holdings, LLC (<strong>Orna Therapeutics</strong>) (the <strong>Acquisition</strong>).&nbsp;</p>
+    <p>Infosys Nova Holdings LLC proposes to acquire Optimum Achieve Holdings, Inc including Optimum’s subsidiary, Optimum Healthcare IT Pty Ltd.</p>
 
-<p>Eli Lilly is a US-based pharmaceutical company, which discovers, develops, manufactures and markets human pharmaceutical products for various therapeutic areas, including diabetes, oncology, immunology and neuroscience. Eli Lilly is headquartered in Indianapolis, US and is publicly listed on the New York Stock Exchange. Eli Lilly has an Australian subsidiary that registers and markets medicine in Australia.</p>
+<p>Infosys Nova Holdings LLC is a wholly owned subsidiary of Infosys Limited (<strong>Infosys</strong>). Infosys is a global consulting and IT services company. Infosys provides a range of professional services across consulting, application development and maintenance, testing, business process management, cybersecurity, transformation, digital, cloud services, AI and automation, and data analytics. It is a leading provider of application sustainment, development and testing services. In Australia, Infosys provides services to Government and private sector organisations including in the financial services and telecommunications sectors.&nbsp;</p>
 
-<p>Orna Therapeutics is a US-based pre-clinical biotechnology company developing a new class of engineered circular RNA (oRNA) therapeutics and immune tropic lipid nanoparticles (LNP) delivery technologies for the treatment of autoimmune disorders, and cancer conditions. Orna Therapeutics has a pipeline consisting of two pre-clinical in vivo&nbsp;Chimeric Antigen Receptor T-cell (CAR-T) therapies, designed to treat B cell-driven autoimmune diseases.</p>
+<p>Infosys is a foreign company registered in its original jurisdiction of India. Infosys trades as Infosys Technologies Limited in Australia.</p>
+
+<p>Optimum Achieve Holdings, Inc is a digital transformation and consulting firm based in the US that specialises in providing services to the healthcare industry. Its broader suite of services includes digital transformation services, enterprise application services, managed services and application managed services, analytics and AI enablement, and cybersecurity and compliance.</p>
 
   </div>
       <a href="#" class="read-toggle" data-expanded="true">read more</a>
@@ -3634,32 +3764,28 @@
     <div class="views-row">
 
 <div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-167512">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/sembcorp-industries-ltd-alinta-energy">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  Sembcorp Industries Ltd - Alinta Energy
+  <div class="accc-collapsed-card__header" id="heading-168029">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/mizuho-%E2%80%93-avendus">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  Mizuho – Avendus
 </h3>
 </div>
       
 <div  class="accc-collapsed-card__header-info">
-        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline under-assessment clearfix">
+        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
     <h3 class="field__label">Acquisition status</h3>
-              <div class="field__item">Under assessment</div>
+              <div class="field__item">Assessment completed</div>
           </div>
 
 <div  class="accc-collapsed-card__header-content">
       <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
-<div class="field__item">Notification</div>
+<div class="field__item">Waiver</div>
 </div>
   <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
     <h3 class="field__label">Case number</h3>
-              <div class="field__item">MN-95001</div>
-          </div>
-  <div class="field field--name-field-acquisition-stage field--type-list-string field--label-inline clearfix">
-    <h3 class="field__label">Stage</h3>
-              <div class="field__item">Phase 1 - initial assessment</div>
+              <div class="field__item">WA-80009</div>
           </div>
   <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
-    <h3 class="field__label">Effective notification date</h3>
+    <h3 class="field__label">Waiver application date</h3>
               <div class="field__item"><time datetime="2026-04-07T12:00:00Z" class="datetime">7 Apr 2026</time>
 </div>
           </div>
@@ -3668,24 +3794,24 @@
 
   </div>
 </a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167512" href="#card-167512">
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-168029" href="#card-168029">
       <span>expandable trigger</span>
     </a>
   </div>
-  <div id="card-167512" role="region" aria-labelledby="heading-167512" class="accc-collapsed-card__body collapse">
+  <div id="card-168029" role="region" aria-labelledby="heading-168029" class="accc-collapsed-card__body collapse">
     
 <div >
     <h3 class="border-bottom">About the acquisition</h3>
       <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
   <h3 class="field__label">Acquirer(s)</h3>
       <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--630233">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631445">
       <span class="field_acccgov_name">
-            Sembcorp Industries Ltd
+            Mizuho Securities Co., Ltd.
 
       </span>
       <span>
-                      SG1R50925390 (Singapore ISIN Code)
+                      No. 94
 
               </span>
     </div>
@@ -3695,14 +3821,40 @@
 <div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
   <h3 class="field__label">Target(s) or Vendor(s)</h3>
       <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--630235">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631454">
       <span class="field_acccgov_name">
-            Pioneer Sail Holdings Pty Limited
+            Redpoint Investments Pte Ltd
 
       </span>
       <span>
-                        ABN -
-    45 617 844 569
+                      201536795E
+
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631455">
+      <span class="field_acccgov_name">
+            Avendus Capital Private Limited
+
+      </span>
+      <span>
+                      CIN U99999MH1999PTC123358
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-other-parties field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Other party(ies)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631453">
+      <span class="field_acccgov_name">
+            Spark Institutional Equities Private Limited
+
+      </span>
+      <span>
+                      CIN U65999TN2022PTC149473
 
               </span>
     </div>
@@ -3712,29 +3864,23 @@
   <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
     <h3 class="field__label">ANZSIC code(s)</h3>
           <div class="field__item">
-              26  Electricity Supply;           261  Electricity Generation;           2611  Fossil Fuel Electricity Generation;           2619  Other Electricity Generation;           2640  On Selling Electricity and Electricity Market Operation;           27  Gas Supply;           2700  Gas Supply              </div>
+              6419  Other Auxiliary Finance and Investment Services              </div>
       </div>
   <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
     <h3 class="field__label">Description</h3>
               <div class="field__item">
 <div class="read-more-wrapper">
       <div class="summary-text">
-      <p>Sembcorp Industries Ltd (<strong>Sembcorp</strong>) proposes to acquire, via share sale agreement, 100% of Pioneer Sail Holdings Pty Limited and its subsidiaries including Alinta Energy Ltd (</p>
+      <p>Mizuho Securities Co.</p>
     </div>
     <div class="full-text" style="display:none;">
-    <p>Sembcorp Industries Ltd (<strong>Sembcorp</strong>) proposes to acquire, via share sale agreement, 100% of Pioneer Sail Holdings Pty Limited and its subsidiaries including Alinta Energy Ltd (<strong>Alinta Energy</strong>) and Latrobe Valley Power (Holdings) Pty Ltd (<strong>Latrobe Valley Power</strong>), which operates the Loy Yang B coal-fired power station (together, the <strong>Target Group</strong>).</p>
+    <p>Mizuho Securities Co. Ltd (<strong>Mizuho</strong>) proposes to acquire an interest of between 61.60% and 78.30% in Avendus Capital Private Limited (<strong>Avendus</strong>) (the <strong>Acquisition</strong>).</p>
 
-<p>Sembcorp is an energy, renewable and industrial solutions company headquartered in Singapore with renewable energy and gas assets in the wider Asia region.&nbsp;Sembcorp does not own any operating assets in Australia, nor have any minority or controlling interests in any entities active in the energy sector in Australia.&nbsp;</p>
+<p>Mizuho is a subsidiary of Mizuho Financial Group, a full service Japanese financial services company. Mizuho through its connected entities, supplies financial services within Australia, including business banking, financial advisory and auto finance and car leasing.</p>
 
-<p>Alinta Energy is an Australian "gentailer" which supplies electricity and gas to customers across Australia.&nbsp;It has over 3.4GW of installed and contracted generation assets&nbsp;comprising coal, gas, onshore wind and solar and a development pipeline of up to 10.4GW of renewable energy projects.&nbsp;</p>
+<p>Avendus is an Indian investment bank and financial services firm that provides bespoke solutions in the areas of investment banking, institutional equities, wealth management, asset management and credit solutions. Founded in 1999, Avendus operates in India, the United States, Singapore and United Kingdom through its subsidiaries. It is a Securities and Exchange Board of India registered merchant banker.</p>
 
-<p>The Loy Yang B power station is a baseload brown coal fired power generator located 160km east of Melbourne which supplies electricity into the National Electricity Market. The Target Group also has joint venture interests in the Yandin Wind Farm and Spinifex Offshore Wind Project, which is currently in the planning and development phase.&nbsp;</p>
-
-<p>Temasek is the largest shareholder of Sembcorp. Temasek has interests in a variety of industries globally, including financial services, telecommunications, transportation, and real estate and is headquartered in Singapore.&nbsp;</p>
-
-<p>Temasek wholly-owns Singapore Power Group, an electricity and gas distribution company, which through its subsidiary Singapore Power International has an indirect interest in SGSP Australia Assets Pty Ltd (<strong>SGSPAA</strong>). SGSPAA owns Jemena, which is the owner and operator of gas distribution and transmission and electricity distribution network assets on the east coast of Australia and has interests in three electricity distribution networks located in New South Wales, Victoria and the Australian Capital Territory.&nbsp;</p>
-
-<p>Temasek also has an interest in Neoen SA (<strong>Neoen</strong>), a France-headquartered global developer, constructor, financier, and operator of renewable energy assets. Neoen owns and/or operates a number of wind, solar and energy storage projects in New South Wales, Queensland, South Australia, Tasmania, and Western Australia.</p>
+<p>Avendus has limited operations in Australia, supplying some research analyst and stock broking services via its wholly owned subsidiary, Spark Institutional Equities Private Limited.</p>
 
   </div>
       <a href="#" class="read-toggle" data-expanded="true">read more</a>
@@ -4013,28 +4159,32 @@
     <div class="views-row">
 
 <div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-168049">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/infosys-%E2%80%93-optimum-healthcare-it">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  Infosys – Optimum Healthcare IT
+  <div class="accc-collapsed-card__header" id="heading-167512">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/sembcorp-industries-ltd-alinta-energy">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  Sembcorp Industries Ltd - Alinta Energy
 </h3>
 </div>
       
 <div  class="accc-collapsed-card__header-info">
-        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
+        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline under-assessment clearfix">
     <h3 class="field__label">Acquisition status</h3>
-              <div class="field__item">Assessment completed</div>
+              <div class="field__item">Under assessment</div>
           </div>
 
 <div  class="accc-collapsed-card__header-content">
       <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
-<div class="field__item">Waiver</div>
+<div class="field__item">Notification</div>
 </div>
   <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
     <h3 class="field__label">Case number</h3>
-              <div class="field__item">WA-40014</div>
+              <div class="field__item">MN-95001</div>
+          </div>
+  <div class="field field--name-field-acquisition-stage field--type-list-string field--label-inline clearfix">
+    <h3 class="field__label">Stage</h3>
+              <div class="field__item">Phase 1 - initial assessment</div>
           </div>
   <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
-    <h3 class="field__label">Waiver application date</h3>
+    <h3 class="field__label">Effective notification date</h3>
               <div class="field__item"><time datetime="2026-04-07T12:00:00Z" class="datetime">7 Apr 2026</time>
 </div>
           </div>
@@ -4043,154 +4193,24 @@
 
   </div>
 </a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-168049" href="#card-168049">
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167512" href="#card-167512">
       <span>expandable trigger</span>
     </a>
   </div>
-  <div id="card-168049" role="region" aria-labelledby="heading-168049" class="accc-collapsed-card__body collapse">
+  <div id="card-167512" role="region" aria-labelledby="heading-167512" class="accc-collapsed-card__body collapse">
     
 <div >
     <h3 class="border-bottom">About the acquisition</h3>
       <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
   <h3 class="field__label">Acquirer(s)</h3>
       <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631509">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--630233">
       <span class="field_acccgov_name">
-            Infosys Nova Holdings LLC
+            Sembcorp Industries Ltd
 
       </span>
       <span>
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Target(s) or Vendor(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631514">
-      <span class="field_acccgov_name">
-            Optimum Achieve Holdings, Inc
-
-      </span>
-      <span>
-              </span>
-    </div>
-  </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631515">
-      <span class="field_acccgov_name">
-            OPTIMUM HEALTHCARE IT PTY LTD
-
-      </span>
-      <span>
-                        ABN -
-    53 689 795 702
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-other-parties field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Other party(ies)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631513">
-      <span class="field_acccgov_name">
-            INFOSYS TECHNOLOGIES LIMITED
-
-      </span>
-      <span>
-                        ABN -
-    52 090 591 209
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-  <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
-    <h3 class="field__label">ANZSIC code(s)</h3>
-          <div class="field__item">
-              7000  Computer System Design and Related Services              </div>
-      </div>
-  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
-    <h3 class="field__label">Description</h3>
-              <div class="field__item">
-<div class="read-more-wrapper">
-      <div class="summary-text">
-      <p>Infosys Nova Holdings LLC proposes to acquire Optimum Achieve Holdings, Inc including Optimum’s subsidiary, Optimum Healthcare IT Pty Ltd.</p>
-    </div>
-    <div class="full-text" style="display:none;">
-    <p>Infosys Nova Holdings LLC proposes to acquire Optimum Achieve Holdings, Inc including Optimum’s subsidiary, Optimum Healthcare IT Pty Ltd.</p>
-
-<p>Infosys Nova Holdings LLC is a wholly owned subsidiary of Infosys Limited (<strong>Infosys</strong>). Infosys is a global consulting and IT services company. Infosys provides a range of professional services across consulting, application development and maintenance, testing, business process management, cybersecurity, transformation, digital, cloud services, AI and automation, and data analytics. It is a leading provider of application sustainment, development and testing services. In Australia, Infosys provides services to Government and private sector organisations including in the financial services and telecommunications sectors.&nbsp;</p>
-
-<p>Infosys is a foreign company registered in its original jurisdiction of India. Infosys trades as Infosys Technologies Limited in Australia.</p>
-
-<p>Optimum Achieve Holdings, Inc is a digital transformation and consulting firm based in the US that specialises in providing services to the healthcare industry. Its broader suite of services includes digital transformation services, enterprise application services, managed services and application managed services, analytics and AI enablement, and cybersecurity and compliance.</p>
-
-  </div>
-      <a href="#" class="read-toggle" data-expanded="true">read more</a>
-  </div></div>
-          </div>
-
-  </div>
-
-  </div>
-</div>
-
-</div>
-    <div class="views-row">
-
-<div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-168029">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/mizuho-%E2%80%93-avendus">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  Mizuho – Avendus
-</h3>
-</div>
-      
-<div  class="accc-collapsed-card__header-info">
-        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
-    <h3 class="field__label">Acquisition status</h3>
-              <div class="field__item">Assessment completed</div>
-          </div>
-
-<div  class="accc-collapsed-card__header-content">
-      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
-<div class="field__item">Waiver</div>
-</div>
-  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
-    <h3 class="field__label">Case number</h3>
-              <div class="field__item">WA-80009</div>
-          </div>
-  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
-    <h3 class="field__label">Waiver application date</h3>
-              <div class="field__item"><time datetime="2026-04-07T12:00:00Z" class="datetime">7 Apr 2026</time>
-</div>
-          </div>
-
-  </div>
-
-  </div>
-</a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-168029" href="#card-168029">
-      <span>expandable trigger</span>
-    </a>
-  </div>
-  <div id="card-168029" role="region" aria-labelledby="heading-168029" class="accc-collapsed-card__body collapse">
-    
-<div >
-    <h3 class="border-bottom">About the acquisition</h3>
-      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Acquirer(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631445">
-      <span class="field_acccgov_name">
-            Mizuho Securities Co., Ltd.
-
-      </span>
-      <span>
-                      No. 94
+                      SG1R50925390 (Singapore ISIN Code)
 
               </span>
     </div>
@@ -4200,40 +4220,14 @@
 <div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
   <h3 class="field__label">Target(s) or Vendor(s)</h3>
       <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631454">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--630235">
       <span class="field_acccgov_name">
-            Redpoint Investments Pte Ltd
+            Pioneer Sail Holdings Pty Limited
 
       </span>
       <span>
-                      201536795E
-
-              </span>
-    </div>
-  </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631455">
-      <span class="field_acccgov_name">
-            Avendus Capital Private Limited
-
-      </span>
-      <span>
-                      CIN U99999MH1999PTC123358
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-other-parties field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Other party(ies)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631453">
-      <span class="field_acccgov_name">
-            Spark Institutional Equities Private Limited
-
-      </span>
-      <span>
-                      CIN U65999TN2022PTC149473
+                        ABN -
+    45 617 844 569
 
               </span>
     </div>
@@ -4243,23 +4237,29 @@
   <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
     <h3 class="field__label">ANZSIC code(s)</h3>
           <div class="field__item">
-              6419  Other Auxiliary Finance and Investment Services              </div>
+              26  Electricity Supply;           261  Electricity Generation;           2611  Fossil Fuel Electricity Generation;           2619  Other Electricity Generation;           2640  On Selling Electricity and Electricity Market Operation;           27  Gas Supply;           2700  Gas Supply              </div>
       </div>
   <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
     <h3 class="field__label">Description</h3>
               <div class="field__item">
 <div class="read-more-wrapper">
       <div class="summary-text">
-      <p>Mizuho Securities Co.</p>
+      <p>Sembcorp Industries Ltd (<strong>Sembcorp</strong>) proposes to acquire, via share sale agreement, 100% of Pioneer Sail Holdings Pty Limited and its subsidiaries including Alinta Energy Ltd (</p>
     </div>
     <div class="full-text" style="display:none;">
-    <p>Mizuho Securities Co. Ltd (<strong>Mizuho</strong>) proposes to acquire an interest of between 61.60% and 78.30% in Avendus Capital Private Limited (<strong>Avendus</strong>) (the <strong>Acquisition</strong>).</p>
+    <p>Sembcorp Industries Ltd (<strong>Sembcorp</strong>) proposes to acquire, via share sale agreement, 100% of Pioneer Sail Holdings Pty Limited and its subsidiaries including Alinta Energy Ltd (<strong>Alinta Energy</strong>) and Latrobe Valley Power (Holdings) Pty Ltd (<strong>Latrobe Valley Power</strong>), which operates the Loy Yang B coal-fired power station (together, the <strong>Target Group</strong>).</p>
 
-<p>Mizuho is a subsidiary of Mizuho Financial Group, a full service Japanese financial services company. Mizuho through its connected entities, supplies financial services within Australia, including business banking, financial advisory and auto finance and car leasing.</p>
+<p>Sembcorp is an energy, renewable and industrial solutions company headquartered in Singapore with renewable energy and gas assets in the wider Asia region.&nbsp;Sembcorp does not own any operating assets in Australia, nor have any minority or controlling interests in any entities active in the energy sector in Australia.&nbsp;</p>
 
-<p>Avendus is an Indian investment bank and financial services firm that provides bespoke solutions in the areas of investment banking, institutional equities, wealth management, asset management and credit solutions. Founded in 1999, Avendus operates in India, the United States, Singapore and United Kingdom through its subsidiaries. It is a Securities and Exchange Board of India registered merchant banker.</p>
+<p>Alinta Energy is an Australian "gentailer" which supplies electricity and gas to customers across Australia.&nbsp;It has over 3.4GW of installed and contracted generation assets&nbsp;comprising coal, gas, onshore wind and solar and a development pipeline of up to 10.4GW of renewable energy projects.&nbsp;</p>
 
-<p>Avendus has limited operations in Australia, supplying some research analyst and stock broking services via its wholly owned subsidiary, Spark Institutional Equities Private Limited.</p>
+<p>The Loy Yang B power station is a baseload brown coal fired power generator located 160km east of Melbourne which supplies electricity into the National Electricity Market. The Target Group also has joint venture interests in the Yandin Wind Farm and Spinifex Offshore Wind Project, which is currently in the planning and development phase.&nbsp;</p>
+
+<p>Temasek is the largest shareholder of Sembcorp. Temasek has interests in a variety of industries globally, including financial services, telecommunications, transportation, and real estate and is headquartered in Singapore.&nbsp;</p>
+
+<p>Temasek wholly-owns Singapore Power Group, an electricity and gas distribution company, which through its subsidiary Singapore Power International has an indirect interest in SGSP Australia Assets Pty Ltd (<strong>SGSPAA</strong>). SGSPAA owns Jemena, which is the owner and operator of gas distribution and transmission and electricity distribution network assets on the east coast of Australia and has interests in three electricity distribution networks located in New South Wales, Victoria and the Australian Capital Territory.&nbsp;</p>
+
+<p>Temasek also has an interest in Neoen SA (<strong>Neoen</strong>), a France-headquartered global developer, constructor, financier, and operator of renewable energy assets. Neoen owns and/or operates a number of wind, solar and energy storage projects in New South Wales, Queensland, South Australia, Tasmania, and Western Australia.</p>
 
   </div>
       <a href="#" class="read-toggle" data-expanded="true">read more</a>
@@ -4439,222 +4439,6 @@
     <div class="views-row">
 
 <div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-167927">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/danaher-masimo">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  Danaher - Masimo
-</h3>
-</div>
-      
-<div  class="accc-collapsed-card__header-info">
-        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline under-assessment clearfix">
-    <h3 class="field__label">Acquisition status</h3>
-              <div class="field__item">Under assessment</div>
-          </div>
-
-<div  class="accc-collapsed-card__header-content">
-      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
-<div class="field__item">Notification</div>
-</div>
-  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
-    <h3 class="field__label">Case number</h3>
-              <div class="field__item">MN-15011</div>
-          </div>
-  <div class="field field--name-field-acquisition-stage field--type-list-string field--label-inline clearfix">
-    <h3 class="field__label">Stage</h3>
-              <div class="field__item">Phase 1 - initial assessment</div>
-          </div>
-  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
-    <h3 class="field__label">Effective notification date</h3>
-              <div class="field__item"><time datetime="2026-04-02T12:00:00Z" class="datetime">2 Apr 2026</time>
-</div>
-          </div>
-
-  </div>
-
-  </div>
-</a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167927" href="#card-167927">
-      <span>expandable trigger</span>
-    </a>
-  </div>
-  <div id="card-167927" role="region" aria-labelledby="heading-167927" class="accc-collapsed-card__body collapse">
-    
-<div >
-    <h3 class="border-bottom">About the acquisition</h3>
-      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Acquirer(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631152">
-      <span class="field_acccgov_name">
-            Danaher Corporation
-
-      </span>
-      <span>
-                      213594
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Target(s) or Vendor(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631154">
-      <span class="field_acccgov_name">
-            Masimo Corporation
-
-      </span>
-      <span>
-                      2614702
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-  <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
-    <h3 class="field__label">ANZSIC code(s)</h3>
-          <div class="field__item">
-              2412  Medical and Surgical Equipment Manufacturing;           2419  Other Professional and Scientific Equipment Manufacturing;           3491  Professional and Scientific Goods Wholesaling;           6910  Scientific Research Services              </div>
-      </div>
-  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
-    <h3 class="field__label">Description</h3>
-              <div class="field__item">
-<div class="read-more-wrapper">
-      <div class="summary-text">
-      <p class="Default">Danaher Corporation (<strong>Danaher</strong>) proposes to acquire 100% of the outstanding share capital of Masimo Corporation (<strong>Masimo</strong>).</p>
-    </div>
-    <div class="full-text" style="display:none;">
-    <p class="Default">Danaher Corporation (<strong>Danaher</strong>) proposes to acquire 100% of the outstanding share capital of Masimo Corporation (<strong>Masimo</strong>).</p>
-
-<p class="Default">Danaher is a global science and technology company. Danaher designs, manufactures and markets professional, medical, industrial and commercial products and services under three core segments: biotechnology, life sciences, and diagnostics.</p>
-
-<p>Masimo is a global medical technology company. Masimo is a provider of pulse oximetry and other patient sensors and monitoring solutions.</p>
-
-  </div>
-      <a href="#" class="read-toggle" data-expanded="true">read more</a>
-  </div></div>
-          </div>
-
-  </div>
-
-  </div>
-</div>
-
-</div>
-    <div class="views-row">
-
-<div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-167990">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/yancoal-kestrel-coal-group">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  Yancoal - Kestrel Coal Group
-</h3>
-</div>
-      
-<div  class="accc-collapsed-card__header-info">
-        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
-    <h3 class="field__label">Acquisition status</h3>
-              <div class="field__item">Assessment completed</div>
-          </div>
-
-<div  class="accc-collapsed-card__header-content">
-      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
-<div class="field__item">Waiver</div>
-</div>
-  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
-    <h3 class="field__label">Case number</h3>
-              <div class="field__item">WA-85021</div>
-          </div>
-  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
-    <h3 class="field__label">Waiver application date</h3>
-              <div class="field__item"><time datetime="2026-04-02T12:00:00Z" class="datetime">2 Apr 2026</time>
-</div>
-          </div>
-
-  </div>
-
-  </div>
-</a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167990" href="#card-167990">
-      <span>expandable trigger</span>
-    </a>
-  </div>
-  <div id="card-167990" role="region" aria-labelledby="heading-167990" class="accc-collapsed-card__body collapse">
-    
-<div >
-    <h3 class="border-bottom">About the acquisition</h3>
-      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Acquirer(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631380">
-      <span class="field_acccgov_name">
-            YANCOAL AUSTRALIA LTD
-
-      </span>
-      <span>
-                        ABN -
-    82 111 859 119
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Target(s) or Vendor(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631382">
-      <span class="field_acccgov_name">
-            KESTREL COAL GROUP PTY LTD
-
-      </span>
-      <span>
-                        ABN -
-    70 624 655 518
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-  <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
-    <h3 class="field__label">ANZSIC code(s)</h3>
-          <div class="field__item">
-              2110  Iron Smelting and Steel Manufacturing;           2611  Fossil Fuel Electricity Generation              </div>
-      </div>
-  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
-    <h3 class="field__label">Description</h3>
-              <div class="field__item">
-<div class="read-more-wrapper">
-      <div class="summary-text">
-      <p>Yancoal Australia Limited (<strong>Yancoal</strong>) proposes to acquire 100% of the shares in Kestrel Coal Group Pty Ltd (<strong>Kestrel Coal Group</strong>) from investment funds and/or their in</p>
-    </div>
-    <div class="full-text" style="display:none;">
-    <p>Yancoal Australia Limited (<strong>Yancoal</strong>) proposes to acquire 100% of the shares in Kestrel Coal Group Pty Ltd (<strong>Kestrel Coal Group</strong>) from investment funds and/or their investors which are managed by EMR Capital Management Limited or EMR Capital Advisors Pty Ltd and Adaro Capital Limited (the <b>Acquisition</b>).&nbsp;</p>
-
-<p>Kestrel Coal Group holds an 80% interest in the Kestrel Joint Venture, an unincorporated joint venture which owns and operates the Kestrel Coal Mine in Queensland. The remaining 20% of the Kestrel Coal Joint Venture is held by Mitsui Kestrel Coal Investment Pty Ltd.&nbsp;</p>
-
-<p>Kestrel Coal Group was formed to hold the 80% interest in the Kestrel Coal Joint Venture and does not itself supply goods or services. The Acquisition will result in Yancoal holding an 80% interest in the Kestrel Coal Mine.&nbsp;</p>
-
-<p>Yancoal produces thermal coal from mines located in New South Wales, Queensland, and Western Australia. It also produces a smaller volume of metallurgical coal.</p>
-
-<p>The Kestrel Coal Mine is located in Queensland’s Bowen Basin and produces metallurgical coal, in addition to a smaller volume of thermal coal.&nbsp;</p>
-
-  </div>
-      <a href="#" class="read-toggle" data-expanded="true">read more</a>
-  </div></div>
-          </div>
-
-  </div>
-
-  </div>
-</div>
-
-</div>
-    <div class="views-row">
-
-<div  class="accc-collapsed-card contextual-region h-100">
   <div class="accc-collapsed-card__header" id="heading-168056">
   <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/prime-super-additional-interest-in-peninsula-link-project">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
   Prime Super - Additional interest in Peninsula Link Project
@@ -4783,6 +4567,222 @@
 <p>Prime Super is a multi-industry fully independent profit-to-members superannuation fund with approximately $8.4 billion in funds under management and 140,000 members.&nbsp;</p>
 
 <p>The target, Southern Way Holdings, is responsible for the delivery and maintenance of the Peninsula Link Project. The Peninsula Link Project is a Public Private Partnership to design, construct, maintain and operate the 27km Peninsula Link Freeway between Frankston and Mount Martha in Victoria, Australia. Southern Way Holdings is responsible for the maintenance and availability of Peninsula Link.&nbsp;</p>
+
+  </div>
+      <a href="#" class="read-toggle" data-expanded="true">read more</a>
+  </div></div>
+          </div>
+
+  </div>
+
+  </div>
+</div>
+
+</div>
+    <div class="views-row">
+
+<div  class="accc-collapsed-card contextual-region h-100">
+  <div class="accc-collapsed-card__header" id="heading-167990">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/yancoal-kestrel-coal-group">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  Yancoal - Kestrel Coal Group
+</h3>
+</div>
+      
+<div  class="accc-collapsed-card__header-info">
+        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
+    <h3 class="field__label">Acquisition status</h3>
+              <div class="field__item">Assessment completed</div>
+          </div>
+
+<div  class="accc-collapsed-card__header-content">
+      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
+<div class="field__item">Waiver</div>
+</div>
+  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
+    <h3 class="field__label">Case number</h3>
+              <div class="field__item">WA-85021</div>
+          </div>
+  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
+    <h3 class="field__label">Waiver application date</h3>
+              <div class="field__item"><time datetime="2026-04-02T12:00:00Z" class="datetime">2 Apr 2026</time>
+</div>
+          </div>
+
+  </div>
+
+  </div>
+</a>
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167990" href="#card-167990">
+      <span>expandable trigger</span>
+    </a>
+  </div>
+  <div id="card-167990" role="region" aria-labelledby="heading-167990" class="accc-collapsed-card__body collapse">
+    
+<div >
+    <h3 class="border-bottom">About the acquisition</h3>
+      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Acquirer(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631380">
+      <span class="field_acccgov_name">
+            YANCOAL AUSTRALIA LTD
+
+      </span>
+      <span>
+                        ABN -
+    82 111 859 119
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Target(s) or Vendor(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631382">
+      <span class="field_acccgov_name">
+            KESTREL COAL GROUP PTY LTD
+
+      </span>
+      <span>
+                        ABN -
+    70 624 655 518
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+  <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
+    <h3 class="field__label">ANZSIC code(s)</h3>
+          <div class="field__item">
+              2110  Iron Smelting and Steel Manufacturing;           2611  Fossil Fuel Electricity Generation              </div>
+      </div>
+  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
+    <h3 class="field__label">Description</h3>
+              <div class="field__item">
+<div class="read-more-wrapper">
+      <div class="summary-text">
+      <p>Yancoal Australia Limited (<strong>Yancoal</strong>) proposes to acquire 100% of the shares in Kestrel Coal Group Pty Ltd (<strong>Kestrel Coal Group</strong>) from investment funds and/or their in</p>
+    </div>
+    <div class="full-text" style="display:none;">
+    <p>Yancoal Australia Limited (<strong>Yancoal</strong>) proposes to acquire 100% of the shares in Kestrel Coal Group Pty Ltd (<strong>Kestrel Coal Group</strong>) from investment funds and/or their investors which are managed by EMR Capital Management Limited or EMR Capital Advisors Pty Ltd and Adaro Capital Limited (the <b>Acquisition</b>).&nbsp;</p>
+
+<p>Kestrel Coal Group holds an 80% interest in the Kestrel Joint Venture, an unincorporated joint venture which owns and operates the Kestrel Coal Mine in Queensland. The remaining 20% of the Kestrel Coal Joint Venture is held by Mitsui Kestrel Coal Investment Pty Ltd.&nbsp;</p>
+
+<p>Kestrel Coal Group was formed to hold the 80% interest in the Kestrel Coal Joint Venture and does not itself supply goods or services. The Acquisition will result in Yancoal holding an 80% interest in the Kestrel Coal Mine.&nbsp;</p>
+
+<p>Yancoal produces thermal coal from mines located in New South Wales, Queensland, and Western Australia. It also produces a smaller volume of metallurgical coal.</p>
+
+<p>The Kestrel Coal Mine is located in Queensland’s Bowen Basin and produces metallurgical coal, in addition to a smaller volume of thermal coal.&nbsp;</p>
+
+  </div>
+      <a href="#" class="read-toggle" data-expanded="true">read more</a>
+  </div></div>
+          </div>
+
+  </div>
+
+  </div>
+</div>
+
+</div>
+    <div class="views-row">
+
+<div  class="accc-collapsed-card contextual-region h-100">
+  <div class="accc-collapsed-card__header" id="heading-167927">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/danaher-masimo">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  Danaher - Masimo
+</h3>
+</div>
+      
+<div  class="accc-collapsed-card__header-info">
+        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline under-assessment clearfix">
+    <h3 class="field__label">Acquisition status</h3>
+              <div class="field__item">Under assessment</div>
+          </div>
+
+<div  class="accc-collapsed-card__header-content">
+      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
+<div class="field__item">Notification</div>
+</div>
+  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
+    <h3 class="field__label">Case number</h3>
+              <div class="field__item">MN-15011</div>
+          </div>
+  <div class="field field--name-field-acquisition-stage field--type-list-string field--label-inline clearfix">
+    <h3 class="field__label">Stage</h3>
+              <div class="field__item">Phase 1 - initial assessment</div>
+          </div>
+  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
+    <h3 class="field__label">Effective notification date</h3>
+              <div class="field__item"><time datetime="2026-04-02T12:00:00Z" class="datetime">2 Apr 2026</time>
+</div>
+          </div>
+
+  </div>
+
+  </div>
+</a>
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167927" href="#card-167927">
+      <span>expandable trigger</span>
+    </a>
+  </div>
+  <div id="card-167927" role="region" aria-labelledby="heading-167927" class="accc-collapsed-card__body collapse">
+    
+<div >
+    <h3 class="border-bottom">About the acquisition</h3>
+      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Acquirer(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631152">
+      <span class="field_acccgov_name">
+            Danaher Corporation
+
+      </span>
+      <span>
+                      213594
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Target(s) or Vendor(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631154">
+      <span class="field_acccgov_name">
+            Masimo Corporation
+
+      </span>
+      <span>
+                      2614702
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+  <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
+    <h3 class="field__label">ANZSIC code(s)</h3>
+          <div class="field__item">
+              2412  Medical and Surgical Equipment Manufacturing;           2419  Other Professional and Scientific Equipment Manufacturing;           3491  Professional and Scientific Goods Wholesaling;           6910  Scientific Research Services              </div>
+      </div>
+  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
+    <h3 class="field__label">Description</h3>
+              <div class="field__item">
+<div class="read-more-wrapper">
+      <div class="summary-text">
+      <p class="Default">Danaher Corporation (<strong>Danaher</strong>) proposes to acquire 100% of the outstanding share capital of Masimo Corporation (<strong>Masimo</strong>).</p>
+    </div>
+    <div class="full-text" style="display:none;">
+    <p class="Default">Danaher Corporation (<strong>Danaher</strong>) proposes to acquire 100% of the outstanding share capital of Masimo Corporation (<strong>Masimo</strong>).</p>
+
+<p class="Default">Danaher is a global science and technology company. Danaher designs, manufactures and markets professional, medical, industrial and commercial products and services under three core segments: biotechnology, life sciences, and diagnostics.</p>
+
+<p>Masimo is a global medical technology company. Masimo is a provider of pulse oximetry and other patient sensors and monitoring solutions.</p>
 
   </div>
       <a href="#" class="read-toggle" data-expanded="true">read more</a>
@@ -5006,119 +5006,6 @@
 <p>EPAP is a wholly owned subsidiary of Egis S.A., a France-based engineering, consulting and operation services company. Neither EPAP nor any of its connected entities are involved in the supply of operations, maintenance, and facilities management services for roads and tunnels in Australia, other than through FHE. In Australia, other subsidiaries of Egis S.A. provide façade design and engineering services, building sustainability services, multi-disciplinary engineering consulting services (including rail signalling, rail systems, electrical, transmission/distribution, urban development, water, roads, environmental, and civil), architecture services, and enterprise asset management solutions.&nbsp;</p>
 
 <p>Fulton Hogan Industries provides services in pavement, asphalting, civil construction, and road and asset maintenance across Australia in sectors including defence, roads, and airports.&nbsp;</p>
-
-  </div>
-      <a href="#" class="read-toggle" data-expanded="true">read more</a>
-  </div></div>
-          </div>
-
-  </div>
-
-  </div>
-</div>
-
-</div>
-    <div class="views-row">
-
-<div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-167901">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/eagers-vic-audi-melbourne-and-audi-richmond">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  Eagers Vic - Audi Melbourne and Audi Richmond
-</h3>
-</div>
-      
-<div  class="accc-collapsed-card__header-info">
-        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline under-assessment clearfix">
-    <h3 class="field__label">Acquisition status</h3>
-              <div class="field__item">Under assessment</div>
-          </div>
-
-<div  class="accc-collapsed-card__header-content">
-      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
-<div class="field__item">Notification</div>
-</div>
-  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
-    <h3 class="field__label">Case number</h3>
-              <div class="field__item">MN-05012</div>
-          </div>
-  <div class="field field--name-field-acquisition-stage field--type-list-string field--label-inline clearfix">
-    <h3 class="field__label">Stage</h3>
-              <div class="field__item">Phase 1 - initial assessment</div>
-          </div>
-  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
-    <h3 class="field__label">Effective notification date</h3>
-              <div class="field__item"><time datetime="2026-03-31T12:00:00Z" class="datetime">31 Mar 2026</time>
-</div>
-          </div>
-
-  </div>
-
-  </div>
-</a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167901" href="#card-167901">
-      <span>expandable trigger</span>
-    </a>
-  </div>
-  <div id="card-167901" role="region" aria-labelledby="heading-167901" class="accc-collapsed-card__body collapse">
-    
-<div >
-    <h3 class="border-bottom">About the acquisition</h3>
-      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Acquirer(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631107">
-      <span class="field_acccgov_name">
-            EAGERS VIC PTY LTD
-
-      </span>
-      <span>
-                        ABN -
-    29 616 989 596
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Target(s) or Vendor(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631108">
-      <span class="field_acccgov_name">
-            Zagame Automotive Group Pty Ltd
-
-      </span>
-      <span>
-                        ABN -
-    85 085 950 063
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-  <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
-    <h3 class="field__label">ANZSIC code(s)</h3>
-          <div class="field__item">
-              3911  Car Retailing;           3921  Motor Vehicle Parts Retailing              </div>
-      </div>
-  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
-    <h3 class="field__label">Description</h3>
-              <div class="field__item">
-<div class="read-more-wrapper">
-      <div class="summary-text">
-      <p>Eagers Vic Pty Ltd (<strong>Eagers</strong>) is a subsidiary of Eagers Automotive Limited (ASX: APE), a publicly listed automotive retail group which owns and operates motor vehicle dealerships acr</p>
-    </div>
-    <div class="full-text" style="display:none;">
-    <p>Eagers Vic Pty Ltd (<strong>Eagers</strong>) is a subsidiary of Eagers Automotive Limited (ASX: APE), a publicly listed automotive retail group which owns and operates motor vehicle dealerships across Australia. Eagers Automotive Limited sells new and used motor vehicles through its dealerships, representing around 50 automotive brands. Eagers also provides related goods and services including motor vehicle service, parts and allied consumer finance. Eagers operates 12 dealerships in the Melbourne area, including in Toorak (Mercedes-Benz), Malvern (ULR Jaguar and ULR Land Rover) and Port Melbourne (Jaguar, Volvo, Volkswagen and Land Rover). Eagers does not currently have any Audi dealerships in Victoria.</p>
-
-<p>Zagame Automotive Group Pty Ltd (<strong>Zagame</strong>) operates motor vehicle dealerships (franchises and agencies), selling new and used motor vehicles, focusing on sports, luxury and performance vehicles. It represents 16 automotive brands with dealerships across the Melbourne area (including five Audi dealerships). Zagame also operates related businesses including automotive repairs, wholesale automotive parts, and retail automotive finance.&nbsp;</p>
-
-<p>Eagers proposes to acquire the assets for the following Audi dealerships from Zagame:&nbsp;</p>
-
-<p>Audi Centre Melbourne, 501 Swanston St, Melbourne 3000 (<strong>Audi Melbourne</strong>); and&nbsp;</p>
-
-<p>Audi Richmond, 408 – 410 Swan Street, Richmond 3121 (<strong>Audi Richmond</strong>).&nbsp;</p>
 
   </div>
       <a href="#" class="read-toggle" data-expanded="true">read more</a>
@@ -5507,6 +5394,228 @@
     <div class="views-row">
 
 <div  class="accc-collapsed-card contextual-region h-100">
+  <div class="accc-collapsed-card__header" id="heading-167901">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/eagers-vic-audi-melbourne-and-audi-richmond">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  Eagers Vic - Audi Melbourne and Audi Richmond
+</h3>
+</div>
+      
+<div  class="accc-collapsed-card__header-info">
+        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline under-assessment clearfix">
+    <h3 class="field__label">Acquisition status</h3>
+              <div class="field__item">Under assessment</div>
+          </div>
+
+<div  class="accc-collapsed-card__header-content">
+      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
+<div class="field__item">Notification</div>
+</div>
+  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
+    <h3 class="field__label">Case number</h3>
+              <div class="field__item">MN-05012</div>
+          </div>
+  <div class="field field--name-field-acquisition-stage field--type-list-string field--label-inline clearfix">
+    <h3 class="field__label">Stage</h3>
+              <div class="field__item">Phase 1 - initial assessment</div>
+          </div>
+  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
+    <h3 class="field__label">Effective notification date</h3>
+              <div class="field__item"><time datetime="2026-03-31T12:00:00Z" class="datetime">31 Mar 2026</time>
+</div>
+          </div>
+
+  </div>
+
+  </div>
+</a>
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167901" href="#card-167901">
+      <span>expandable trigger</span>
+    </a>
+  </div>
+  <div id="card-167901" role="region" aria-labelledby="heading-167901" class="accc-collapsed-card__body collapse">
+    
+<div >
+    <h3 class="border-bottom">About the acquisition</h3>
+      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Acquirer(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631107">
+      <span class="field_acccgov_name">
+            EAGERS VIC PTY LTD
+
+      </span>
+      <span>
+                        ABN -
+    29 616 989 596
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Target(s) or Vendor(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631108">
+      <span class="field_acccgov_name">
+            Zagame Automotive Group Pty Ltd
+
+      </span>
+      <span>
+                        ABN -
+    85 085 950 063
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+  <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
+    <h3 class="field__label">ANZSIC code(s)</h3>
+          <div class="field__item">
+              3911  Car Retailing;           3921  Motor Vehicle Parts Retailing              </div>
+      </div>
+  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
+    <h3 class="field__label">Description</h3>
+              <div class="field__item">
+<div class="read-more-wrapper">
+      <div class="summary-text">
+      <p>Eagers Vic Pty Ltd (<strong>Eagers</strong>) is a subsidiary of Eagers Automotive Limited (ASX: APE), a publicly listed automotive retail group which owns and operates motor vehicle dealerships acr</p>
+    </div>
+    <div class="full-text" style="display:none;">
+    <p>Eagers Vic Pty Ltd (<strong>Eagers</strong>) is a subsidiary of Eagers Automotive Limited (ASX: APE), a publicly listed automotive retail group which owns and operates motor vehicle dealerships across Australia. Eagers Automotive Limited sells new and used motor vehicles through its dealerships, representing around 50 automotive brands. Eagers also provides related goods and services including motor vehicle service, parts and allied consumer finance. Eagers operates 12 dealerships in the Melbourne area, including in Toorak (Mercedes-Benz), Malvern (ULR Jaguar and ULR Land Rover) and Port Melbourne (Jaguar, Volvo, Volkswagen and Land Rover). Eagers does not currently have any Audi dealerships in Victoria.</p>
+
+<p>Zagame Automotive Group Pty Ltd (<strong>Zagame</strong>) operates motor vehicle dealerships (franchises and agencies), selling new and used motor vehicles, focusing on sports, luxury and performance vehicles. It represents 16 automotive brands with dealerships across the Melbourne area (including five Audi dealerships). Zagame also operates related businesses including automotive repairs, wholesale automotive parts, and retail automotive finance.&nbsp;</p>
+
+<p>Eagers proposes to acquire the assets for the following Audi dealerships from Zagame:&nbsp;</p>
+
+<p>Audi Centre Melbourne, 501 Swanston St, Melbourne 3000 (<strong>Audi Melbourne</strong>); and&nbsp;</p>
+
+<p>Audi Richmond, 408 – 410 Swan Street, Richmond 3121 (<strong>Audi Richmond</strong>).&nbsp;</p>
+
+  </div>
+      <a href="#" class="read-toggle" data-expanded="true">read more</a>
+  </div></div>
+          </div>
+
+  </div>
+
+  </div>
+</div>
+
+</div>
+    <div class="views-row">
+
+<div  class="accc-collapsed-card contextual-region h-100">
+  <div class="accc-collapsed-card__header" id="heading-168063">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/princeton-digital-group-australia-land-located-in-campbelltown-nsw">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  Princeton Digital Group Australia - land located in Campbelltown, NSW
+</h3>
+</div>
+      
+<div  class="accc-collapsed-card__header-info">
+        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
+    <h3 class="field__label">Acquisition status</h3>
+              <div class="field__item">Assessment completed</div>
+          </div>
+
+<div  class="accc-collapsed-card__header-content">
+      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
+<div class="field__item">Waiver</div>
+</div>
+  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
+    <h3 class="field__label">Case number</h3>
+              <div class="field__item">WA-80008</div>
+          </div>
+  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
+    <h3 class="field__label">Waiver application date</h3>
+              <div class="field__item"><time datetime="2026-03-30T12:00:00Z" class="datetime">30 Mar 2026</time>
+</div>
+          </div>
+
+  </div>
+
+  </div>
+</a>
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-168063" href="#card-168063">
+      <span>expandable trigger</span>
+    </a>
+  </div>
+  <div id="card-168063" role="region" aria-labelledby="heading-168063" class="accc-collapsed-card__body collapse">
+    
+<div >
+    <h3 class="border-bottom">About the acquisition</h3>
+      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Acquirer(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631555">
+      <span class="field_acccgov_name">
+            Princeton Digital Group (Australia Alpha) Prop Pty Ltd
+
+      </span>
+      <span>
+                        ACN -
+    693 155 663
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Target(s) or Vendor(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631557">
+      <span class="field_acccgov_name">
+            MH Property No. 1 Pty Ltd
+
+      </span>
+      <span>
+                        ACN -
+    644 453 430
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+  <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
+    <h3 class="field__label">ANZSIC code(s)</h3>
+          <div class="field__item">
+              6712  Non-Residential Property Operators              </div>
+      </div>
+  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
+    <h3 class="field__label">Description</h3>
+              <div class="field__item">
+<div class="read-more-wrapper">
+      <div class="summary-text">
+      <p>Princeton Digital Group (Australia Alpha) Prop Pty Ltd (<strong>Princeton Digital Group Australia</strong>),&nbsp;as trustee of Princeton Digital Group (Australia Alpha) Prop Trust, proposes to acq</p>
+    </div>
+    <div class="full-text" style="display:none;">
+    <p>Princeton Digital Group (Australia Alpha) Prop Pty Ltd (<strong>Princeton Digital Group Australia</strong>),&nbsp;as trustee of Princeton Digital Group (Australia Alpha) Prop Trust, proposes to acquire&nbsp;land located in Campbelltown, NSW from MH Property No. 1 Pty Ltd (<strong>MH Property</strong>)(the <strong>Acquisition</strong>).</p>
+
+<p>The Acquisition is for the purpose of building, owning and operating a data centre in Australia. Once developed, Princeton Digital Group Australia intends to supply data centre facilities and associated infrastructure to tenants in Australia.</p>
+
+<p>The land is currently vacant and contains no existing fixtures, structures or buildings. The land will be acquired by way of a land title transfer from MH Property to Princeton Digital Group Australia .</p>
+
+<p>Princeton Digital Group Australia is an indirectly wholly owned subsidiary of Princeton Digital Group Limited (<strong>Princeton Digital Group</strong>), a Singapore headquartered group which operates a data centre business across more than 20 data centres in seven countries – Singapore, Japan, China, Indonesia, India, Malaysia and South Korea. Princeton Digital Group does not currently own or operate any data centre assets in Australia.</p>
+
+<p>MH Property is an Australian property developer which owns land in New South Wales.</p>
+
+  </div>
+      <a href="#" class="read-toggle" data-expanded="true">read more</a>
+  </div></div>
+          </div>
+
+  </div>
+
+  </div>
+</div>
+
+</div>
+    <div class="views-row">
+
+<div  class="accc-collapsed-card contextual-region h-100">
   <div class="accc-collapsed-card__header" id="heading-167929">
   <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/francisco-partners-%E2%80%93-capsa-healthcare">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
   Francisco Partners – Capsa Healthcare
@@ -5683,115 +5792,6 @@
     <div class="views-row">
 
 <div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-168063">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/princeton-digital-group-australia-land-located-in-campbelltown-nsw">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  Princeton Digital Group Australia - land located in Campbelltown, NSW
-</h3>
-</div>
-      
-<div  class="accc-collapsed-card__header-info">
-        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
-    <h3 class="field__label">Acquisition status</h3>
-              <div class="field__item">Assessment completed</div>
-          </div>
-
-<div  class="accc-collapsed-card__header-content">
-      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
-<div class="field__item">Waiver</div>
-</div>
-  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
-    <h3 class="field__label">Case number</h3>
-              <div class="field__item">WA-80008</div>
-          </div>
-  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
-    <h3 class="field__label">Waiver application date</h3>
-              <div class="field__item"><time datetime="2026-03-30T12:00:00Z" class="datetime">30 Mar 2026</time>
-</div>
-          </div>
-
-  </div>
-
-  </div>
-</a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-168063" href="#card-168063">
-      <span>expandable trigger</span>
-    </a>
-  </div>
-  <div id="card-168063" role="region" aria-labelledby="heading-168063" class="accc-collapsed-card__body collapse">
-    
-<div >
-    <h3 class="border-bottom">About the acquisition</h3>
-      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Acquirer(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631555">
-      <span class="field_acccgov_name">
-            Princeton Digital Group (Australia Alpha) Prop Pty Ltd
-
-      </span>
-      <span>
-                        ACN -
-    693 155 663
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Target(s) or Vendor(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631557">
-      <span class="field_acccgov_name">
-            MH Property No. 1 Pty Ltd
-
-      </span>
-      <span>
-                        ACN -
-    644 453 430
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-  <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
-    <h3 class="field__label">ANZSIC code(s)</h3>
-          <div class="field__item">
-              6712  Non-Residential Property Operators              </div>
-      </div>
-  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
-    <h3 class="field__label">Description</h3>
-              <div class="field__item">
-<div class="read-more-wrapper">
-      <div class="summary-text">
-      <p>Princeton Digital Group (Australia Alpha) Prop Pty Ltd (<strong>Princeton Digital Group Australia</strong>),&nbsp;as trustee of Princeton Digital Group (Australia Alpha) Prop Trust, proposes to acq</p>
-    </div>
-    <div class="full-text" style="display:none;">
-    <p>Princeton Digital Group (Australia Alpha) Prop Pty Ltd (<strong>Princeton Digital Group Australia</strong>),&nbsp;as trustee of Princeton Digital Group (Australia Alpha) Prop Trust, proposes to acquire&nbsp;land located in Campbelltown, NSW from MH Property No. 1 Pty Ltd (<strong>MH Property</strong>)(the <strong>Acquisition</strong>).</p>
-
-<p>The Acquisition is for the purpose of building, owning and operating a data centre in Australia. Once developed, Princeton Digital Group Australia intends to supply data centre facilities and associated infrastructure to tenants in Australia.</p>
-
-<p>The land is currently vacant and contains no existing fixtures, structures or buildings. The land will be acquired by way of a land title transfer from MH Property to Princeton Digital Group Australia .</p>
-
-<p>Princeton Digital Group Australia is an indirectly wholly owned subsidiary of Princeton Digital Group Limited (<strong>Princeton Digital Group</strong>), a Singapore headquartered group which operates a data centre business across more than 20 data centres in seven countries – Singapore, Japan, China, Indonesia, India, Malaysia and South Korea. Princeton Digital Group does not currently own or operate any data centre assets in Australia.</p>
-
-<p>MH Property is an Australian property developer which owns land in New South Wales.</p>
-
-  </div>
-      <a href="#" class="read-toggle" data-expanded="true">read more</a>
-  </div></div>
-          </div>
-
-  </div>
-
-  </div>
-</div>
-
-</div>
-    <div class="views-row">
-
-<div  class="accc-collapsed-card contextual-region h-100">
   <div class="accc-collapsed-card__header" id="heading-167879">
   <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/calvary-holmesglen-private-hospital">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
   Calvary - Holmesglen Private Hospital
@@ -5924,6 +5924,151 @@
 <p>Holmesglen Private is a private hospital in located in Moorabbin, which is currently operated by Healthscope. In May 2025, Healthscope’s parent entities went into voluntary administration, and receivers and administrators were appointed by its lenders and the Healthscope Board, respectively, to conduct an orderly sale of the hospitals in its network.</p>
 
 <p>Holmesglen Private is an acute care facility with 147 beds offering a 24/7 Emergency Department, intensive care unit, and coronary care unit. It provides a wide range of surgical and medical services including cardiology, orthopaedic and general surgery, and plastic and reconstructive surgery. Holmesglen Private does not have a palliative care unit.&nbsp;</p>
+
+  </div>
+      <a href="#" class="read-toggle" data-expanded="true">read more</a>
+  </div></div>
+          </div>
+
+  </div>
+
+  </div>
+</div>
+
+</div>
+    <div class="views-row">
+
+<div  class="accc-collapsed-card contextual-region h-100">
+  <div class="accc-collapsed-card__header" id="heading-167948">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/ochre-health-telegraph-road-clinic-bracken-ridge-qld">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  Ochre Health - Telegraph Road Clinic, Bracken Ridge QLD
+</h3>
+</div>
+      
+<div  class="accc-collapsed-card__header-info">
+        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
+    <h3 class="field__label">Acquisition status</h3>
+              <div class="field__item">Assessment completed</div>
+          </div>
+
+<div  class="accc-collapsed-card__header-content">
+      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
+<div class="field__item">Waiver</div>
+</div>
+  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
+    <h3 class="field__label">Case number</h3>
+              <div class="field__item">WA-15012</div>
+          </div>
+  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
+    <h3 class="field__label">Waiver application date</h3>
+              <div class="field__item"><time datetime="2026-03-26T12:00:00Z" class="datetime">26 Mar 2026</time>
+</div>
+          </div>
+
+  </div>
+
+  </div>
+</a>
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167948" href="#card-167948">
+      <span>expandable trigger</span>
+    </a>
+  </div>
+  <div id="card-167948" role="region" aria-labelledby="heading-167948" class="accc-collapsed-card__body collapse">
+    
+<div >
+    <h3 class="border-bottom">About the acquisition</h3>
+      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Acquirer(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631276">
+      <span class="field_acccgov_name">
+            OCHRE HEALTH PTY LIMITED
+
+      </span>
+      <span>
+                        ABN -
+    79 101 069 452
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Target(s) or Vendor(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631280">
+      <span class="field_acccgov_name">
+            TELEGRAPH ROAD MEDICAL SERVICES PTY LTD
+
+      </span>
+      <span>
+                        ABN -
+    53 107 416 080
+
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631281">
+      <span class="field_acccgov_name">
+            The Trustee for TELEGRAPH ROAD MEDICAL SERVICES UNIT TRUST
+
+      </span>
+      <span>
+                        ABN -
+    94 428 158 606
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-other-parties field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Other party(ies)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631278">
+      <span class="field_acccgov_name">
+            RAINLEIGH PTY LIMITED
+
+      </span>
+      <span>
+                        ABN -
+    41 056 364 679
+
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631279">
+      <span class="field_acccgov_name">
+            Genesis Capital
+
+      </span>
+      <span>
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+  <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
+    <h3 class="field__label">ANZSIC code(s)</h3>
+          <div class="field__item">
+              8511  General Practice Medical Services              </div>
+      </div>
+  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
+    <h3 class="field__label">Description</h3>
+              <div class="field__item">
+<div class="read-more-wrapper">
+      <div class="summary-text">
+      <p>Ochre Health Pty Limited (<strong>Ochre Health</strong>) proposes to acquire the business and all of the assets of the Telegraph Road Clinic (<strong>TRC</strong>) in Bracken Ridge, Queensland, thr</p>
+    </div>
+    <div class="full-text" style="display:none;">
+    <p>Ochre Health Pty Limited (<strong>Ochre Health</strong>) proposes to acquire the business and all of the assets of the Telegraph Road Clinic (<strong>TRC</strong>) in Bracken Ridge, Queensland, through a business and assets acquisition agreement (the <strong>Acquisition</strong>).&nbsp;</p>
+
+<p>The acquirer, Ochre Health, supports independent doctors to provide general practice medical services in regional, rural and urban communities around Australia. Ochre Health currently operates 68 medical centres and urgent care clinics located in the ACT, NSW, Queensland, Tasmania and Victoria, but currently does not operate any medical centres or urgent care clinics within 10km of TRC in Bracken Ridge, Queensland. Ochre Health Group’s medical recruitment business, Ochre Recruitment, also works with hospitals and medical practices across Australia and NZ to source and place locum and permanent doctors across a range of specialities.&nbsp;</p>
+
+<p>Ochre Health is majority owned and controlled by Genesis Capital (<strong>Genesis</strong>), an Australian-based private equity firm that invests in businesses operating in the healthcare sector. Genesis’s investments also include Holdsworth House Medical Group (<strong>Holdsworth House</strong>), which operates a general medical practice in Fortitude Valley, Brisbane and another general medical practice in Sydney which is co-located with a medical research centre, specialist medical clinic and dentistry clinic.</p>
+
+<p>The target, TRC, is a family medical practice providing comprehensive general practice medical care from its clinic located in the Bracken Ridge Plaza, Shop 26, 250 Telegraph Road, Bracken Ridge, Queensland, and home visits to nearby patients (within a 3km radius of the clinic). TRC is owned and operated by Telegraph Road Medical Services Pty Ltd as trustee for Telegraph Road Medical Services Unit Trust.</p>
 
   </div>
       <a href="#" class="read-toggle" data-expanded="true">read more</a>
@@ -6253,151 +6398,6 @@
 <p>Apollo is an alternative asset management firm headquartered in New York. Examples of current investments include companies in natural resources, manufacturing and industrial, education, insurance, financial services, and leisure businesses.</p>
 
 <p>Molycop is a global supplier of mining consumables, with a focus on the manufacture and sale of grinding media and flotation chemicals for use in both semi-autogenous grinding mills and ball mills. These products are used for mineral extraction and processing for copper, gold and iron ore.&nbsp;In Australia, Molycop also supplies engineered products for the Australian rail and manufacturing industries</p>
-
-  </div>
-      <a href="#" class="read-toggle" data-expanded="true">read more</a>
-  </div></div>
-          </div>
-
-  </div>
-
-  </div>
-</div>
-
-</div>
-    <div class="views-row">
-
-<div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-167948">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/ochre-health-telegraph-road-clinic-bracken-ridge-qld">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  Ochre Health - Telegraph Road Clinic, Bracken Ridge QLD
-</h3>
-</div>
-      
-<div  class="accc-collapsed-card__header-info">
-        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
-    <h3 class="field__label">Acquisition status</h3>
-              <div class="field__item">Assessment completed</div>
-          </div>
-
-<div  class="accc-collapsed-card__header-content">
-      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
-<div class="field__item">Waiver</div>
-</div>
-  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
-    <h3 class="field__label">Case number</h3>
-              <div class="field__item">WA-15012</div>
-          </div>
-  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
-    <h3 class="field__label">Waiver application date</h3>
-              <div class="field__item"><time datetime="2026-03-26T12:00:00Z" class="datetime">26 Mar 2026</time>
-</div>
-          </div>
-
-  </div>
-
-  </div>
-</a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167948" href="#card-167948">
-      <span>expandable trigger</span>
-    </a>
-  </div>
-  <div id="card-167948" role="region" aria-labelledby="heading-167948" class="accc-collapsed-card__body collapse">
-    
-<div >
-    <h3 class="border-bottom">About the acquisition</h3>
-      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Acquirer(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631276">
-      <span class="field_acccgov_name">
-            OCHRE HEALTH PTY LIMITED
-
-      </span>
-      <span>
-                        ABN -
-    79 101 069 452
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Target(s) or Vendor(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631280">
-      <span class="field_acccgov_name">
-            TELEGRAPH ROAD MEDICAL SERVICES PTY LTD
-
-      </span>
-      <span>
-                        ABN -
-    53 107 416 080
-
-              </span>
-    </div>
-  </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631281">
-      <span class="field_acccgov_name">
-            The Trustee for TELEGRAPH ROAD MEDICAL SERVICES UNIT TRUST
-
-      </span>
-      <span>
-                        ABN -
-    94 428 158 606
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-other-parties field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Other party(ies)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631278">
-      <span class="field_acccgov_name">
-            RAINLEIGH PTY LIMITED
-
-      </span>
-      <span>
-                        ABN -
-    41 056 364 679
-
-              </span>
-    </div>
-  </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631279">
-      <span class="field_acccgov_name">
-            Genesis Capital
-
-      </span>
-      <span>
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-  <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
-    <h3 class="field__label">ANZSIC code(s)</h3>
-          <div class="field__item">
-              8511  General Practice Medical Services              </div>
-      </div>
-  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
-    <h3 class="field__label">Description</h3>
-              <div class="field__item">
-<div class="read-more-wrapper">
-      <div class="summary-text">
-      <p>Ochre Health Pty Limited (<strong>Ochre Health</strong>) proposes to acquire the business and all of the assets of the Telegraph Road Clinic (<strong>TRC</strong>) in Bracken Ridge, Queensland, thr</p>
-    </div>
-    <div class="full-text" style="display:none;">
-    <p>Ochre Health Pty Limited (<strong>Ochre Health</strong>) proposes to acquire the business and all of the assets of the Telegraph Road Clinic (<strong>TRC</strong>) in Bracken Ridge, Queensland, through a business and assets acquisition agreement (the <strong>Acquisition</strong>).&nbsp;</p>
-
-<p>The acquirer, Ochre Health, supports independent doctors to provide general practice medical services in regional, rural and urban communities around Australia. Ochre Health currently operates 68 medical centres and urgent care clinics located in the ACT, NSW, Queensland, Tasmania and Victoria, but currently does not operate any medical centres or urgent care clinics within 10km of TRC in Bracken Ridge, Queensland. Ochre Health Group’s medical recruitment business, Ochre Recruitment, also works with hospitals and medical practices across Australia and NZ to source and place locum and permanent doctors across a range of specialities.&nbsp;</p>
-
-<p>Ochre Health is majority owned and controlled by Genesis Capital (<strong>Genesis</strong>), an Australian-based private equity firm that invests in businesses operating in the healthcare sector. Genesis’s investments also include Holdsworth House Medical Group (<strong>Holdsworth House</strong>), which operates a general medical practice in Fortitude Valley, Brisbane and another general medical practice in Sydney which is co-located with a medical research centre, specialist medical clinic and dentistry clinic.</p>
-
-<p>The target, TRC, is a family medical practice providing comprehensive general practice medical care from its clinic located in the Bracken Ridge Plaza, Shop 26, 250 Telegraph Road, Bracken Ridge, Queensland, and home visits to nearby patients (within a 3km radius of the clinic). TRC is owned and operated by Telegraph Road Medical Services Pty Ltd as trustee for Telegraph Road Medical Services Unit Trust.</p>
 
   </div>
       <a href="#" class="read-toggle" data-expanded="true">read more</a>
@@ -6793,6 +6793,123 @@ The Acquirers are part of the MA Marina Fund, managed by entities held by MA Fin
     <div class="views-row">
 
 <div  class="accc-collapsed-card contextual-region h-100">
+  <div class="accc-collapsed-card__header" id="heading-167976">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/idemitsu-midocean-energy">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  Idemitsu - MidOcean Energy
+</h3>
+</div>
+      
+<div  class="accc-collapsed-card__header-info">
+        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
+    <h3 class="field__label">Acquisition status</h3>
+              <div class="field__item">Assessment completed</div>
+          </div>
+
+<div  class="accc-collapsed-card__header-content">
+      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
+<div class="field__item">Waiver</div>
+</div>
+  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
+    <h3 class="field__label">Case number</h3>
+              <div class="field__item">WA-45009</div>
+          </div>
+  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
+    <h3 class="field__label">Waiver application date</h3>
+              <div class="field__item"><time datetime="2026-03-23T12:00:00Z" class="datetime">23 Mar 2026</time>
+</div>
+          </div>
+
+  </div>
+
+  </div>
+</a>
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167976" href="#card-167976">
+      <span>expandable trigger</span>
+    </a>
+  </div>
+  <div id="card-167976" role="region" aria-labelledby="heading-167976" class="accc-collapsed-card__body collapse">
+    
+<div >
+    <h3 class="border-bottom">About the acquisition</h3>
+      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Acquirer(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631351">
+      <span class="field_acccgov_name">
+            IDEMITSU EUROPE LTD.
+
+      </span>
+      <span>
+                      UK Company Number 17103829
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Target(s) or Vendor(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631354">
+      <span class="field_acccgov_name">
+            MidOcean Holdings II L.P.
+
+      </span>
+      <span>
+                      SL036455
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-other-parties field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Other party(ies)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631353">
+      <span class="field_acccgov_name">
+            Idemitsu Kosan Co., Ltd.
+
+      </span>
+      <span>
+                      TYO 5019
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+  <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
+    <h3 class="field__label">ANZSIC code(s)</h3>
+          <div class="field__item">
+              0600  Coal Mining;           0700  Oil and Gas Extraction              </div>
+      </div>
+  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
+    <h3 class="field__label">Description</h3>
+              <div class="field__item">
+<div class="read-more-wrapper">
+      <div class="summary-text">
+      <p>The acquirer, Idemitsu, is a Japanese company oil-refining and marketing company. It has been involved in the development, production, and sale of coal at several mines in Australia.</p>
+    </div>
+    <div class="full-text" style="display:none;">
+    <p>The acquirer, Idemitsu, is a Japanese company oil-refining and marketing company. It has been involved in the development, production, and sale of coal at several mines in Australia. Idemitsu currently operates the Boggabri Coal Mine in NSW. Idemitsu has invested in lithium and vanadium development companies, renewables and acquired a fuel oil retail business.&nbsp;</p>
+
+<p>MidOcean Energy is a global liquid natural gas (LNG) platform formed and managed by EIG Partners in 2023. In Australia, MidOcean holds minority interests in the Queensland Curtis LNG Project, Gorgon LNG Project and Pluto LNG Project. These projects are involved in the extraction and production of natural gas and LNG.</p>
+
+  </div>
+      <a href="#" class="read-toggle" data-expanded="true">read more</a>
+  </div></div>
+          </div>
+
+  </div>
+
+  </div>
+</div>
+
+</div>
+    <div class="views-row">
+
+<div  class="accc-collapsed-card contextual-region h-100">
   <div class="accc-collapsed-card__header" id="heading-167989">
   <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/lighthouse-precise-services-group">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
   Lighthouse - Precise Services Group
@@ -7112,123 +7229,6 @@ The Acquirers are part of the MA Marina Fund, managed by entities held by MA Fin
 <p>Intrepid Group Pty Ltd (<strong>IG</strong>) is a global, purpose-led experiential travel company, specialising in small group tours and travel experiences. IG has 31 offices around the world and operates more than 1,000 small group adventures in 118 countries. Intrepid Travel is a subsidiary of IG.&nbsp;</p>
 
 <p>Wild Bush Luxury is a boutique Australian tourism operator that manages and operates the ‘The Maria Island Walk’ (in Tasmania), ‘Arkaba Walk’ (in South Australia), ‘Arkaba Homestead’ (in South Australia), and ‘Bamurru Plains’ (in the Northern Territory).&nbsp;</p>
-
-  </div>
-      <a href="#" class="read-toggle" data-expanded="true">read more</a>
-  </div></div>
-          </div>
-
-  </div>
-
-  </div>
-</div>
-
-</div>
-    <div class="views-row">
-
-<div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-167976">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/idemitsu-midocean-energy">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  Idemitsu - MidOcean Energy
-</h3>
-</div>
-      
-<div  class="accc-collapsed-card__header-info">
-        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
-    <h3 class="field__label">Acquisition status</h3>
-              <div class="field__item">Assessment completed</div>
-          </div>
-
-<div  class="accc-collapsed-card__header-content">
-      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
-<div class="field__item">Waiver</div>
-</div>
-  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
-    <h3 class="field__label">Case number</h3>
-              <div class="field__item">WA-45009</div>
-          </div>
-  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
-    <h3 class="field__label">Waiver application date</h3>
-              <div class="field__item"><time datetime="2026-03-23T12:00:00Z" class="datetime">23 Mar 2026</time>
-</div>
-          </div>
-
-  </div>
-
-  </div>
-</a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167976" href="#card-167976">
-      <span>expandable trigger</span>
-    </a>
-  </div>
-  <div id="card-167976" role="region" aria-labelledby="heading-167976" class="accc-collapsed-card__body collapse">
-    
-<div >
-    <h3 class="border-bottom">About the acquisition</h3>
-      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Acquirer(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631351">
-      <span class="field_acccgov_name">
-            IDEMITSU EUROPE LTD.
-
-      </span>
-      <span>
-                      UK Company Number 17103829
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Target(s) or Vendor(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631354">
-      <span class="field_acccgov_name">
-            MidOcean Holdings II L.P.
-
-      </span>
-      <span>
-                      SL036455
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-other-parties field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Other party(ies)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631353">
-      <span class="field_acccgov_name">
-            Idemitsu Kosan Co., Ltd.
-
-      </span>
-      <span>
-                      TYO 5019
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-  <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
-    <h3 class="field__label">ANZSIC code(s)</h3>
-          <div class="field__item">
-              0600  Coal Mining;           0700  Oil and Gas Extraction              </div>
-      </div>
-  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
-    <h3 class="field__label">Description</h3>
-              <div class="field__item">
-<div class="read-more-wrapper">
-      <div class="summary-text">
-      <p>The acquirer, Idemitsu, is a Japanese company oil-refining and marketing company. It has been involved in the development, production, and sale of coal at several mines in Australia.</p>
-    </div>
-    <div class="full-text" style="display:none;">
-    <p>The acquirer, Idemitsu, is a Japanese company oil-refining and marketing company. It has been involved in the development, production, and sale of coal at several mines in Australia. Idemitsu currently operates the Boggabri Coal Mine in NSW. Idemitsu has invested in lithium and vanadium development companies, renewables and acquired a fuel oil retail business.&nbsp;</p>
-
-<p>MidOcean Energy is a global liquid natural gas (LNG) platform formed and managed by EIG Partners in 2023. In Australia, MidOcean holds minority interests in the Queensland Curtis LNG Project, Gorgon LNG Project and Pluto LNG Project. These projects are involved in the extraction and production of natural gas and LNG.</p>
 
   </div>
       <a href="#" class="read-toggle" data-expanded="true">read more</a>
@@ -8050,276 +8050,6 @@ The Acquirers are part of the MA Marina Fund, managed by entities held by MA Fin
     <div class="views-row">
 
 <div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-167778">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/maas-%E2%80%93-50-acquisition-of-colas%E2%80%99-caloundra-asphalt-plant-and-100-of-colas%E2%80%99-tomago-asphalt-plant">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  Maas – 50% acquisition of COLAS’ Caloundra asphalt plant and 100% of COLAS’ Tomago asphalt plant
-</h3>
-</div>
-      
-<div  class="accc-collapsed-card__header-info">
-        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
-    <h3 class="field__label">Acquisition status</h3>
-              <div class="field__item">Assessment completed</div>
-          </div>
-
-<div  class="accc-collapsed-card__header-content">
-      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
-<div class="field__item">Notification</div>
-</div>
-  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
-    <h3 class="field__label">Case number</h3>
-              <div class="field__item">MN-50012</div>
-          </div>
-  <div class="field field--name-field-acquisition-stage field--type-list-string field--label-inline clearfix">
-    <h3 class="field__label">Stage</h3>
-              <div class="field__item">Phase 1 - initial assessment</div>
-          </div>
-  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
-    <h3 class="field__label">Effective notification date</h3>
-              <div class="field__item"><time datetime="2026-03-18T12:00:00Z" class="datetime">18 Mar 2026</time>
-</div>
-          </div>
-
-  </div>
-
-  </div>
-</a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167778" href="#card-167778">
-      <span>expandable trigger</span>
-    </a>
-  </div>
-  <div id="card-167778" role="region" aria-labelledby="heading-167778" class="accc-collapsed-card__body collapse">
-    
-<div >
-    <h3 class="border-bottom">About the acquisition</h3>
-      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Acquirer(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--630866">
-      <span class="field_acccgov_name">
-            ASPHALT OPERATORS AUSTRALIA PTY LTD
-
-      </span>
-      <span>
-                        ABN -
-    11 682 698 282
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Target(s) or Vendor(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--630868">
-      <span class="field_acccgov_name">
-            COLAS QUEENSLAND PTY LTD
-
-      </span>
-      <span>
-                        ABN -
-    91 169 872 208
-
-              </span>
-    </div>
-  </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--630869">
-      <span class="field_acccgov_name">
-            COLAS AUSTRALIA GROUP PTY LTD
-
-      </span>
-      <span>
-                        ABN -
-    11 000 388 161
-
-              </span>
-    </div>
-  </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--630870">
-      <span class="field_acccgov_name">
-            COLAS NEW SOUTH WALES PTY LTD
-
-      </span>
-      <span>
-                        ABN -
-    16 064 662 148
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-  <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
-    <h3 class="field__label">ANZSIC code(s)</h3>
-          <div class="field__item">
-              1709  Other Petroleum and Coal Product Manufacturing;           3101  Road and Bridge Construction              </div>
-      </div>
-  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
-    <h3 class="field__label">Description</h3>
-              <div class="field__item">
-<div class="read-more-wrapper">
-      <div class="summary-text">
-      <div class="ck-content stickystyles-wrapper-insert" data-wrapper="true" dir="ltr">
-<p>Maas Group Holdings Limited (<strong>Maas</strong>) proposes to acquire, through its subsidiary Asphalt Operators </p></div>
-    </div>
-    <div class="full-text" style="display:none;">
-    <div class="ck-content stickystyles-wrapper-insert" data-wrapper="true" dir="ltr">
-<p>Maas Group Holdings Limited (<strong>Maas</strong>) proposes to acquire, through its subsidiary Asphalt Operators Australia Pty Ltd (<strong>AOA</strong>), a 50% interest in Coltek Asphalt Pty Ltd (<strong>Coltek</strong>), which will own and operate the hot-mix asphalt business currently owned and operated by a subsidiary of COLAS Australia Group Pty Ltd (<strong>COLAS</strong>) at Caloundra on the Sunshine Coast, Queensland. The remaining 50% interest in Coltek will be retained by COLAS, and Coltek will operate the hot-mix asphalt business at Caloundra as an incorporated joint venture between Maas and COLAS.</p>
-
-<p>Maas also proposes to acquire, through its subsidiary Austek Roads NSW Pty Ltd (<strong>Austek Roads NSW</strong>) (which forms part of the AOA business), the hot-mix asphalt business currently owned and operated by a subsidiary of COLAS at Tomago, NSW (Newcastle).</p>
-
-<p>Maas (ASX: MGH) is a diversified industrial group with operations in construction materials, civil construction and hire, manufacturing and equipment sales, and residential and commercial real estate. Under the Austek brand the AOA business produces asphalt and supplies roadlaying services (such as asphalt paving, asphalt repairs and spray seal services).</p>
-
-<p>COLAS supplies asphalt, road maintenance and preservation services, quarrying and binder management services, dust management and quality control services, and research and development services. COLAS is a subsidiary of France-based COLAS SA.</p>
-</div>
-
-  </div>
-      <a href="#" class="read-toggle" data-expanded="true">read more</a>
-  </div></div>
-          </div>
-
-  </div>
-
-  </div>
-</div>
-
-</div>
-    <div class="views-row">
-
-<div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-167775">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/cvc-capital-partners-%E2%80%93-marathon-asset-management">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  CVC Capital Partners – Marathon Asset Management
-</h3>
-</div>
-      
-<div  class="accc-collapsed-card__header-info">
-        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
-    <h3 class="field__label">Acquisition status</h3>
-              <div class="field__item">Assessment completed</div>
-          </div>
-
-<div  class="accc-collapsed-card__header-content">
-      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
-<div class="field__item">Notification</div>
-</div>
-  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
-    <h3 class="field__label">Case number</h3>
-              <div class="field__item">MN-65009</div>
-          </div>
-  <div class="field field--name-field-acquisition-stage field--type-list-string field--label-inline clearfix">
-    <h3 class="field__label">Stage</h3>
-              <div class="field__item">Phase 1 - initial assessment</div>
-          </div>
-  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
-    <h3 class="field__label">Effective notification date</h3>
-              <div class="field__item"><time datetime="2026-03-18T12:00:00Z" class="datetime">18 Mar 2026</time>
-</div>
-          </div>
-
-  </div>
-
-  </div>
-</a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167775" href="#card-167775">
-      <span>expandable trigger</span>
-    </a>
-  </div>
-  <div id="card-167775" role="region" aria-labelledby="heading-167775" class="accc-collapsed-card__body collapse">
-    
-<div >
-    <h3 class="border-bottom">About the acquisition</h3>
-      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Acquirer(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--630861">
-      <span class="field_acccgov_name">
-            CVC Capital Partners plc
-
-      </span>
-      <span>
-                      140080
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Target(s) or Vendor(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--630864">
-      <span class="field_acccgov_name">
-            Marathon Asset Management; LP, Marathon GP Holdings I, LLC and Marathon GP Holdings II, LLC
-
-      </span>
-      <span>
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-other-parties field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Other party(ies)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--630862">
-      <span class="field_acccgov_name">
-            Auto Europe Group
-
-      </span>
-      <span>
-              </span>
-    </div>
-  </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--630863">
-      <span class="field_acccgov_name">
-            Kaléo Inc
-
-      </span>
-      <span>
-                      5279364
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-  <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
-    <h3 class="field__label">ANZSIC code(s)</h3>
-          <div class="field__item">
-              1841  Human Pharmaceutical and Medicinal Product Manufacturing;           6240  Financial Asset Investing;           6419  Other Auxiliary Finance and Investment Services;           7220  Travel Agency and Tour Arrangement Services              </div>
-      </div>
-  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
-    <h3 class="field__label">Description</h3>
-              <div class="field__item">
-<div class="read-more-wrapper">
-      <div class="summary-text">
-      <p>CVC Capital Partners plc (CVC Capital Partners) proposes to indirectly acquire 100% of the shares in Marathon Asset Management, LP, Marathon GP Holdings I, LLC and Marathon GP Holdings II, LLC (tog</p>
-    </div>
-    <div class="full-text" style="display:none;">
-    <p>CVC Capital Partners plc (CVC Capital Partners) proposes to indirectly acquire 100% of the shares in Marathon Asset Management, LP, Marathon GP Holdings I, LLC and Marathon GP Holdings II, LLC (together, Marathon Asset Management) (the Acquisition).</p>
-
-<p>CVC Capital Partners is listed on the Euronext Amsterdam Stock Exchange and is part of the CVC Network, a global private equity and investment advisory firm that provides investment advice to and/or manages investments on behalf of certain funds and investment vehicles with assets under management (AuM) globally. The CVC Network manages AuM across private equity, credit, secondaries and infrastructure. It holds interests in a range of industries, including energy, renewables, transportation, chemicals, utilities, manufacturing, retail and distribution. CVC Capital Partners has interests in Etraveli Group AB,&nbsp;a&nbsp;flight online travel agency (OTA), and in companies which provide pharmaceutical packaging, excipients and specialty chemicals, being Syntegon Technology GmbH, DFE Pharma GmbH &amp; Co. KG, and Cohizon Life Sciences Limited.</p>
-
-<p>Marathon Asset Management is a New York-based global asset manager focused on liquid (public) and private credit.&nbsp;In addition to its credit asset management and advisory activities, Marathon Asset Management-advised funds and accounts hold equity stakes in a small number of companies and own and lease out numerous assets. Marathon Asset Management has an&nbsp;interest in Auto Europe Group, a car rental OTA business and in Kaléo Inc,<sup>&nbsp;</sup>a pharmaceutical manufacturer of auto-injector drug delivery systems for epinephrine and naloxone, which are used to treat anaphylaxis, or severe allergic reactions, and opioid overdoses respectively.</p>
-
-<p>Both CVC Capital Partners and Marathon Asset Management supply asset management services, specifically in credit asset management, globally.&nbsp;</p>
-
-  </div>
-      <a href="#" class="read-toggle" data-expanded="true">read more</a>
-  </div></div>
-          </div>
-
-  </div>
-
-  </div>
-</div>
-
-</div>
-    <div class="views-row">
-
-<div  class="accc-collapsed-card contextual-region h-100">
   <div class="accc-collapsed-card__header" id="heading-167960">
   <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/regent-motors-group-lane-groups-mandurah-dealerships">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
   Regent Motors Group - Lane Group&#039;s Mandurah Dealerships
@@ -8889,9 +8619,279 @@ The Acquirers are part of the MA Marina Fund, managed by entities held by MA Fin
     <div class="views-row">
 
 <div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-167930">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/star-hotels-group-%E2%80%93-liquor-legends-berserker-liquor-legends-highway-a1-qld">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  Star Hotels Group – Liquor Legends Berserker &amp; Liquor Legends Highway A1, QLD
+  <div class="accc-collapsed-card__header" id="heading-167778">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/maas-%E2%80%93-50-acquisition-of-colas%E2%80%99-caloundra-asphalt-plant-and-100-of-colas%E2%80%99-tomago-asphalt-plant">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  Maas – 50% acquisition of COLAS’ Caloundra asphalt plant and 100% of COLAS’ Tomago asphalt plant
+</h3>
+</div>
+      
+<div  class="accc-collapsed-card__header-info">
+        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
+    <h3 class="field__label">Acquisition status</h3>
+              <div class="field__item">Assessment completed</div>
+          </div>
+
+<div  class="accc-collapsed-card__header-content">
+      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
+<div class="field__item">Notification</div>
+</div>
+  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
+    <h3 class="field__label">Case number</h3>
+              <div class="field__item">MN-50012</div>
+          </div>
+  <div class="field field--name-field-acquisition-stage field--type-list-string field--label-inline clearfix">
+    <h3 class="field__label">Stage</h3>
+              <div class="field__item">Phase 1 - initial assessment</div>
+          </div>
+  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
+    <h3 class="field__label">Effective notification date</h3>
+              <div class="field__item"><time datetime="2026-03-18T12:00:00Z" class="datetime">18 Mar 2026</time>
+</div>
+          </div>
+
+  </div>
+
+  </div>
+</a>
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167778" href="#card-167778">
+      <span>expandable trigger</span>
+    </a>
+  </div>
+  <div id="card-167778" role="region" aria-labelledby="heading-167778" class="accc-collapsed-card__body collapse">
+    
+<div >
+    <h3 class="border-bottom">About the acquisition</h3>
+      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Acquirer(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--630866">
+      <span class="field_acccgov_name">
+            ASPHALT OPERATORS AUSTRALIA PTY LTD
+
+      </span>
+      <span>
+                        ABN -
+    11 682 698 282
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Target(s) or Vendor(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--630868">
+      <span class="field_acccgov_name">
+            COLAS QUEENSLAND PTY LTD
+
+      </span>
+      <span>
+                        ABN -
+    91 169 872 208
+
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--630869">
+      <span class="field_acccgov_name">
+            COLAS AUSTRALIA GROUP PTY LTD
+
+      </span>
+      <span>
+                        ABN -
+    11 000 388 161
+
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--630870">
+      <span class="field_acccgov_name">
+            COLAS NEW SOUTH WALES PTY LTD
+
+      </span>
+      <span>
+                        ABN -
+    16 064 662 148
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+  <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
+    <h3 class="field__label">ANZSIC code(s)</h3>
+          <div class="field__item">
+              1709  Other Petroleum and Coal Product Manufacturing;           3101  Road and Bridge Construction              </div>
+      </div>
+  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
+    <h3 class="field__label">Description</h3>
+              <div class="field__item">
+<div class="read-more-wrapper">
+      <div class="summary-text">
+      <div class="ck-content stickystyles-wrapper-insert" data-wrapper="true" dir="ltr">
+<p>Maas Group Holdings Limited (<strong>Maas</strong>) proposes to acquire, through its subsidiary Asphalt Operators </p></div>
+    </div>
+    <div class="full-text" style="display:none;">
+    <div class="ck-content stickystyles-wrapper-insert" data-wrapper="true" dir="ltr">
+<p>Maas Group Holdings Limited (<strong>Maas</strong>) proposes to acquire, through its subsidiary Asphalt Operators Australia Pty Ltd (<strong>AOA</strong>), a 50% interest in Coltek Asphalt Pty Ltd (<strong>Coltek</strong>), which will own and operate the hot-mix asphalt business currently owned and operated by a subsidiary of COLAS Australia Group Pty Ltd (<strong>COLAS</strong>) at Caloundra on the Sunshine Coast, Queensland. The remaining 50% interest in Coltek will be retained by COLAS, and Coltek will operate the hot-mix asphalt business at Caloundra as an incorporated joint venture between Maas and COLAS.</p>
+
+<p>Maas also proposes to acquire, through its subsidiary Austek Roads NSW Pty Ltd (<strong>Austek Roads NSW</strong>) (which forms part of the AOA business), the hot-mix asphalt business currently owned and operated by a subsidiary of COLAS at Tomago, NSW (Newcastle).</p>
+
+<p>Maas (ASX: MGH) is a diversified industrial group with operations in construction materials, civil construction and hire, manufacturing and equipment sales, and residential and commercial real estate. Under the Austek brand the AOA business produces asphalt and supplies roadlaying services (such as asphalt paving, asphalt repairs and spray seal services).</p>
+
+<p>COLAS supplies asphalt, road maintenance and preservation services, quarrying and binder management services, dust management and quality control services, and research and development services. COLAS is a subsidiary of France-based COLAS SA.</p>
+</div>
+
+  </div>
+      <a href="#" class="read-toggle" data-expanded="true">read more</a>
+  </div></div>
+          </div>
+
+  </div>
+
+  </div>
+</div>
+
+</div>
+    <div class="views-row">
+
+<div  class="accc-collapsed-card contextual-region h-100">
+  <div class="accc-collapsed-card__header" id="heading-167775">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/cvc-capital-partners-%E2%80%93-marathon-asset-management">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  CVC Capital Partners – Marathon Asset Management
+</h3>
+</div>
+      
+<div  class="accc-collapsed-card__header-info">
+        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
+    <h3 class="field__label">Acquisition status</h3>
+              <div class="field__item">Assessment completed</div>
+          </div>
+
+<div  class="accc-collapsed-card__header-content">
+      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
+<div class="field__item">Notification</div>
+</div>
+  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
+    <h3 class="field__label">Case number</h3>
+              <div class="field__item">MN-65009</div>
+          </div>
+  <div class="field field--name-field-acquisition-stage field--type-list-string field--label-inline clearfix">
+    <h3 class="field__label">Stage</h3>
+              <div class="field__item">Phase 1 - initial assessment</div>
+          </div>
+  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
+    <h3 class="field__label">Effective notification date</h3>
+              <div class="field__item"><time datetime="2026-03-18T12:00:00Z" class="datetime">18 Mar 2026</time>
+</div>
+          </div>
+
+  </div>
+
+  </div>
+</a>
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167775" href="#card-167775">
+      <span>expandable trigger</span>
+    </a>
+  </div>
+  <div id="card-167775" role="region" aria-labelledby="heading-167775" class="accc-collapsed-card__body collapse">
+    
+<div >
+    <h3 class="border-bottom">About the acquisition</h3>
+      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Acquirer(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--630861">
+      <span class="field_acccgov_name">
+            CVC Capital Partners plc
+
+      </span>
+      <span>
+                      140080
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Target(s) or Vendor(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--630864">
+      <span class="field_acccgov_name">
+            Marathon Asset Management; LP, Marathon GP Holdings I, LLC and Marathon GP Holdings II, LLC
+
+      </span>
+      <span>
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-other-parties field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Other party(ies)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--630862">
+      <span class="field_acccgov_name">
+            Auto Europe Group
+
+      </span>
+      <span>
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--630863">
+      <span class="field_acccgov_name">
+            Kaléo Inc
+
+      </span>
+      <span>
+                      5279364
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+  <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
+    <h3 class="field__label">ANZSIC code(s)</h3>
+          <div class="field__item">
+              1841  Human Pharmaceutical and Medicinal Product Manufacturing;           6240  Financial Asset Investing;           6419  Other Auxiliary Finance and Investment Services;           7220  Travel Agency and Tour Arrangement Services              </div>
+      </div>
+  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
+    <h3 class="field__label">Description</h3>
+              <div class="field__item">
+<div class="read-more-wrapper">
+      <div class="summary-text">
+      <p>CVC Capital Partners plc (CVC Capital Partners) proposes to indirectly acquire 100% of the shares in Marathon Asset Management, LP, Marathon GP Holdings I, LLC and Marathon GP Holdings II, LLC (tog</p>
+    </div>
+    <div class="full-text" style="display:none;">
+    <p>CVC Capital Partners plc (CVC Capital Partners) proposes to indirectly acquire 100% of the shares in Marathon Asset Management, LP, Marathon GP Holdings I, LLC and Marathon GP Holdings II, LLC (together, Marathon Asset Management) (the Acquisition).</p>
+
+<p>CVC Capital Partners is listed on the Euronext Amsterdam Stock Exchange and is part of the CVC Network, a global private equity and investment advisory firm that provides investment advice to and/or manages investments on behalf of certain funds and investment vehicles with assets under management (AuM) globally. The CVC Network manages AuM across private equity, credit, secondaries and infrastructure. It holds interests in a range of industries, including energy, renewables, transportation, chemicals, utilities, manufacturing, retail and distribution. CVC Capital Partners has interests in Etraveli Group AB,&nbsp;a&nbsp;flight online travel agency (OTA), and in companies which provide pharmaceutical packaging, excipients and specialty chemicals, being Syntegon Technology GmbH, DFE Pharma GmbH &amp; Co. KG, and Cohizon Life Sciences Limited.</p>
+
+<p>Marathon Asset Management is a New York-based global asset manager focused on liquid (public) and private credit.&nbsp;In addition to its credit asset management and advisory activities, Marathon Asset Management-advised funds and accounts hold equity stakes in a small number of companies and own and lease out numerous assets. Marathon Asset Management has an&nbsp;interest in Auto Europe Group, a car rental OTA business and in Kaléo Inc,<sup>&nbsp;</sup>a pharmaceutical manufacturer of auto-injector drug delivery systems for epinephrine and naloxone, which are used to treat anaphylaxis, or severe allergic reactions, and opioid overdoses respectively.</p>
+
+<p>Both CVC Capital Partners and Marathon Asset Management supply asset management services, specifically in credit asset management, globally.&nbsp;</p>
+
+  </div>
+      <a href="#" class="read-toggle" data-expanded="true">read more</a>
+  </div></div>
+          </div>
+
+  </div>
+
+  </div>
+</div>
+
+</div>
+    <div class="views-row">
+
+<div  class="accc-collapsed-card contextual-region h-100">
+  <div class="accc-collapsed-card__header" id="heading-167962">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/ironbark-investment-in-viola-private-wealth">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  Ironbark - Investment in Viola Private Wealth
 </h3>
 </div>
       
@@ -8907,7 +8907,7 @@ The Acquirers are part of the MA Marina Fund, managed by entities held by MA Fin
 </div>
   <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
     <h3 class="field__label">Case number</h3>
-              <div class="field__item">WA-75015</div>
+              <div class="field__item">WA-05005</div>
           </div>
   <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
     <h3 class="field__label">Waiver application date</h3>
@@ -8919,25 +8919,25 @@ The Acquirers are part of the MA Marina Fund, managed by entities held by MA Fin
 
   </div>
 </a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167930" href="#card-167930">
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-167962" href="#card-167962">
       <span>expandable trigger</span>
     </a>
   </div>
-  <div id="card-167930" role="region" aria-labelledby="heading-167930" class="accc-collapsed-card__body collapse">
+  <div id="card-167962" role="region" aria-labelledby="heading-167962" class="accc-collapsed-card__body collapse">
     
 <div >
     <h3 class="border-bottom">About the acquisition</h3>
       <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
   <h3 class="field__label">Acquirer(s)</h3>
       <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631170">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631335">
       <span class="field_acccgov_name">
-            MIGALOO QLD PTY LTD
+            IBWM PTY LTD
 
       </span>
       <span>
                         ABN -
-    30 600 219 172
+    28 621 141 026
 
               </span>
     </div>
@@ -8947,14 +8947,14 @@ The Acquirers are part of the MA Marina Fund, managed by entities held by MA Fin
 <div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
   <h3 class="field__label">Target(s) or Vendor(s)</h3>
       <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631173">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631337">
       <span class="field_acccgov_name">
-            The Trustee for The Garden Holdings Trust
+            VIOLA GROUP HOLDINGS PTY LTD
 
       </span>
       <span>
                         ABN -
-    45 745 542 544
+    20 680 038 180
 
               </span>
     </div>
@@ -8964,14 +8964,14 @@ The Acquirers are part of the MA Marina Fund, managed by entities held by MA Fin
 <div class="field field--name-field-acccgov-other-parties field--type-entity-reference-revisions field--label-inline clearfix">
   <h3 class="field__label">Other party(ies)</h3>
       <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631172">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--631338">
       <span class="field_acccgov_name">
-            STAR CONSOLIDATED HOLDINGS PTY LTD
+            Ironbark Investment Partners Pty Limited
 
       </span>
       <span>
                         ABN -
-    12 615 803 588
+    94 136 679 215
 
               </span>
     </div>
@@ -8981,28 +8981,19 @@ The Acquirers are part of the MA Marina Fund, managed by entities held by MA Fin
   <div class="field field--name-field-acquisition-anzsic-code field--type-string field--label-inline clearfix">
     <h3 class="field__label">ANZSIC code(s)</h3>
           <div class="field__item">
-              4123  Liquor Retailing;           4520  Pubs, Taverns and Bars              </div>
+              6240  Financial Asset Investing              </div>
       </div>
   <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
     <h3 class="field__label">Description</h3>
               <div class="field__item">
 <div class="read-more-wrapper">
       <div class="summary-text">
-      <p>The transaction involves the acquisition by Migaloo QLD Pty Ltd, a subsidiary of Star Consolidated Holdings Pty Ltd and its controlled entities (<strong>Star Hotels Group</strong>), of:</p>
+      <p>IBWM Pty Ltd (<strong>IBWM</strong>), a subsidiary of Ironbark Investment Partners Pty Ltd (<strong>Ironbark</strong>), will acquire 40% of the shares on issue in Viola Group Holdings Pty Ltd (</p>
     </div>
     <div class="full-text" style="display:none;">
-    <p>The transaction involves the acquisition by Migaloo QLD Pty Ltd, a subsidiary of Star Consolidated Holdings Pty Ltd and its controlled entities (<strong>Star Hotels Group</strong>), of:</p>
+    <p>IBWM Pty Ltd (<strong>IBWM</strong>), a subsidiary of Ironbark Investment Partners Pty Ltd (<strong>Ironbark</strong>), will acquire 40% of the shares on issue in Viola Group Holdings Pty Ltd (<strong>Viola Group</strong>). Viola Group is the parent company of Viola Finance Pty Ltd, Viola Private Holdings Pty Ltd, Viola Services Pty Ltd and Viola Private Wealth Pty Ltd (<strong>Viola</strong>).</p>
 
-<ul>
-<li>the leasehold interest in the land that the Liquor Legends Berserker and Liquor Legends Highway A1 stores operate on; and</li>
-<li>
-<p>business assets including goodwill, fixtures, fittings and all licences involved with the Liquor Legends Berserker and Liquor Legends Highway A1 stores.</p>
-</li>
-</ul>
-
-<p>The Star Hotels Group is an independently owned and operated hospitality group, primarily operating pubs along the eastern seaboard of Queensland with 4 venues in South Australia. It operates multiple licensed venues and liquor retail outlets under brands such as Star Liquor, Sense of Taste and Bob’s Bulk Booze, as well as accommodation at selected venues.</p>
-
-<p>Liquor Legends Berserker and Liquor Legends Highway A1 are bottle shop businesses which are located at 169 High Street, Berserker, QLD 4701 and 86 Derby Street, Rockhampton, QLD 4700, respectively. These outlets sell a range of alcoholic beverages to retail customers. Liquor Legends Berserker and Liquor Legends Highway A1 Liquor are currently owned and operated by The Trustee for The Garden Holdings Trust.</p>
+<p>Ironbark has a business division which provides financial advice to retail and wholesale clients. Viola Group focuses on private wealth and high net worth clients.</p>
 
   </div>
       <a href="#" class="read-toggle" data-expanded="true">read more</a>

--- a/data/raw/matters/MN-01016.html
+++ b/data/raw/matters/MN-01016.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2025-09-05T09:00:27+10:00" />
 <meta name="dcterms.created" content="2025-08-18T10:58:49+10:00" />
+<meta name="dcterms.modified" content="2025-09-05T09:00:27+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-01017.html
+++ b/data/raw/matters/MN-01017.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2025-08-29T11:39:42+10:00" />
 <meta name="dcterms.created" content="2025-08-11T10:39:59+10:00" />
+<meta name="dcterms.modified" content="2025-08-29T11:39:42+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-01019.html
+++ b/data/raw/matters/MN-01019.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-21T12:43:30+10:00" />
 <meta name="dcterms.created" content="2025-10-13T16:50:57+11:00" />
+<meta name="dcterms.modified" content="2026-04-21T12:43:30+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-01031.html
+++ b/data/raw/matters/MN-01031.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2025-11-26T14:15:53+11:00" />
 <meta name="dcterms.created" content="2025-10-30T12:01:32+11:00" />
+<meta name="dcterms.modified" content="2025-11-26T14:15:53+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-01035.html
+++ b/data/raw/matters/MN-01035.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2025-11-18T17:22:00+11:00" />
 <meta name="dcterms.created" content="2025-10-27T14:53:19+11:00" />
+<meta name="dcterms.modified" content="2025-11-18T17:22:00+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-01037.html
+++ b/data/raw/matters/MN-01037.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2025-11-18T16:08:38+11:00" />
 <meta name="dcterms.created" content="2025-10-27T16:11:37+11:00" />
+<meta name="dcterms.modified" content="2025-11-18T16:08:38+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-01058.html
+++ b/data/raw/matters/MN-01058.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2025-12-18T17:53:27+11:00" />
 <meta name="dcterms.created" content="2025-11-11T17:56:02+11:00" />
+<meta name="dcterms.modified" content="2025-12-18T17:53:27+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-01061.html
+++ b/data/raw/matters/MN-01061.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2025-12-05T08:54:58+11:00" />
 <meta name="dcterms.created" content="2025-11-14T08:54:40+11:00" />
+<meta name="dcterms.modified" content="2025-12-05T08:54:58+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-01064.html
+++ b/data/raw/matters/MN-01064.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2025-12-18T13:50:40+11:00" />
 <meta name="dcterms.created" content="2025-11-27T16:52:18+11:00" />
+<meta name="dcterms.modified" content="2025-12-18T13:50:40+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-01068.html
+++ b/data/raw/matters/MN-01068.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-06T16:10:40+11:00" />
 <meta name="dcterms.created" content="2025-11-28T13:51:15+11:00" />
+<meta name="dcterms.modified" content="2026-03-06T16:10:40+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-01069.html
+++ b/data/raw/matters/MN-01069.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-01-29T16:35:44+11:00" />
 <meta name="dcterms.created" content="2025-12-15T16:03:58+11:00" />
+<meta name="dcterms.modified" content="2026-01-29T16:35:44+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-01071.html
+++ b/data/raw/matters/MN-01071.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-03T12:06:27+11:00" />
 <meta name="dcterms.created" content="2026-01-12T10:46:39+11:00" />
+<meta name="dcterms.modified" content="2026-02-03T12:06:27+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-01074.html
+++ b/data/raw/matters/MN-01074.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-26T15:17:05+11:00" />
 <meta name="dcterms.created" content="2026-01-21T11:12:48+11:00" />
+<meta name="dcterms.modified" content="2026-02-26T15:17:05+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-01075.html
+++ b/data/raw/matters/MN-01075.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-10T12:44:10+11:00" />
 <meta name="dcterms.created" content="2026-01-19T12:21:40+11:00" />
+<meta name="dcterms.modified" content="2026-02-10T12:44:10+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-01080.html
+++ b/data/raw/matters/MN-01080.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-11T09:29:05+11:00" />
 <meta name="dcterms.created" content="2026-01-16T11:18:03+11:00" />
+<meta name="dcterms.modified" content="2026-02-11T09:29:05+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-01083.html
+++ b/data/raw/matters/MN-01083.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-02T14:28:37+11:00" />
 <meta name="dcterms.created" content="2026-02-26T15:49:22+11:00" />
+<meta name="dcterms.modified" content="2026-04-02T14:28:37+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-01090.html
+++ b/data/raw/matters/MN-01090.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-10T10:40:04+10:00" />
 <meta name="dcterms.created" content="2026-03-12T14:16:34+11:00" />
+<meta name="dcterms.modified" content="2026-04-10T10:40:04+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-01093.html
+++ b/data/raw/matters/MN-01093.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-07T12:28:24+10:00" />
 <meta name="dcterms.created" content="2026-03-27T15:11:17+11:00" />
+<meta name="dcterms.modified" content="2026-04-07T12:28:24+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-05004.html
+++ b/data/raw/matters/MN-05004.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-09T17:47:13+10:00" />
 <meta name="dcterms.created" content="2026-03-16T17:19:30+11:00" />
+<meta name="dcterms.modified" content="2026-04-09T17:47:13+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-05012.html
+++ b/data/raw/matters/MN-05012.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-10T15:50:44+10:00" />
 <meta name="dcterms.created" content="2026-04-01T14:50:50+11:00" />
+<meta name="dcterms.modified" content="2026-04-10T15:50:44+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-10001.html
+++ b/data/raw/matters/MN-10001.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-03T14:40:04+11:00" />
 <meta name="dcterms.created" content="2026-02-05T11:20:43+11:00" />
+<meta name="dcterms.modified" content="2026-03-03T14:40:04+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-10005.html
+++ b/data/raw/matters/MN-10005.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-12T11:27:44+11:00" />
 <meta name="dcterms.created" content="2026-02-17T15:04:41+11:00" />
+<meta name="dcterms.modified" content="2026-03-12T11:27:44+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-10006.html
+++ b/data/raw/matters/MN-10006.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-03T13:07:04+11:00" />
 <meta name="dcterms.created" content="2026-02-09T14:55:48+11:00" />
+<meta name="dcterms.modified" content="2026-03-03T13:07:04+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-10012.html
+++ b/data/raw/matters/MN-10012.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-21T13:51:00+10:00" />
 <meta name="dcterms.created" content="2026-04-21T12:53:10+10:00" />
+<meta name="dcterms.modified" content="2026-04-21T13:51:00+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-10013.html
+++ b/data/raw/matters/MN-10013.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-17T16:30:07+10:00" />
 <meta name="dcterms.created" content="2026-04-17T16:19:32+10:00" />
+<meta name="dcterms.modified" content="2026-04-17T16:30:07+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-15002.html
+++ b/data/raw/matters/MN-15002.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-19T17:11:53+11:00" />
 <meta name="dcterms.created" content="2026-01-12T13:26:15+11:00" />
+<meta name="dcterms.modified" content="2026-02-19T17:11:53+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-15005.html
+++ b/data/raw/matters/MN-15005.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-17T13:21:43+11:00" />
 <meta name="dcterms.created" content="2026-02-23T11:32:45+11:00" />
+<meta name="dcterms.modified" content="2026-03-17T13:21:43+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-15011.html
+++ b/data/raw/matters/MN-15011.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-13T16:08:34+10:00" />
 <meta name="dcterms.created" content="2026-04-02T14:40:51+11:00" />
+<meta name="dcterms.modified" content="2026-04-13T16:08:34+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-15013.html
+++ b/data/raw/matters/MN-15013.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-16T11:54:17+10:00" />
 <meta name="dcterms.created" content="2026-04-08T14:08:24+10:00" />
+<meta name="dcterms.modified" content="2026-04-16T11:54:17+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-20009.html
+++ b/data/raw/matters/MN-20009.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-01T14:49:08+11:00" />
 <meta name="dcterms.created" content="2026-03-12T13:28:03+11:00" />
+<meta name="dcterms.modified" content="2026-04-01T14:49:08+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-20011.html
+++ b/data/raw/matters/MN-20011.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-21T17:07:07+10:00" />
 <meta name="dcterms.created" content="2026-03-25T12:37:04+11:00" />
+<meta name="dcterms.modified" content="2026-04-21T17:07:07+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-20013.html
+++ b/data/raw/matters/MN-20013.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-16T11:14:22+10:00" />
 <meta name="dcterms.created" content="2026-04-09T14:14:21+10:00" />
+<meta name="dcterms.modified" content="2026-04-16T11:14:22+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-25002.html
+++ b/data/raw/matters/MN-25002.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-20T09:48:15+11:00" />
 <meta name="dcterms.created" content="2026-01-23T17:42:29+11:00" />
+<meta name="dcterms.modified" content="2026-02-20T09:48:15+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-25004.html
+++ b/data/raw/matters/MN-25004.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-12T16:37:10+11:00" />
 <meta name="dcterms.created" content="2026-02-16T11:47:07+11:00" />
+<meta name="dcterms.modified" content="2026-03-12T16:37:10+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-25006.html
+++ b/data/raw/matters/MN-25006.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-07T13:15:28+10:00" />
 <meta name="dcterms.created" content="2026-03-13T12:30:16+11:00" />
+<meta name="dcterms.modified" content="2026-04-07T13:15:28+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-30002.html
+++ b/data/raw/matters/MN-30002.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-07T15:03:09+10:00" />
 <meta name="dcterms.created" content="2026-03-05T17:23:53+11:00" />
+<meta name="dcterms.modified" content="2026-04-07T15:03:09+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-30003.html
+++ b/data/raw/matters/MN-30003.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-21T14:20:17+10:00" />
 <meta name="dcterms.created" content="2026-02-09T14:50:18+11:00" />
+<meta name="dcterms.modified" content="2026-04-21T14:20:17+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-30005.html
+++ b/data/raw/matters/MN-30005.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-13T15:47:05+10:00" />
 <meta name="dcterms.created" content="2026-03-17T17:43:02+11:00" />
+<meta name="dcterms.modified" content="2026-04-13T15:47:05+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-30009.html
+++ b/data/raw/matters/MN-30009.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-17T16:14:05+10:00" />
 <meta name="dcterms.created" content="2026-04-17T14:38:49+10:00" />
+<meta name="dcterms.modified" content="2026-04-17T16:14:05+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-35013.html
+++ b/data/raw/matters/MN-35013.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-20T16:25:54+10:00" />
 <meta name="dcterms.created" content="2026-04-13T14:52:41+10:00" />
+<meta name="dcterms.modified" content="2026-04-20T16:25:54+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-40005.html
+++ b/data/raw/matters/MN-40005.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-12T12:24:22+11:00" />
 <meta name="dcterms.created" content="2026-02-19T16:45:08+11:00" />
+<meta name="dcterms.modified" content="2026-03-12T12:24:22+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-40008.html
+++ b/data/raw/matters/MN-40008.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-16T16:08:25+10:00" />
 <meta name="dcterms.created" content="2026-03-24T11:14:23+11:00" />
+<meta name="dcterms.modified" content="2026-04-16T16:08:25+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-40009.html
+++ b/data/raw/matters/MN-40009.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-13T17:07:35+10:00" />
 <meta name="dcterms.created" content="2026-03-19T12:06:37+11:00" />
+<meta name="dcterms.modified" content="2026-04-13T17:07:35+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-40012.html
+++ b/data/raw/matters/MN-40012.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-21T17:07:49+10:00" />
 <meta name="dcterms.created" content="2026-04-14T16:57:12+10:00" />
+<meta name="dcterms.modified" content="2026-04-21T17:07:49+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-40015.html
+++ b/data/raw/matters/MN-40015.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-17T12:13:44+10:00" />
 <meta name="dcterms.created" content="2026-04-10T14:50:14+10:00" />
+<meta name="dcterms.modified" content="2026-04-17T12:13:44+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-45002.html
+++ b/data/raw/matters/MN-45002.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-15T12:13:13+10:00" />
 <meta name="dcterms.created" content="2026-04-07T11:08:29+10:00" />
+<meta name="dcterms.modified" content="2026-04-15T12:13:13+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-45005.html
+++ b/data/raw/matters/MN-45005.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-17T14:30:20+10:00" />
 <meta name="dcterms.created" content="2026-03-25T16:11:44+11:00" />
+<meta name="dcterms.modified" content="2026-04-17T14:30:20+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-50007.html
+++ b/data/raw/matters/MN-50007.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-07T14:42:53+10:00" />
 <meta name="dcterms.created" content="2026-03-16T10:39:24+11:00" />
+<meta name="dcterms.modified" content="2026-04-07T14:42:53+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-50012.html
+++ b/data/raw/matters/MN-50012.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-13T17:51:27+10:00" />
 <meta name="dcterms.created" content="2026-03-19T15:40:24+11:00" />
+<meta name="dcterms.modified" content="2026-04-13T17:51:27+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-55003.html
+++ b/data/raw/matters/MN-55003.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-24T12:53:55+11:00" />
 <meta name="dcterms.created" content="2026-02-04T15:45:57+11:00" />
+<meta name="dcterms.modified" content="2026-02-24T12:53:55+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-55006.html
+++ b/data/raw/matters/MN-55006.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-17T17:37:17+11:00" />
 <meta name="dcterms.created" content="2026-02-19T17:04:57+11:00" />
+<meta name="dcterms.modified" content="2026-03-17T17:37:17+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-55010.html
+++ b/data/raw/matters/MN-55010.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-08T16:06:54+10:00" />
 <meta name="dcterms.created" content="2026-03-30T14:46:55+11:00" />
+<meta name="dcterms.modified" content="2026-04-08T16:06:54+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-55012.html
+++ b/data/raw/matters/MN-55012.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-01T12:17:52+11:00" />
 <meta name="dcterms.created" content="2026-03-10T16:38:02+11:00" />
+<meta name="dcterms.modified" content="2026-04-01T12:17:52+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-55013.html
+++ b/data/raw/matters/MN-55013.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-21T10:08:30+10:00" />
 <meta name="dcterms.created" content="2026-04-13T14:27:40+10:00" />
+<meta name="dcterms.modified" content="2026-04-21T10:08:30+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-55016.html
+++ b/data/raw/matters/MN-55016.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-22T09:28:40+10:00" />
 <meta name="dcterms.created" content="2026-04-22T09:20:38+10:00" />
+<meta name="dcterms.modified" content="2026-04-22T09:28:40+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-60004.html
+++ b/data/raw/matters/MN-60004.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-25T11:05:41+11:00" />
 <meta name="dcterms.created" content="2026-02-27T09:47:08+11:00" />
+<meta name="dcterms.modified" content="2026-03-25T11:05:41+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-60007.html
+++ b/data/raw/matters/MN-60007.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-19T12:04:41+11:00" />
 <meta name="dcterms.created" content="2026-02-23T13:54:53+11:00" />
+<meta name="dcterms.modified" content="2026-03-19T12:04:41+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-65005.html
+++ b/data/raw/matters/MN-65005.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-17T09:21:28+10:00" />
 <meta name="dcterms.created" content="2026-03-04T16:56:47+11:00" />
+<meta name="dcterms.modified" content="2026-04-17T09:21:28+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-65007.html
+++ b/data/raw/matters/MN-65007.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-17T12:07:54+11:00" />
 <meta name="dcterms.created" content="2026-02-24T12:30:13+11:00" />
+<meta name="dcterms.modified" content="2026-03-17T12:07:54+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-65008.html
+++ b/data/raw/matters/MN-65008.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-15T16:28:26+10:00" />
 <meta name="dcterms.created" content="2026-04-08T15:24:08+10:00" />
+<meta name="dcterms.modified" content="2026-04-15T16:28:26+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-65009.html
+++ b/data/raw/matters/MN-65009.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-16T17:13:43+10:00" />
 <meta name="dcterms.created" content="2026-03-19T14:19:19+11:00" />
+<meta name="dcterms.modified" content="2026-04-16T17:13:43+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-70005.html
+++ b/data/raw/matters/MN-70005.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-12T18:05:50+11:00" />
 <meta name="dcterms.created" content="2026-02-09T17:26:41+11:00" />
+<meta name="dcterms.modified" content="2026-03-12T18:05:50+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-70013.html
+++ b/data/raw/matters/MN-70013.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-16T16:46:03+10:00" />
 <meta name="dcterms.created" content="2026-04-16T16:33:20+10:00" />
+<meta name="dcterms.modified" content="2026-04-16T16:46:03+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-70014.html
+++ b/data/raw/matters/MN-70014.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-17T14:58:39+10:00" />
 <meta name="dcterms.created" content="2026-04-17T14:06:01+10:00" />
+<meta name="dcterms.modified" content="2026-04-17T14:58:39+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-75002.html
+++ b/data/raw/matters/MN-75002.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-10T16:24:51+11:00" />
 <meta name="dcterms.created" content="2026-01-20T10:17:49+11:00" />
+<meta name="dcterms.modified" content="2026-02-10T16:24:51+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-75003.html
+++ b/data/raw/matters/MN-75003.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-12T17:10:36+11:00" />
 <meta name="dcterms.created" content="2026-01-22T16:35:26+11:00" />
+<meta name="dcterms.modified" content="2026-02-12T17:10:36+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-75004.html
+++ b/data/raw/matters/MN-75004.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-10T17:20:58+11:00" />
 <meta name="dcterms.created" content="2026-02-06T12:12:44+11:00" />
+<meta name="dcterms.modified" content="2026-03-10T17:20:58+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-75009.html
+++ b/data/raw/matters/MN-75009.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-20T12:31:56+11:00" />
 <meta name="dcterms.created" content="2026-02-18T16:06:30+11:00" />
+<meta name="dcterms.modified" content="2026-03-20T12:31:56+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-75012.html
+++ b/data/raw/matters/MN-75012.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-13T14:41:36+10:00" />
 <meta name="dcterms.created" content="2026-03-20T09:32:48+11:00" />
+<meta name="dcterms.modified" content="2026-04-13T14:41:36+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-80002.html
+++ b/data/raw/matters/MN-80002.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-03T14:10:12+11:00" />
 <meta name="dcterms.created" content="2026-02-06T14:11:04+11:00" />
+<meta name="dcterms.modified" content="2026-03-03T14:10:12+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-80004.html
+++ b/data/raw/matters/MN-80004.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-17T11:46:00+11:00" />
 <meta name="dcterms.created" content="2026-02-20T15:49:02+11:00" />
+<meta name="dcterms.modified" content="2026-03-17T11:46:00+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-85002.html
+++ b/data/raw/matters/MN-85002.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-10T15:42:30+11:00" />
 <meta name="dcterms.created" content="2025-12-23T12:07:24+11:00" />
+<meta name="dcterms.modified" content="2026-02-10T15:42:30+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-85003.html
+++ b/data/raw/matters/MN-85003.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-19T12:58:20+11:00" />
 <meta name="dcterms.created" content="2026-01-30T12:25:56+11:00" />
+<meta name="dcterms.modified" content="2026-03-19T12:58:20+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-85006.html
+++ b/data/raw/matters/MN-85006.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-07T14:19:23+10:00" />
 <meta name="dcterms.created" content="2026-03-27T13:50:46+11:00" />
+<meta name="dcterms.modified" content="2026-04-07T14:19:23+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-85007.html
+++ b/data/raw/matters/MN-85007.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-17T14:06:31+11:00" />
 <meta name="dcterms.created" content="2026-02-19T13:07:30+11:00" />
+<meta name="dcterms.modified" content="2026-03-17T14:06:31+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-90006.html
+++ b/data/raw/matters/MN-90006.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-31T12:15:53+11:00" />
 <meta name="dcterms.created" content="2026-03-06T13:46:57+11:00" />
+<meta name="dcterms.modified" content="2026-03-31T12:15:53+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-90009.html
+++ b/data/raw/matters/MN-90009.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-21T16:06:23+10:00" />
 <meta name="dcterms.created" content="2026-04-14T16:41:50+10:00" />
+<meta name="dcterms.modified" content="2026-04-21T16:06:23+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-95001.html
+++ b/data/raw/matters/MN-95001.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-16T08:22:54+10:00" />
 <meta name="dcterms.created" content="2026-02-13T13:14:57+11:00" />
+<meta name="dcterms.modified" content="2026-04-16T08:22:54+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-95002.html
+++ b/data/raw/matters/MN-95002.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-24T15:38:43+11:00" />
 <meta name="dcterms.created" content="2026-02-02T14:31:25+11:00" />
+<meta name="dcterms.modified" content="2026-02-24T15:38:43+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-95003.html
+++ b/data/raw/matters/MN-95003.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-09T16:26:26+10:00" />
 <meta name="dcterms.created" content="2026-02-13T11:18:16+11:00" />
+<meta name="dcterms.modified" content="2026-04-09T16:26:26+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/MN-95011.html
+++ b/data/raw/matters/MN-95011.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-20T16:23:51+10:00" />
 <meta name="dcterms.created" content="2026-04-13T14:57:38+10:00" />
+<meta name="dcterms.modified" content="2026-04-20T16:23:51+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-01081.html
+++ b/data/raw/matters/WA-01081.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-01-20T17:53:47+11:00" />
 <meta name="dcterms.created" content="2026-01-20T16:42:26+11:00" />
+<meta name="dcterms.modified" content="2026-01-20T17:53:47+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-01087.html
+++ b/data/raw/matters/WA-01087.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-12T18:31:06+11:00" />
 <meta name="dcterms.created" content="2026-03-12T16:09:00+11:00" />
+<meta name="dcterms.modified" content="2026-03-12T18:31:06+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-01088.html
+++ b/data/raw/matters/WA-01088.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-06T20:07:56+11:00" />
 <meta name="dcterms.created" content="2026-03-06T19:56:12+11:00" />
+<meta name="dcterms.modified" content="2026-03-06T20:07:56+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-05003.html
+++ b/data/raw/matters/WA-05003.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-01-27T18:02:24+11:00" />
 <meta name="dcterms.created" content="2026-01-27T17:00:09+11:00" />
+<meta name="dcterms.modified" content="2026-01-27T18:02:24+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-05005.html
+++ b/data/raw/matters/WA-05005.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-09T18:24:25+10:00" />
 <meta name="dcterms.created" content="2026-04-09T16:55:41+10:00" />
+<meta name="dcterms.modified" content="2026-04-09T18:24:25+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-05007.html
+++ b/data/raw/matters/WA-05007.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-26T18:26:54+11:00" />
 <meta name="dcterms.created" content="2026-02-26T17:53:55+11:00" />
+<meta name="dcterms.modified" content="2026-02-26T18:26:54+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-05008.html
+++ b/data/raw/matters/WA-05008.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-06T19:17:18+11:00" />
 <meta name="dcterms.created" content="2026-03-06T19:04:44+11:00" />
+<meta name="dcterms.modified" content="2026-03-06T19:17:18+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-10002.html
+++ b/data/raw/matters/WA-10002.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-13T18:31:05+11:00" />
 <meta name="dcterms.created" content="2026-02-13T18:17:59+11:00" />
+<meta name="dcterms.modified" content="2026-02-13T18:31:05+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-10008.html
+++ b/data/raw/matters/WA-10008.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-13T16:44:43+11:00" />
 <meta name="dcterms.created" content="2026-03-12T16:26:43+11:00" />
+<meta name="dcterms.modified" content="2026-03-13T16:44:43+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-10009.html
+++ b/data/raw/matters/WA-10009.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-24T18:12:00+11:00" />
 <meta name="dcterms.created" content="2026-03-24T17:49:13+11:00" />
+<meta name="dcterms.modified" content="2026-03-24T18:12:00+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-10010.html
+++ b/data/raw/matters/WA-10010.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-07T17:09:01+10:00" />
 <meta name="dcterms.created" content="2026-04-07T16:56:10+10:00" />
+<meta name="dcterms.modified" content="2026-04-07T17:09:01+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-10011.html
+++ b/data/raw/matters/WA-10011.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-07T19:09:20+10:00" />
 <meta name="dcterms.created" content="2026-04-07T17:44:41+10:00" />
+<meta name="dcterms.modified" content="2026-04-07T19:09:20+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-15003.html
+++ b/data/raw/matters/WA-15003.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-13T18:15:28+11:00" />
 <meta name="dcterms.created" content="2026-02-13T17:54:17+11:00" />
+<meta name="dcterms.modified" content="2026-02-13T18:15:28+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-15004.html
+++ b/data/raw/matters/WA-15004.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-20T18:33:32+11:00" />
 <meta name="dcterms.created" content="2026-02-20T17:55:26+11:00" />
+<meta name="dcterms.modified" content="2026-02-20T18:33:32+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-15007.html
+++ b/data/raw/matters/WA-15007.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-19T18:52:09+11:00" />
 <meta name="dcterms.created" content="2026-02-19T18:19:29+11:00" />
+<meta name="dcterms.modified" content="2026-02-19T18:52:09+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-15008.html
+++ b/data/raw/matters/WA-15008.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-25T17:22:14+11:00" />
 <meta name="dcterms.created" content="2026-02-25T16:27:08+11:00" />
+<meta name="dcterms.modified" content="2026-02-25T17:22:14+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-15009.html
+++ b/data/raw/matters/WA-15009.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-20T16:34:34+11:00" />
 <meta name="dcterms.created" content="2026-03-20T16:13:12+11:00" />
+<meta name="dcterms.modified" content="2026-03-20T16:34:34+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-15010.html
+++ b/data/raw/matters/WA-15010.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-24T18:32:16+11:00" />
 <meta name="dcterms.created" content="2026-03-24T18:14:48+11:00" />
+<meta name="dcterms.modified" content="2026-03-24T18:32:16+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-15012.html
+++ b/data/raw/matters/WA-15012.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-07T19:16:55+10:00" />
 <meta name="dcterms.created" content="2026-04-07T19:00:45+10:00" />
+<meta name="dcterms.modified" content="2026-04-07T19:16:55+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-20003.html
+++ b/data/raw/matters/WA-20003.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-01-30T17:04:46+11:00" />
 <meta name="dcterms.created" content="2026-01-30T16:48:27+11:00" />
+<meta name="dcterms.modified" content="2026-01-30T17:04:46+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-20005.html
+++ b/data/raw/matters/WA-20005.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-12T19:50:43+11:00" />
 <meta name="dcterms.created" content="2026-02-12T18:43:21+11:00" />
+<meta name="dcterms.modified" content="2026-02-12T19:50:43+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-20007.html
+++ b/data/raw/matters/WA-20007.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-19T18:15:59+11:00" />
 <meta name="dcterms.created" content="2026-03-19T17:23:21+11:00" />
+<meta name="dcterms.modified" content="2026-03-19T18:15:59+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-20008.html
+++ b/data/raw/matters/WA-20008.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-24T18:19:17+11:00" />
 <meta name="dcterms.created" content="2026-03-24T18:03:28+11:00" />
+<meta name="dcterms.modified" content="2026-03-24T18:19:17+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-20010.html
+++ b/data/raw/matters/WA-20010.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-19T18:09:33+11:00" />
 <meta name="dcterms.created" content="2026-03-19T17:41:14+11:00" />
+<meta name="dcterms.modified" content="2026-03-19T18:09:33+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-25001.html
+++ b/data/raw/matters/WA-25001.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-05T17:25:20+11:00" />
 <meta name="dcterms.created" content="2026-02-05T17:12:48+11:00" />
+<meta name="dcterms.modified" content="2026-02-05T17:25:20+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-25003.html
+++ b/data/raw/matters/WA-25003.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-03T17:33:20+11:00" />
 <meta name="dcterms.created" content="2026-02-03T13:23:44+11:00" />
+<meta name="dcterms.modified" content="2026-02-03T17:33:20+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-25005.html
+++ b/data/raw/matters/WA-25005.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-09T17:36:29+11:00" />
 <meta name="dcterms.created" content="2026-02-09T17:10:17+11:00" />
+<meta name="dcterms.modified" content="2026-02-09T17:36:29+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-25008.html
+++ b/data/raw/matters/WA-25008.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-24T18:16:26+11:00" />
 <meta name="dcterms.created" content="2026-03-24T17:54:04+11:00" />
+<meta name="dcterms.modified" content="2026-03-24T18:16:26+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-25009.html
+++ b/data/raw/matters/WA-25009.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-08T17:36:06+10:00" />
 <meta name="dcterms.created" content="2026-04-08T17:28:36+10:00" />
+<meta name="dcterms.modified" content="2026-04-08T17:36:06+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-25010.html
+++ b/data/raw/matters/WA-25010.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-16T17:23:04+10:00" />
 <meta name="dcterms.created" content="2026-04-16T17:08:07+10:00" />
+<meta name="dcterms.modified" content="2026-04-16T17:23:04+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-25011.html
+++ b/data/raw/matters/WA-25011.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-07T17:29:32+10:00" />
 <meta name="dcterms.created" content="2026-04-07T17:17:47+10:00" />
+<meta name="dcterms.modified" content="2026-04-07T17:29:32+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-25013.html
+++ b/data/raw/matters/WA-25013.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-01T18:46:07+11:00" />
 <meta name="dcterms.created" content="2026-04-01T18:39:52+11:00" />
+<meta name="dcterms.modified" content="2026-04-01T18:46:07+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-25014.html
+++ b/data/raw/matters/WA-25014.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-07T17:26:00+10:00" />
 <meta name="dcterms.created" content="2026-04-07T17:06:43+10:00" />
+<meta name="dcterms.modified" content="2026-04-07T17:26:00+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-35001.html
+++ b/data/raw/matters/WA-35001.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-01-13T11:25:23+11:00" />
 <meta name="dcterms.created" content="2026-01-13T10:20:56+11:00" />
+<meta name="dcterms.modified" content="2026-01-13T11:25:23+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-35002.html
+++ b/data/raw/matters/WA-35002.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-01-27T16:34:12+11:00" />
 <meta name="dcterms.created" content="2026-01-27T16:19:09+11:00" />
+<meta name="dcterms.modified" content="2026-01-27T16:34:12+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-35003.html
+++ b/data/raw/matters/WA-35003.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-01-21T09:04:10+11:00" />
 <meta name="dcterms.created" content="2026-01-20T17:50:23+11:00" />
+<meta name="dcterms.modified" content="2026-01-21T09:04:10+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-35004.html
+++ b/data/raw/matters/WA-35004.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-04T16:44:51+11:00" />
 <meta name="dcterms.created" content="2026-02-04T16:38:56+11:00" />
+<meta name="dcterms.modified" content="2026-02-04T16:44:51+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-35005.html
+++ b/data/raw/matters/WA-35005.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-24T19:17:24+11:00" />
 <meta name="dcterms.created" content="2026-02-24T18:33:20+11:00" />
+<meta name="dcterms.modified" content="2026-02-24T19:17:24+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-35008.html
+++ b/data/raw/matters/WA-35008.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-26T22:13:05+11:00" />
 <meta name="dcterms.created" content="2026-03-26T19:40:37+11:00" />
+<meta name="dcterms.modified" content="2026-03-26T22:13:05+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-35010.html
+++ b/data/raw/matters/WA-35010.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-24T18:28:24+11:00" />
 <meta name="dcterms.created" content="2026-03-24T18:10:16+11:00" />
+<meta name="dcterms.modified" content="2026-03-24T18:28:24+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-35011.html
+++ b/data/raw/matters/WA-35011.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-07T17:36:44+10:00" />
 <meta name="dcterms.created" content="2026-04-07T17:28:00+10:00" />
+<meta name="dcterms.modified" content="2026-04-07T17:36:44+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-40002.html
+++ b/data/raw/matters/WA-40002.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-03T10:08:37+11:00" />
 <meta name="dcterms.created" content="2026-02-02T17:05:11+11:00" />
+<meta name="dcterms.modified" content="2026-02-03T10:08:37+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-40003.html
+++ b/data/raw/matters/WA-40003.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-01-30T17:11:06+11:00" />
 <meta name="dcterms.created" content="2026-01-30T16:58:35+11:00" />
+<meta name="dcterms.modified" content="2026-01-30T17:11:06+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-40004.html
+++ b/data/raw/matters/WA-40004.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-12T18:10:44+11:00" />
 <meta name="dcterms.created" content="2026-02-12T17:49:36+11:00" />
+<meta name="dcterms.modified" content="2026-02-12T18:10:44+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-40010.html
+++ b/data/raw/matters/WA-40010.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-01T18:43:03+11:00" />
 <meta name="dcterms.created" content="2026-04-01T17:36:56+11:00" />
+<meta name="dcterms.modified" content="2026-04-01T18:43:03+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-40011.html
+++ b/data/raw/matters/WA-40011.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-07T17:43:00+10:00" />
 <meta name="dcterms.created" content="2026-04-07T17:36:44+10:00" />
+<meta name="dcterms.modified" content="2026-04-07T17:43:00+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-40014.html
+++ b/data/raw/matters/WA-40014.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-17T16:42:02+10:00" />
 <meta name="dcterms.created" content="2026-04-17T16:14:56+10:00" />
+<meta name="dcterms.modified" content="2026-04-17T16:42:02+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-45001.html
+++ b/data/raw/matters/WA-45001.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-16T18:35:23+11:00" />
 <meta name="dcterms.created" content="2026-02-16T18:23:06+11:00" />
+<meta name="dcterms.modified" content="2026-02-16T18:35:23+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-45003.html
+++ b/data/raw/matters/WA-45003.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-11T18:33:16+11:00" />
 <meta name="dcterms.created" content="2026-03-11T18:27:33+11:00" />
+<meta name="dcterms.modified" content="2026-03-11T18:33:16+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-45007.html
+++ b/data/raw/matters/WA-45007.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-07T18:12:37+10:00" />
 <meta name="dcterms.created" content="2026-04-07T18:06:00+10:00" />
+<meta name="dcterms.modified" content="2026-04-07T18:12:37+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-45009.html
+++ b/data/raw/matters/WA-45009.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-10T17:06:36+10:00" />
 <meta name="dcterms.created" content="2026-04-10T16:56:47+10:00" />
+<meta name="dcterms.modified" content="2026-04-10T17:06:36+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-45011.html
+++ b/data/raw/matters/WA-45011.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-16T17:19:44+10:00" />
 <meta name="dcterms.created" content="2026-04-16T16:21:52+10:00" />
+<meta name="dcterms.modified" content="2026-04-16T17:19:44+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-50003.html
+++ b/data/raw/matters/WA-50003.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-20T18:41:18+11:00" />
 <meta name="dcterms.created" content="2026-02-20T18:25:36+11:00" />
+<meta name="dcterms.modified" content="2026-02-20T18:41:18+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-50005.html
+++ b/data/raw/matters/WA-50005.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-06T19:40:13+11:00" />
 <meta name="dcterms.created" content="2026-03-06T19:30:22+11:00" />
+<meta name="dcterms.modified" content="2026-03-06T19:40:13+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-50006.html
+++ b/data/raw/matters/WA-50006.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-19T18:39:40+11:00" />
 <meta name="dcterms.created" content="2026-03-19T18:31:25+11:00" />
+<meta name="dcterms.modified" content="2026-03-19T18:39:40+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-50010.html
+++ b/data/raw/matters/WA-50010.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-01T18:38:46+11:00" />
 <meta name="dcterms.created" content="2026-04-01T17:52:18+11:00" />
+<meta name="dcterms.modified" content="2026-04-01T18:38:46+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-55004.html
+++ b/data/raw/matters/WA-55004.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-10T16:00:35+11:00" />
 <meta name="dcterms.created" content="2026-02-10T15:35:21+11:00" />
+<meta name="dcterms.modified" content="2026-02-10T16:00:35+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-55005.html
+++ b/data/raw/matters/WA-55005.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-19T18:12:02+11:00" />
 <meta name="dcterms.created" content="2026-02-19T16:18:34+11:00" />
+<meta name="dcterms.modified" content="2026-02-19T18:12:02+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-55009.html
+++ b/data/raw/matters/WA-55009.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-11T18:58:29+11:00" />
 <meta name="dcterms.created" content="2026-03-11T18:46:09+11:00" />
+<meta name="dcterms.modified" content="2026-03-11T18:58:29+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-55011.html
+++ b/data/raw/matters/WA-55011.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-16T18:20:16+11:00" />
 <meta name="dcterms.created" content="2026-03-16T18:06:03+11:00" />
+<meta name="dcterms.modified" content="2026-03-16T18:20:16+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-55014.html
+++ b/data/raw/matters/WA-55014.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-07T19:07:11+10:00" />
 <meta name="dcterms.created" content="2026-04-07T18:27:53+10:00" />
+<meta name="dcterms.modified" content="2026-04-07T19:07:11+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-60006.html
+++ b/data/raw/matters/WA-60006.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-01-29T17:03:58+11:00" />
 <meta name="dcterms.created" content="2026-01-29T15:37:33+11:00" />
+<meta name="dcterms.modified" content="2026-01-29T17:03:58+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-60008.html
+++ b/data/raw/matters/WA-60008.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-01-30T18:10:49+11:00" />
 <meta name="dcterms.created" content="2026-01-30T17:20:16+11:00" />
+<meta name="dcterms.modified" content="2026-01-30T18:10:49+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-60010.html
+++ b/data/raw/matters/WA-60010.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-27T18:22:20+11:00" />
 <meta name="dcterms.created" content="2026-03-27T18:12:39+11:00" />
+<meta name="dcterms.modified" content="2026-03-27T18:22:20+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-65003.html
+++ b/data/raw/matters/WA-65003.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-05T17:37:16+11:00" />
 <meta name="dcterms.created" content="2026-02-05T17:25:11+11:00" />
+<meta name="dcterms.modified" content="2026-02-05T17:37:16+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-65004.html
+++ b/data/raw/matters/WA-65004.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-13T17:48:41+11:00" />
 <meta name="dcterms.created" content="2026-02-13T17:34:40+11:00" />
+<meta name="dcterms.modified" content="2026-02-13T17:48:41+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-65010.html
+++ b/data/raw/matters/WA-65010.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-01T16:47:19+11:00" />
 <meta name="dcterms.created" content="2026-04-01T16:28:54+11:00" />
+<meta name="dcterms.modified" content="2026-04-01T16:47:19+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-65011.html
+++ b/data/raw/matters/WA-65011.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-14T16:52:12+10:00" />
 <meta name="dcterms.created" content="2026-04-14T16:10:18+10:00" />
+<meta name="dcterms.modified" content="2026-04-14T16:52:12+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-70002.html
+++ b/data/raw/matters/WA-70002.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-01-13T11:27:41+11:00" />
 <meta name="dcterms.created" content="2026-01-13T11:12:33+11:00" />
+<meta name="dcterms.modified" content="2026-01-13T11:27:41+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-70003.html
+++ b/data/raw/matters/WA-70003.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-05T17:30:19+11:00" />
 <meta name="dcterms.created" content="2026-02-05T17:19:46+11:00" />
+<meta name="dcterms.modified" content="2026-02-05T17:30:19+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-70004.html
+++ b/data/raw/matters/WA-70004.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-26T17:25:08+11:00" />
 <meta name="dcterms.created" content="2026-02-26T17:10:46+11:00" />
+<meta name="dcterms.modified" content="2026-02-26T17:25:08+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-70006.html
+++ b/data/raw/matters/WA-70006.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-06T18:39:09+11:00" />
 <meta name="dcterms.created" content="2026-03-06T18:26:52+11:00" />
+<meta name="dcterms.modified" content="2026-03-06T18:39:09+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-70007.html
+++ b/data/raw/matters/WA-70007.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-06T19:00:57+11:00" />
 <meta name="dcterms.created" content="2026-03-06T18:39:43+11:00" />
+<meta name="dcterms.modified" content="2026-03-06T19:00:57+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-70008.html
+++ b/data/raw/matters/WA-70008.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-01T18:25:57+11:00" />
 <meta name="dcterms.created" content="2026-04-01T16:49:52+11:00" />
+<meta name="dcterms.modified" content="2026-04-01T18:25:57+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-70009.html
+++ b/data/raw/matters/WA-70009.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-26T22:08:46+11:00" />
 <meta name="dcterms.created" content="2026-03-26T19:25:37+11:00" />
+<meta name="dcterms.modified" content="2026-03-26T22:08:46+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-70010.html
+++ b/data/raw/matters/WA-70010.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-02T17:22:24+11:00" />
 <meta name="dcterms.created" content="2026-04-02T15:56:54+11:00" />
+<meta name="dcterms.modified" content="2026-04-02T17:22:24+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-70011.html
+++ b/data/raw/matters/WA-70011.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-22T21:47:20+10:00" />
 <meta name="dcterms.created" content="2026-04-22T21:32:20+10:00" />
+<meta name="dcterms.modified" content="2026-04-22T21:47:20+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-75006.html
+++ b/data/raw/matters/WA-75006.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-19T18:09:05+11:00" />
 <meta name="dcterms.created" content="2026-02-19T17:43:22+11:00" />
+<meta name="dcterms.modified" content="2026-02-19T18:09:05+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-75008.html
+++ b/data/raw/matters/WA-75008.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-27T17:31:29+11:00" />
 <meta name="dcterms.created" content="2026-02-27T17:03:40+11:00" />
+<meta name="dcterms.modified" content="2026-02-27T17:31:29+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-75010.html
+++ b/data/raw/matters/WA-75010.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-06T18:30:43+11:00" />
 <meta name="dcterms.created" content="2026-03-06T18:16:16+11:00" />
+<meta name="dcterms.modified" content="2026-03-06T18:30:43+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-75011.html
+++ b/data/raw/matters/WA-75011.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-11T18:43:18+11:00" />
 <meta name="dcterms.created" content="2026-03-11T18:35:02+11:00" />
+<meta name="dcterms.modified" content="2026-03-11T18:43:18+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-75013.html
+++ b/data/raw/matters/WA-75013.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-01T18:32:38+11:00" />
 <meta name="dcterms.created" content="2026-04-01T17:07:26+11:00" />
+<meta name="dcterms.modified" content="2026-04-01T18:32:38+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-75015.html
+++ b/data/raw/matters/WA-75015.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-02T17:28:26+11:00" />
 <meta name="dcterms.created" content="2026-04-02T16:30:11+11:00" />
+<meta name="dcterms.modified" content="2026-04-02T17:28:26+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-75017.html
+++ b/data/raw/matters/WA-75017.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-07T19:13:23+10:00" />
 <meta name="dcterms.created" content="2026-04-07T18:37:07+10:00" />
+<meta name="dcterms.modified" content="2026-04-07T19:13:23+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-80001.html
+++ b/data/raw/matters/WA-80001.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-01-29T17:03:49+11:00" />
 <meta name="dcterms.created" content="2026-01-29T16:36:08+11:00" />
+<meta name="dcterms.modified" content="2026-01-29T17:03:49+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-80006.html
+++ b/data/raw/matters/WA-80006.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-12T18:36:38+11:00" />
 <meta name="dcterms.created" content="2026-03-12T16:39:37+11:00" />
+<meta name="dcterms.modified" content="2026-03-12T18:36:38+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-80007.html
+++ b/data/raw/matters/WA-80007.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-07T18:05:35+10:00" />
 <meta name="dcterms.created" content="2026-04-07T17:59:39+10:00" />
+<meta name="dcterms.modified" content="2026-04-07T18:05:35+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-80008.html
+++ b/data/raw/matters/WA-80008.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-21T18:09:55+10:00" />
 <meta name="dcterms.created" content="2026-04-21T17:34:01+10:00" />
+<meta name="dcterms.modified" content="2026-04-21T18:09:55+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-80009.html
+++ b/data/raw/matters/WA-80009.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-17T16:41:57+10:00" />
 <meta name="dcterms.created" content="2026-04-16T16:31:56+10:00" />
+<meta name="dcterms.modified" content="2026-04-17T16:41:57+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-85004.html
+++ b/data/raw/matters/WA-85004.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-01-27T18:09:51+11:00" />
 <meta name="dcterms.created" content="2026-01-27T17:44:11+11:00" />
+<meta name="dcterms.modified" content="2026-01-27T18:09:51+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-85005.html
+++ b/data/raw/matters/WA-85005.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-01-30T18:17:51+11:00" />
 <meta name="dcterms.created" content="2026-01-30T17:39:39+11:00" />
+<meta name="dcterms.modified" content="2026-01-30T18:17:51+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-85008.html
+++ b/data/raw/matters/WA-85008.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-19T17:57:38+11:00" />
 <meta name="dcterms.created" content="2026-02-19T17:07:09+11:00" />
+<meta name="dcterms.modified" content="2026-02-19T17:57:38+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-85011.html
+++ b/data/raw/matters/WA-85011.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-17T16:54:48+11:00" />
 <meta name="dcterms.created" content="2026-03-17T16:20:24+11:00" />
+<meta name="dcterms.modified" content="2026-03-17T16:54:48+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-85013.html
+++ b/data/raw/matters/WA-85013.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-10T19:25:43+11:00" />
 <meta name="dcterms.created" content="2026-03-10T19:16:46+11:00" />
+<meta name="dcterms.modified" content="2026-03-10T19:25:43+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-85014.html
+++ b/data/raw/matters/WA-85014.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-19T18:48:09+11:00" />
 <meta name="dcterms.created" content="2026-03-19T18:42:36+11:00" />
+<meta name="dcterms.modified" content="2026-03-19T18:48:09+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-85016.html
+++ b/data/raw/matters/WA-85016.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-14T17:04:50+10:00" />
 <meta name="dcterms.created" content="2026-04-14T16:14:20+10:00" />
+<meta name="dcterms.modified" content="2026-04-14T17:04:50+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-85017.html
+++ b/data/raw/matters/WA-85017.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-10T16:59:53+10:00" />
 <meta name="dcterms.created" content="2026-04-09T16:36:33+10:00" />
+<meta name="dcterms.modified" content="2026-04-10T16:59:53+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-85018.html
+++ b/data/raw/matters/WA-85018.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-10T17:03:25+10:00" />
 <meta name="dcterms.created" content="2026-04-10T16:48:14+10:00" />
+<meta name="dcterms.modified" content="2026-04-10T17:03:25+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-85020.html
+++ b/data/raw/matters/WA-85020.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-02T17:24:56+11:00" />
 <meta name="dcterms.created" content="2026-04-02T16:02:06+11:00" />
+<meta name="dcterms.modified" content="2026-04-02T17:24:56+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-85021.html
+++ b/data/raw/matters/WA-85021.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-13T17:49:56+10:00" />
 <meta name="dcterms.created" content="2026-04-13T17:25:08+10:00" />
+<meta name="dcterms.modified" content="2026-04-13T17:49:56+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-85022.html
+++ b/data/raw/matters/WA-85022.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-16T17:17:34+10:00" />
 <meta name="dcterms.created" content="2026-04-16T16:07:39+10:00" />
+<meta name="dcterms.modified" content="2026-04-16T17:17:34+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-90002.html
+++ b/data/raw/matters/WA-90002.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-25T18:08:12+11:00" />
 <meta name="dcterms.created" content="2026-02-24T17:12:03+11:00" />
+<meta name="dcterms.modified" content="2026-02-25T18:08:12+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-90004.html
+++ b/data/raw/matters/WA-90004.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-05T18:03:46+11:00" />
 <meta name="dcterms.created" content="2026-03-05T17:55:14+11:00" />
+<meta name="dcterms.modified" content="2026-03-05T18:03:46+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-90010.html
+++ b/data/raw/matters/WA-90010.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-20T18:01:43+10:00" />
 <meta name="dcterms.created" content="2026-04-20T17:40:01+10:00" />
+<meta name="dcterms.modified" content="2026-04-20T18:01:43+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-95005.html
+++ b/data/raw/matters/WA-95005.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-19T09:02:41+11:00" />
 <meta name="dcterms.created" content="2026-02-18T18:06:41+11:00" />
+<meta name="dcterms.modified" content="2026-02-19T09:02:41+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-95006.html
+++ b/data/raw/matters/WA-95006.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-02-20T17:54:20+11:00" />
 <meta name="dcterms.created" content="2026-02-20T17:04:49+11:00" />
+<meta name="dcterms.modified" content="2026-02-20T17:54:20+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-95008.html
+++ b/data/raw/matters/WA-95008.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-03-10T19:23:17+11:00" />
 <meta name="dcterms.created" content="2026-03-10T17:29:11+11:00" />
+<meta name="dcterms.modified" content="2026-03-10T19:23:17+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-95009.html
+++ b/data/raw/matters/WA-95009.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-01T18:35:29+11:00" />
 <meta name="dcterms.created" content="2026-04-01T17:24:01+11:00" />
+<meta name="dcterms.modified" content="2026-04-01T18:35:29+11:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-95010.html
+++ b/data/raw/matters/WA-95010.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-13T17:31:23+10:00" />
 <meta name="dcterms.created" content="2026-04-13T17:08:04+10:00" />
+<meta name="dcterms.modified" content="2026-04-13T17:31:23+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/data/raw/matters/WA-95012.html
+++ b/data/raw/matters/WA-95012.html
@@ -29,8 +29,8 @@
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
-<meta name="dcterms.modified" content="2026-04-07T19:24:00+10:00" />
 <meta name="dcterms.created" content="2026-04-07T19:14:01+10:00" />
+<meta name="dcterms.modified" content="2026-04-07T19:24:00+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />

--- a/scripts/scrape.sh
+++ b/scripts/scrape.sh
@@ -69,6 +69,10 @@ clean_file() {
   # The injection adds a whitespace-only line followed by the script on one line.
   perl -i -0pe 's/[ \t]*\n[ \t]*<script>!function\(e\)\{var n="https:\/\/s\.go-mpulse\.net\/boomerang\/".*?\(window\);<\/script><\/head>/\n  <\/head>/s' "$file"
 
+  # Normalize dcterms meta tag order: the ACCC website randomly swaps dcterms.created
+  # and dcterms.modified between requests, causing spurious diffs. Always put created first.
+  perl -i -0pe 's{(<meta name="dcterms\.modified"[^\n]*/>\n)(<meta name="dcterms\.created"[^\n]*/>\n)}{$2$1}g' "$file"
+
   # Use a second sed pass for complex multi-line replacements.
   sed -i -E -e ':a;N;$!ba;s#(<a[^>]*class="[^"]*megamenu-page-link-level-3[^"]*"[^>]*href=")[^"]*("[^>]*>[[:space:]]*<span>)[^<]*(</span>)#\1STATIC_HREF\2STATIC_TEXT\3#g' "$file"
 


### PR DESCRIPTION
This PR reduces noise in the git history by filtering out inconsequential changes during the scraping pipeline.

## Summary
The changes address two sources of spurious diffs when scraping the ACCC acquisitions register:

1. **Skip committing acquisitions-register.html alone**: The register HTML file changes frequently but doesn't contain meaningful new information—any actual updates (new mergers, status changes) are reflected in individual matter pages. The pipeline now unstages this file if it's the only thing that changed.

2. **Normalize dcterms meta tag order**: The ACCC website randomly reorders `dcterms.created` and `dcterms.modified` meta tags between requests, causing spurious diffs. The scraper now normalizes the order to always place `dcterms.created` before `dcterms.modified`.

## Key Changes
- **pipeline.yml**: Added logic to detect when only `acquisitions-register.html` has changed and unstage it, marking the step as unchanged
- **scrape.sh**: Added a Perl regex pass to normalize the order of dcterms meta tags, ensuring consistent output regardless of ACCC's tag ordering

These changes help keep the repository history clean by avoiding commits that don't represent actual substantive updates to the data.

https://claude.ai/code/session_01JoPJawDWTsSznoAgv9DB7U