### PR TITLE
Normalize canonical/shortlink link tag order in HTML files

### DIFF
--- a/data/raw/matters/MN-01016.html
+++ b/data/raw/matters/MN-01016.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Asahi will enter into an agreement for lease with GPT (as trustee of the Deer Park Industrial Trust (ABN 49 428 064 142)) in relation to certificate of title 12528 folio 733, being Lot 1 on plan of subdivision PS912165G, known as 179 Tilburn Road, Deer Park VIC 3023 (Property).  The Property is located in Precinct 2 of the proposed Deer Park Estate and is zoned as CZ2 – Commercial 2 Zone under the Brimbank planning scheme. It is located approximately 15 km west of the Melbourne CBD and is currently vacant. " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/asahi-%E2%80%93-warehouse-site-on-tilburn-rd-deer-park-vic" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/166465" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/asahi-%E2%80%93-warehouse-site-on-tilburn-rd-deer-park-vic" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-01017.html
+++ b/data/raw/matters/MN-01017.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Kongsberg Defence Australia Pty Ltd (KDAu), is proposing to enter into lease arrangements with Greater Newcastle Aerotropolis Pty Ltd (GNAPL) for land adjacent to Newcastle Airport, to establish a missile manufacturing and maintenance facility in Newcastle, NSW. KDau is indirectly wholly owned by Kongsberg Gruppen ASA (KOG). KOG is an international technology group that supplies high-technology systems and solutions to customers in the merchant marine, defence, aerospace, offshore oil and gas and renewable and utilities industries. KOG has operated in Australia since 2004." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/kongsberg-defence-%E2%80%93-site-within-newcastle-airport-precinct" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/166423" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/kongsberg-defence-%E2%80%93-site-within-newcastle-airport-precinct" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-01031.html
+++ b/data/raw/matters/MN-01031.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Caisse de dépôt et placement du Québec (La Caisse), through a wholly owned and controlled special purpose vehicle, C Renewables Australia Pty Ltd (C Renewables), proposes to acquire Edify New South Wales Landco Pty Ltd (Edify NSW) through a share sale agreement.  " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/la-caisse-%E2%80%93-edify-nsw-development-assets" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/166966" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/la-caisse-%E2%80%93-edify-nsw-development-assets" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-01035.html
+++ b/data/raw/matters/MN-01035.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Asahi Holdings (Australia) Pty Ltd (Asahi) will enter into an agreement for lease with GTA Industrial Custodian Pty Ltd (Goodman) (as trustee of Redbank River Park Industrial Trust) in relation to what is currently part of Lot 103 on SP 264643 in title reference 50958422 and Lot 202 on SP 320244 in title reference 51251794, known as 43 Weedman Street and 14 Montgomery Street, Redbank QLD 4301 (Property).  The Property forms part of the proposed Redbank Motorway Estate and is zoned as:" />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/asahi-%E2%80%93-warehouse-site-on-weedman-and-montgomery-streets-redbank-qld" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/166948" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/asahi-%E2%80%93-warehouse-site-on-weedman-and-montgomery-streets-redbank-qld" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-01037.html
+++ b/data/raw/matters/MN-01037.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Anglo American plc (Anglo American) proposes to acquire, through its affiliates and subsidiaries, the entire issued share capital of Teck Resources Limited (Teck Resources) by way of statutory plan of arrangement (similar to an Australian Scheme of Arrangement) to effect a merger between the parties." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/anglo-american-teck-resources" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/166949" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/anglo-american-teck-resources" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-01058.html
+++ b/data/raw/matters/MN-01058.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Caterpillar Inc (Caterpillar) proposes to acquire 100% of fully diluted share capital in RPMGlobal Holdings Limited (RPM) (ASX:RUL), through a scheme of arrangement.  Caterpillar is a global manufacturer of construction and mining equipment, off-highway diesel and natural gas engines, industrial gas turbines and diesel-electric locomotives. Caterpillar also supplies a range of different software products which interface with its equipment including MineStar for fleet track, VisionLink and CAT Foresight for asset management." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/caterpillar-%E2%80%93-rpmglobal-holdings" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167030" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/caterpillar-%E2%80%93-rpmglobal-holdings" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-01061.html
+++ b/data/raw/matters/MN-01061.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Molex Electronic Technologies Holdings LLC (Molex) proposes to acquire Smiths Interconnect Group Limited (Smiths Interconnect) from Smiths Group International Holdings Limited through a share sale agreement.   " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/molex-%E2%80%93-smiths-interconnect" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167055" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/molex-%E2%80%93-smiths-interconnect" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-01064.html
+++ b/data/raw/matters/MN-01064.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="The Carlyle Group Inc. (together with its controlled funds and affiliates, Carlyle) proposes to acquire sole control of BASF’s Coatings division (BASF Coatings) from BASF SE (the Seller), a German publicly listed chemical company." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/carlyle-basf-coatings" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167142" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/carlyle-basf-coatings" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-01069.html
+++ b/data/raw/matters/MN-01069.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="On 28 January 2026, the ACCC released its determination that the Acquisition may be put into effect: https://www.accc.gov.au/sites/www.accc.gov.au/files/public-merger-register/documents/Danone-DSDA%20…" />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/danone-%E2%80%93-further-1-interest-in-danone-saputo-dairy-australia" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167254" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/danone-%E2%80%93-further-1-interest-in-danone-saputo-dairy-australia" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-01071.html
+++ b/data/raw/matters/MN-01071.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="CSE Crosscom Pty Ltd (CSE Crosscom) proposes to acquire 100% of the share capital in Progility Pty Ltd (Progility).  CSE Crosscom is an Australian communications systems integrator that designs, supplies, installs and maintains mission- and business-critical communications solutions nationally, including two-way Land Mobile Radio networks, push-to-talk over cellular solutions, in-building coverage/distributed antenna systems, internet protocol networking and managed services." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/cse-crosscom-%E2%80%93-progility" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167371" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/cse-crosscom-%E2%80%93-progility" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-01074.html
+++ b/data/raw/matters/MN-01074.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="GE Healthcare Technologies Inc (GE Healthcare), through a wholly owned subsidiary, proposes to acquire Intelerad Topco Holdings ULC and Intelerad Holdings ULC (together, Intelerad) (the Acquisition). GE Healthcare is a global medical technology, pharmaceutical diagnostics, and digital solutions company." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/ge-healthcare-%E2%80%93-intelerad" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167405" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/ge-healthcare-%E2%80%93-intelerad" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-01075.html
+++ b/data/raw/matters/MN-01075.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Thermo Fisher proposes to acquire all issued and outstanding equity interests of Clario Holdings, Inc." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/thermo-fisher-clario-holdings" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167392" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/thermo-fisher-clario-holdings" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-01080.html
+++ b/data/raw/matters/MN-01080.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="L&#039;Oréal S.A. (L&#039;Oréal) proposes to acquire 100% of the shares in Kering Beauté S.A.S (Kering Beauté), which is wholly owned by Kering Holland, itself 100% held by Kering S.A. " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/l%E2%80%99or%C3%A9al-%E2%80%93-kering-beaut%C3%A9" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167386" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/l%E2%80%99or%C3%A9al-%E2%80%93-kering-beaut%C3%A9" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-10001.html
+++ b/data/raw/matters/MN-10001.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="International Business Machines Corporation (IBM) proposes to acquire 100% of the shares in Confluent, Inc (Confluent)." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/ibm-confluent" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167474" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/ibm-confluent" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-10005.html
+++ b/data/raw/matters/MN-10005.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Apex Group Limited (Apex), through its wholly owned subsidiary, Apex Group Holdings (Australia) Pty Ltd proposes to acquire all of the issued share capital in Mercer Administration Services (Australia) Pty Limited (Mercer Administration Services) and certain assets (including contracts and records necessary to service the contracts) of Mercer Outsourcing (Australia) Pty Ltd (Mercer Outsourcing) from Mercer (Australia) Pty Ltd and Mercer Outsourcing (the Acquisition). " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/apex-mercer-administration-services-and-related-assets" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167530" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/apex-mercer-administration-services-and-related-assets" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-10006.html
+++ b/data/raw/matters/MN-10006.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="AVC Operations Pty Limited (AVC), a subsidiary of Australian Venue Co. Holdings Limited, proposes to acquire substantially all of the assets (including the exclusive right to carry on the businesses in succession of the vendors) of four venues in NSW pursuant to two interdependent transactions: (a) Three Asset Sale Agreement: acquiring Public House Petersham, The Erko, and The Golden Sheaf; and (b) Barangaroo Asset Sale Agreement: acquiring Barangaroo House. " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/australian-venue-co-%E2%80%93-four-licensed-venues-in-metropolitan-sydney-public-house-petersham-the-erko-the-golden-sheaf-and-barangaroo-house" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167487" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/australian-venue-co-%E2%80%93-four-licensed-venues-in-metropolitan-sydney-public-house-petersham-the-erko-the-golden-sheaf-and-barangaroo-house" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-15002.html
+++ b/data/raw/matters/MN-15002.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Google LLC (Google) proposes to acquire 100% of the share capital in Wiz Inc (Wiz). " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/google-wiz" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167372" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/google-wiz" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-15005.html
+++ b/data/raw/matters/MN-15005.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Cvent Atlanta, LLC (Cvent) proposes to acquire ON24, Inc. (ON24), through the merger of Summit Sub Corp. (an indirect wholly owned subsidiary of Cvent) with ON24. Following the merger, ON24 will be the surviving entity and continue as an indirect wholly owned subsidiary of Cvent (Proposed Acquisition)." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/cvent-on24" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167566" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/cvent-on24" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-20009.html
+++ b/data/raw/matters/MN-20009.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Rocket Software, Inc.(Rocket Software), a portfolio company of Bain Capital, proposes to acquire the Vertica Analytics Database Platform (Vertica) from Open Text Corporation (Open Text). The proposed acquisition will occur largely by way of asset sale. " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/rocket-software-%E2%80%93-vertica" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167679" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/rocket-software-%E2%80%93-vertica" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-25002.html
+++ b/data/raw/matters/MN-25002.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Symal Group Limited (Symal Group), through its wholly owned subsidiaries, proposes to acquire all of the business and assets of: the Timms business from Timms Contracting Pty Ltd, Timms Hire Pty Ltd and Teagun Investments Pty Ltd (collectively referred to as Timms Group); and the L&amp;D business from Churinga (Investments) Pty Ltd as trustee for the Churinga Trust and Adawin Pty Ltd (collectively referred to as L&amp;D Group)." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/symal-group-timms-group-and-ld-group" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167420" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/symal-group-timms-group-and-ld-group" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-25004.html
+++ b/data/raw/matters/MN-25004.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="ServiceNow, Inc. (ServiceNow) proposes to acquire Armis Security, Ltd (Armis)." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/servicenow-armis" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167516" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/servicenow-armis" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-40005.html
+++ b/data/raw/matters/MN-40005.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Henkel AG &amp; Co. KGaA (Henkel) proposes to acquire all the shares in and sole control of ATP Adhesives Systems Group GmbH (together with subsidiaries, ATP) from ATP Adhesives Holdings LP, which pre-transaction is controlled by affiliates of Arsenal Capital Partners. " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/henkel-%E2%80%93-atp-adhesives-systems-group" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167548" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/henkel-%E2%80%93-atp-adhesives-systems-group" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-55003.html
+++ b/data/raw/matters/MN-55003.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Symal Group Limited (Symal Group) proposes to acquire 80% of the entity which will own the business, assets and related entities of J. Davison Nominees Pty Ltd, P&amp;A Equipment Pty Ltd and Davison Contractors Pty Ltd (collectively referred to as Davison Earthmovers). The final transaction will be subject to the completion of a restructure of the Davison Earthmovers." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/symal-group-80-acquisition-of-davison-earthmovers" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167472" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/symal-group-80-acquisition-of-davison-earthmovers" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-55006.html
+++ b/data/raw/matters/MN-55006.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Hg Pooled Management Limited (Hg Capital) through a special purpose vehicle, Onward AcquireCo, Inc., proposes to acquire 100% of share capital in Onestream, Inc and OneStream Software LLC (together OneStream)." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/hg-capital-onestream" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167549" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/hg-capital-onestream" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-55012.html
+++ b/data/raw/matters/MN-55012.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Argo Bowen 2 Pty Ltd (Argo Bowen 2) proposes to acquire 100% of the shares in Bowen Coking Coal Limited (ASX:BCB) (BCC) and certain wholly owned subsidiaries (together, the Bowen Group) pursuant to a Deed of Company Arrangement Proposal dated 9 February 2026 (the Acquisition). BCC is a company that focuses on the development, production and sale of metallurgical and thermal coal. BCC appointed voluntary administrators on 30 July 2025." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/argo-bowen-2-%E2%80%93-bowen-coking-coal-and-certain-subsidiaries" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167660" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/argo-bowen-2-%E2%80%93-bowen-coking-coal-and-certain-subsidiaries" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-60004.html
+++ b/data/raw/matters/MN-60004.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="IOR Pty Ltd proposes to acquire the business assets of Delta Specialised Energy Pty Ltd in respect of its diesel, AdBlue and renewable fuels distribution businesses (including the associated plant and equipment and intellectual property). IOR Pty Ltd (IOR), trading as IOR Petroleum, is an Australian-based supplier of fuel and integrated fuel solutions across Australia. Delta Specialised Energy Pty Ltd (Delta), is an Australian-based distributor of diesel, AdBlue and renewable fuels. " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/ior-delta-specialised-energy-assets" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167586" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/ior-delta-specialised-energy-assets" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-60007.html
+++ b/data/raw/matters/MN-60007.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Craig Mostyn Holdings Pty Limited (together with its subsidiaries, Craig Mostyn), via its wholly owned subsidiary Craig Mostyn Farms Pty Ltd, proposes to acquire 100% of the issued shares in Patmore Feeds Pty Ltd (Patmore Feeds) (the Acquisition)." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/craig-mostyn-%E2%80%93-patmore-feeds" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167568" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/craig-mostyn-%E2%80%93-patmore-feeds" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-65007.html
+++ b/data/raw/matters/MN-65007.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="AVC Operations Pty Limited (AVC) proposes to acquire 100% of the business and assets of Ash Promotions Pty Ltd trading as An Sibin Irish Pub (An Sibin) under an asset sale agreement, dated 10 February 2026 (the Acquisition). " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/australian-venue-co-%E2%80%93-an-sibin-irish-pub" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167572" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/australian-venue-co-%E2%80%93-an-sibin-irish-pub" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-70005.html
+++ b/data/raw/matters/MN-70005.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Freudenberg Home and Cleaning Solutions GmbH (Freudenberg) proposes to acquire 100% of share capital in Nilfisk Holding A/S (Nilfisk). Freudenberg supplies manual cleaning tools and other cleaning products in Australia. Freudenberg’s brands include Vileda and Oates and Ansell (which is used under licence). Its products include mops and floorcare, brooms, brushware, cloths and wipes, dusters, cleaning carts and trolleys, waste management, window cleaning equipment, spray bottles, durable gloves, and various cleaning chemicals. " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/freudenberg-home-and-cleaning-solutions-%E2%80%93-nilfisk" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167492" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/freudenberg-home-and-cleaning-solutions-%E2%80%93-nilfisk" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-75002.html
+++ b/data/raw/matters/MN-75002.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="DPG Services Pty Ltd (DPG) and OHCA Property Holdings Pty Limited (being related bodies corporate, and together referred to as Opal Healthcare) propose to acquire the land, assets and business comprising the Sunnymeade Park Aged Care Community (Sunnymeade Park) (Acquisition). DPG is a registered provider of approved residential care homes, and owns and operates 144 residential aged care homes across New South Wales, Victoria, Queensland, Western Australia and South Australia." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/opal-healthcare-%E2%80%93-sunnymeade-park-aged-care-community" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167398" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/opal-healthcare-%E2%80%93-sunnymeade-park-aged-care-community" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-75003.html
+++ b/data/raw/matters/MN-75003.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Ramsay Health Care Investments (Ramsay) or one or more of its wholly owned subsidiaries proposes to acquire the businesses, assets and certain assumed liabilities of National Capital Private Hospital (NCPH) from Healthscope pursuant to a Business and Asset Sale Agreement. " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/ramsay-health-care-%E2%80%93-national-capital-private-hospital" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167409" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/ramsay-health-care-%E2%80%93-national-capital-private-hospital" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-75004.html
+++ b/data/raw/matters/MN-75004.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Parker-Hannifin Corporation (Parker-Hannifin) proposes to acquire 100% of the share capital in Filtration Group Corporation (Filtration Group). Parker-Hannifin is a global engineering company headquartered in Cleveland, Ohio, USA. It designs, manufactures and supplies motion and control technologies and systems to a variety of industries, including aerospace and defence, transportation, energy, and HVAC (heating, ventilation and air conditioning) and refrigeration." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/parker-hannifin-%E2%80%93-filtration-group" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167482" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/parker-hannifin-%E2%80%93-filtration-group" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-75009.html
+++ b/data/raw/matters/MN-75009.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Charter Hall Holdings Pty Limited (Charter Hall Holdings) is wholly owned by Charter Hall Limited (ASX: CHC) and proposes to acquire 100% of JGS Private Capital Pty Ltd (JGS Private Capital), which is wholly owned by J.G. Service Pty Limited (the Proposed Acquisition). " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/charter-hall-holdings-jgs-private-capital" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167540" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/charter-hall-holdings-jgs-private-capital" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-80002.html
+++ b/data/raw/matters/MN-80002.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Bain Capital Investors, LLC (Bain Capital) proposes to indirectly acquire 100% of the shares in MCJ Co., Ltd. (MCJ) through a newly created special purpose vehicle, BCPE Meta Cayman, L.P." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/bain-capital-%E2%80%93-mcj" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167483" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/bain-capital-%E2%80%93-mcj" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-80004.html
+++ b/data/raw/matters/MN-80004.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Audiotonix Limited (Audiotonix) intends to acquire 100% of the shares and sole control of Soundtech Group S.r.l. (Soundtech Group) through 2 special purpose vehicles, Sound Bidco S.r.l and Sound Bidco (Denmark) ApS. Both special purpose vehicles will be 100% directly owned by A6 Audio Bidco Limited (A6 Audio), which, in turn, is 100% indirectly owned by Audiotonix." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/audiotonix-soundtech-group" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167558" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/audiotonix-soundtech-group" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-85002.html
+++ b/data/raw/matters/MN-85002.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="ServiceNow, Inc. (ServiceNow) proposes to acquire Veza Technologies, Inc. (Veza). " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/servicenow-veza" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167342" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/servicenow-veza" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-85003.html
+++ b/data/raw/matters/MN-85003.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="North American Construction Group Limited (NACG), via NACG WA Acquisition Pty Ltd, proposes to acquire 100% of the shares in DCL Corp Pty Ltd, trading as Iron Mining Contracting, and Iron Hire Pty Ltd (the Targets) through a share purchase agreement. NACG is a Canadian supplier of mining and heavy civil construction services to customers in the resource development, industrial construction and infrastructure sectors in Canada, the US, and Australia. Through its Australian subsidiaries, NACG supplies:" />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/north-american-construction-group-%E2%80%93-iron-mine-contracting-and-iron-hire" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167438" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/north-american-construction-group-%E2%80%93-iron-mine-contracting-and-iron-hire" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-85007.html
+++ b/data/raw/matters/MN-85007.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Salesforce, Inc (Salesforce) proposes to acquire all of the outstanding voting securities of Qualified.com, Inc (Qualified)." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/salesforce-%E2%80%93-qualified-0" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167545" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/salesforce-%E2%80%93-qualified-0" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-90006.html
+++ b/data/raw/matters/MN-90006.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="CARe Autobody Pty Ltd (CARe) proposes to acquire 100% of the issued share capital in MotorOne Autobody Pty Ltd (MotorOne Autobody) (the Acquisition). CARe is an Australian supplier of motor vehicle collision repair services. CARe operates a total of 18 repair sites across Australia with 5 sites in Queensland, 7 sites in Victoria, 3 sites in New South Wales, 2 sites in Tasmania and 1 site in South Australia.   " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/care-%E2%80%93-motorone-autobody" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167644" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/care-%E2%80%93-motorone-autobody" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/MN-95002.html
+++ b/data/raw/matters/MN-95002.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Abbott Laboratories (Abbott), via its wholly owned subsidiary Badger Merger Sub I, Inc, proposes to acquired 100% of the shares in Exact Sciences Corporation (Exact Sciences) through an Agreement and Plan of Merger.  Abbott is a global healthcare company, headquartered in the US, active in the provision of diagnostics, medical devices, nutrition, and branded generic pharmaceuticals." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/abbott-laboratories-exact-sciences" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167450" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/abbott-laboratories-exact-sciences" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-01081.html
+++ b/data/raw/matters/WA-01081.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Accenture International B.V. (Accenture) proposes to acquire the issued share capital of Faculty Science Limited (Faculty Science) pursuant to a share purchase agreement. Accenture is a global professional services firm with operations in over 120 countries. It provides a comprehensive suite of professional services designed to assist public and private sectors to navigate digital transformation, optimise operations, and build advanced technological capabilities." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/accenture-%E2%80%93-faculty-science" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167401" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/accenture-%E2%80%93-faculty-science" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-01087.html
+++ b/data/raw/matters/WA-01087.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Eli Lilly and Company (Eli Lilly) proposes to acquire 100% of the issued shares in Orna Therapeutics Holdings, LLC (Orna Therapeutics) pursuant to an Agreement and Plan of Merger. Eli Lilly is a US-based pharmaceutical company, which discovers, develops, manufactures and markets human pharmaceutical products for various therapeutic areas, including diabetes, oncology, immunology and neuroscience. Eli Lilly is headquartered in Indianapolis, US and is publicly listed on the New York Stock Exchange. " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/eli-lilly-%E2%80%93-orna-therapeutics" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167687" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/eli-lilly-%E2%80%93-orna-therapeutics" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-01088.html
+++ b/data/raw/matters/WA-01088.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Pursuant to an Equity Purchase Agreement between SW Soccer Corp Holdings LLC (SW Soccer Corp, the target), SW Soccer HoldCo LLC (the seller), BSN Sports, LLC (BSN Sports, the acquirer), and Varsity Brands, Inc (Varsity Brands, the acquirer’s parent company), BSN Sports intends to acquire 100% of the equity interests in SW Soccer Corp, subject to the rollover by certain direct or indirect holders of equity interests of the seller." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/bsn-sports-%E2%80%93-sports-endeavors" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167651" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/bsn-sports-%E2%80%93-sports-endeavors" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-05003.html
+++ b/data/raw/matters/WA-05003.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="KKR Spire Aggregator L.P., a special purpose vehicle indirectly wholly owned by investment funds, vehicles and/or accounts advised and managed by Kohlberg Kravis Roberts &amp; Co. L.P. (together with its affiliates, KKR) alongside Carrick Capital and other members of the consortium propose acquiring control over Saviynt, Inc." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/kkr-led-consortium-%E2%80%93-saviynt" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167427" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/kkr-led-consortium-%E2%80%93-saviynt" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-05007.html
+++ b/data/raw/matters/WA-05007.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="The acquisition will involve a deleveraging through a debt-to-equity swap resulting in Segula’s creditors, Eiffel Investment Group SAS (Eiffel) and Eurazeo SE (Eurazeo), acquiring joint control of Segula Holding SAS (Segula). The acquisition is part of a financial restructuring aimed at saving Segula from judicial liquidation. It will be carried out under the supervision of the Nanterre Commercial Court (accelerated safeguard procedure) in France and result in Eiffel and Eurazeo each holding 50% of the voting rights in Segula." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/eiffel-and-eurazeo-%E2%80%93-segula" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167585" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/eiffel-and-eurazeo-%E2%80%93-segula" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-05008.html
+++ b/data/raw/matters/WA-05008.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="The transaction involves the indirect acquisition of joint control by funds advised or managed by HongShan Capital Advisors Limited (HSG) and by Rosa Investments Pte. Ltd. (Rosa), an investment holding company indirectly wholly owned by Temasek Holdings Private Limited (Temasek), over Golden Goose Group S.p.A. (GGG), a holding company which in turns owns the entire share capital of Golden Goose S.p.A. (Golden Goose). " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/hongshan-capital-group-and-temasek-%E2%80%93-golden-goose-group" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167649" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/hongshan-capital-group-and-temasek-%E2%80%93-golden-goose-group" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-10002.html
+++ b/data/raw/matters/WA-10002.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="As part of its activities, Stockland Corporation Ltd and Stockland Trust (Stockland) operates a land lease communities (LLC) business, which currently comprises a portfolio of 39 LLC projects nationally, including both established communities and communities under development/in planning." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/stockland-llc-%E2%80%93-intragroup-transfer-of-halcyon-jardin-and-evergreen-projects" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167515" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/stockland-llc-%E2%80%93-intragroup-transfer-of-halcyon-jardin-and-evergreen-projects" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-10008.html
+++ b/data/raw/matters/WA-10008.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Premier Fresh Australia Pty Ltd (Premier Fresh) proposes to purchase 100% of the shares in the following entities that are owned by Carmelo De Domenico and C.A. De Domenico Pty Ltd (the Vendor): (a)        North Queensland IQF Pty Ltd, and (b)        Double D Produce Pty Ltd (collectively, the Domenico Group), as well as the business, land and assets owned and operated by the Domenico Group. " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/premier-fresh-%E2%80%93-charles-domenico-group" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167690" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/premier-fresh-%E2%80%93-charles-domenico-group" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-10009.html
+++ b/data/raw/matters/WA-10009.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Duncan Holdco III LLC, a holding company that is ultimately controlled by SoftBank Group Corp. (Japan) (SoftBank), proposes to acquire 100% of the issued and outstanding shares of common stock (on a fully diluted basis) of, and voting rights in, DigitalBridge Group Inc. (DigitalBridge) (the Acquisition). The Acquisition includes an indirect acquisition of all of DigitalBridge’s interests in each of the relevant general partner entities which manage DigitalBridge investment funds, through Duncan Holdco III LLC." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/softbank-%E2%80%93-digitalbridge" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167842" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/softbank-%E2%80%93-digitalbridge" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-15003.html
+++ b/data/raw/matters/WA-15003.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Coforge Limited (Coforge) proposes to acquire Encora US Holdco, Inc. and Encora Holdings Limited (together, Encora). As consideration, Encora Holdco Limited and AI Altius Parent (Cayman) Limited (together, the Sellers) propose to acquire a non-controlling, minority interest in Coforge. Coforge is a global technology services and solutions provider based in India. Coforge offers a broad range of technology consultancy services and solutions to business customers. Coforge operates across 25 countries, including Australia." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/coforge-encora" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167514" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/coforge-encora" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-15004.html
+++ b/data/raw/matters/WA-15004.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Australian Retirement Trust Pty Ltd as trustee of the Australian Retirement Trust (ART) is an Australian superannuation fund. ART manages retirement savings for &gt;2.4 million members and &gt;207,000 participating employers across Australia as at 30 June 2025. ART has limited interests in a small number of shopping centres in Sydney and New South Wales." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/australian-retirement-trust-%E2%80%93-interests-in-non-rental-income-westfield-sydney" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167562" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/australian-retirement-trust-%E2%80%93-interests-in-non-rental-income-westfield-sydney" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-15007.html
+++ b/data/raw/matters/WA-15007.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Lecta Limited and Lecta Paper Industries Intermediate Financing S.à r.l. have agreed with certain creditors of the Lecta Group to restructure the group’s financial indebtedness. As part of that restructure, funds managed by subsidiaries of Apollo Global Management (together with its indirect subsidiaries managing the investment funds, Apollo) will indirectly acquire sole control over Lecta Paper Industries Intermediate Financing S.à r.l. (together with its subsidiaries, Lecta) by way of a debt-to-equity swap (the Acquisition)." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/apollo-funds-led-consortium-%E2%80%93-lecta-group" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167554" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/apollo-funds-led-consortium-%E2%80%93-lecta-group" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-15008.html
+++ b/data/raw/matters/WA-15008.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="The Acquirer, Global Garella, S.L., a wholly-owned subsidiary of Colliers International Group Inc., (CIGI) proposes to acquire 100% of the shares in Ayesa Engineering, S.A.U. (Ayesa) from Ayesa Inversiones, S.L.U." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/colliers-international-group-%E2%80%93-ayesa-engineering" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167577" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/colliers-international-group-%E2%80%93-ayesa-engineering" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-15009.html
+++ b/data/raw/matters/WA-15009.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="MAHPT TT Pty Ltd (as trustee for Redcape Hotel Property Trust) and Redcape Hotel Group Pty Ltd (the Acquirers) propose to acquire 100% of the freehold land interest, buildings, licences and business assets (both tangible and intangible) of Hotel Brunswick from Brunswick Hotel TT Pty Ltd as trustee for Brunswick Hotel Sub-Trust and Brunswick Hotel Opco Pty Ltd (the Acquisition). Hotel Brunswick is a community, food, beverage and entertainment venue located in Brunswick Heads, New South Wales. It also operates a bottle shop." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/ma-financial-group-redcape-fund-hotel-brunswick" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167793" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/ma-financial-group-redcape-fund-hotel-brunswick" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-15010.html
+++ b/data/raw/matters/WA-15010.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="AZ Next Generation Advisory Pty Ltd (AZ Next Generation Advisory) proposes to acquire 100% of the shares in BMM Partners Pty Ltd, trading as Intend Financial (Intend Financial)." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/az-next-generation-advisory-%E2%80%93-intend-financial" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167846" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/az-next-generation-advisory-%E2%80%93-intend-financial" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-20003.html
+++ b/data/raw/matters/WA-20003.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="The Carlyle Group Inc. (Carlyle) is a global investment firm headquartered in Washington DC, USA, with assets under management across three business segments: (i) Global Private Equity (including corporate private equity and real estate funds); (ii) Global Credit (including liquid credit, illiquid credit and real assets credit); and (iii) Carlyle AlpInvest (including primary, secondary, and co-investments, commingled funds, and separately managed accounts)." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/carlyle-%E2%80%93-peloton-computer-enterprises" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167443" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/carlyle-%E2%80%93-peloton-computer-enterprises" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-20005.html
+++ b/data/raw/matters/WA-20005.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="H-E Parts International Mining Solutions Pty Ltd (H-E Mining) intends to enter into an agreement for lease with ATB Morton Pty Ltd (ATB Morton) in respect of land located at 88 Michelmore Street, Paget, Mackay, Queensland (the Property) and improvements to be constructed by ATB Morton.  ATB Morton will acquire and construct a purpose-built industrial warehouse and workshop facility on the Property. ATB Morton will then lease the Property and improvements constructed by ATB Morton to H-E Mining. " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/h-e-parts-international-mining-solutions-warehouse-workshop-site-in-paget-qld" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167506" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/h-e-parts-international-mining-solutions-warehouse-workshop-site-in-paget-qld" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-20007.html
+++ b/data/raw/matters/WA-20007.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Telstra Limited (Telstra) is a leading Australian telecommunications and technology company, offering a range of communications services. Telstra provides consumer and business connectivity across mobile and fixed broadband, and delivers enterprise solutions including network, cloud, security, data and analytics, software development, and managed/professional services. " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/telstra-%E2%80%93-infosys-technologies" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167779" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/telstra-%E2%80%93-infosys-technologies" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-20008.html
+++ b/data/raw/matters/WA-20008.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Hall &amp; McLean Pty Ltd (Hall &amp; McLean) proposes to acquire a 100% freehold interest in commercial land comprising Lot 8 on SP296133, known as 2 Foundation Street, Wellcamp, QLD 4350 (the Property), from Vision Street Property Pty Ltd (the Vendor) (the Acquisition). Hall &amp; McLean is a 50:50 joint venture between Ellerslie Free Range Farms Pty Ltd (Ellerslie) and the McLean family (through Alpair Pty Ltd)." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/hall-mclean-%E2%80%93-freehold-interest-in-commercial-land-in-wellcamp-qld" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167844" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/hall-mclean-%E2%80%93-freehold-interest-in-commercial-land-in-wellcamp-qld" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-20010.html
+++ b/data/raw/matters/WA-20010.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="PT Asian Bulk Logistics, through its Australian subsidiary, Global Engage Marine Pty Ltd, proposes to acquire 100% of the issued share capital in Engage Marine TopCo Pty Ltd (Engage Marine).  Engage Marine provides terminal and harbour towage including the berthing and sailing of Cape-size, Panamax, and Handy-size vessels. Engage Marine also provides ad-hoc towage emergency response solutions in salvage situations. The main industry Engage Marine operates in is marine services (towage and port services). " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/pt-asian-bulk-logistics-%E2%80%93-engage-marine" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167780" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/pt-asian-bulk-logistics-%E2%80%93-engage-marine" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-25001.html
+++ b/data/raw/matters/WA-25001.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Albany Motors Pty Ltd (Albany Motors), a member of Regent Motors Pty Ltd (Regent Motors Group), proposes to acquire 100% of the issued shares in Esperance Motor Group Pty Ltd (Esperance Motor Group) from Buverie Pty Ltd as trustee for the Schwarzback Family Trust." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/regent-motors-group-%E2%80%93-esperance-motor-group-esperance-toyota-ford" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167478" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/regent-motors-group-%E2%80%93-esperance-motor-group-esperance-toyota-ford" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-25003.html
+++ b/data/raw/matters/WA-25003.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Delinea Inc. (Delinea), a company ultimately controlled by funds managed and/or advised by affiliates of TPG Inc. (TPG), proposes to acquire 100% of the issued share capital in StrongDM, Inc (StrongDM). TPG is a global alternative asset manager firm founded in San Francisco. " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/delinea-tpg-strongdm" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167460" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/delinea-tpg-strongdm" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-25005.html
+++ b/data/raw/matters/WA-25005.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="AVC Operations Pty Limited (AVC) proposes to acquire a leasehold (via lease assignment), the benefit of a liquor licence and certain plant and equipment (with certain exclusions) of Quay Restaurant (Quay) from Q.R.A. Pty Limited (the Acquisition). The Vendor will not transfer the existing business of Quay to AVC, only the specific assets mentioned above. " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/australian-venue-co-%E2%80%93-leasehold-and-certain-other-assets-of-quay-restaurant-sydney" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167490" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/australian-venue-co-%E2%80%93-leasehold-and-certain-other-assets-of-quay-restaurant-sydney" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-25008.html
+++ b/data/raw/matters/WA-25008.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Five V Capital Pty Ltd (Five V Capital) is an Australian-incorporated private equity and venture capital firm with headquarters in Australia and New Zealand. Five V Capital manages a number of Five V funds, including Horizons Fund and Frontier Fund. Horizons Fund and Frontier Fund are investment funds that pursue a strategy of investing in private mid-market businesses." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/five-v-capital-ftp-group" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167843" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/five-v-capital-ftp-group" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-25013.html
+++ b/data/raw/matters/WA-25013.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Rosewood AG, LP, a Guernsey limited partnership (indirectly owned by the Eighth Cinven Fund) proposes to acquire voting rights in Collagen Holdings, LLC (trading as Regenity) (the Acquisition).  The Eighth Cinven Fund is indirectly managed and controlled by Cinven Limited. Cinven Limited has exclusive authority to make investment and management decisions for Eighth Cinven Fund. " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/cinven-%E2%80%93-regenity" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167916" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/cinven-%E2%80%93-regenity" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-35001.html
+++ b/data/raw/matters/WA-35001.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="WSP Global Inc. (WSP) is a global engineering consulting services firm, which is listed on the Toronto Stock Exchange. In Australia, WSP operates through its wholly owned subsidiary, WSP Australia Pty Limited, and provides engineering services to customers across various industries (except where otherwise indicated, WSP and WSP Australia Pty Ltd are collectively referred to as WSP)." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/wsp-%E2%80%93-trc" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167379" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/wsp-%E2%80%93-trc" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-35002.html
+++ b/data/raw/matters/WA-35002.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="IFS North America Inc. (IFS North America), via its wholly owned subsidiary incorporated for the purposes of the transaction, Fjord Merger Sub, Inc. (Merger Sub), proposes to acquire 100% of the issued and outstanding shares of Softeon, Inc. (Softeon) through a reverse triangular merger where: (a) Merger Sub will merge with and into Softeon; and (b) Merger Sub will then cease, and Softeon will be the surviving company. As a result, Softeon will become a wholly owned subsidiary of IFS North America." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/ifs-%E2%80%93-softeon" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167424" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/ifs-%E2%80%93-softeon" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-35003.html
+++ b/data/raw/matters/WA-35003.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Salesforce, Inc (Salesforce) is a global supplier of customer relationship management (CRM) software and other software-as-a-service solutions that enable companies to manage and improve their relationships with customers. Salesforce is a publicly listed company on the New York Stock Exchange and is headquartered in San Francisco, California." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/salesforce-%E2%80%93-qualified" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167402" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/salesforce-%E2%80%93-qualified" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-35004.html
+++ b/data/raw/matters/WA-35004.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="L Catterton Management Limited, together with its controlled funds and affiliates (LCAT), proposes to acquire ~45% of the issued share capital of Ex Nihilo Group (Ex Nihilo), through LCAT’s controlled entity, Saphir Holdings SAS (Saphir).  LCAT is a consumer-focused private equity firm based in the United States with assets under management globally. " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/l-catterton-management-%E2%80%93-ex-nihilo-group" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167473" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/l-catterton-management-%E2%80%93-ex-nihilo-group" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-35005.html
+++ b/data/raw/matters/WA-35005.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Superloop Limited (ASX: SLC) (Superloop) proposes to acquire 100% of the shares in Lynham Networks Pty. Ltd. (Lynham Networks)." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/superloop-%E2%80%93-lynham-networks" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167576" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/superloop-%E2%80%93-lynham-networks" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-35008.html
+++ b/data/raw/matters/WA-35008.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Victorian Funds Management Corporation (VFMC), as investment manager of several investment vehicles (VFMC Clients), proposes for the VFMC Clients to subscribe to units in two stapled trusts of which CorVal Partners Limited acts as trustee, comprising RF CorVal MHE Land Trust (Land Trust) and RF CorVal MHE Operator Trust (Operator Trust) (together, MHE Fund). " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/vfmc-%E2%80%93-corval-land-and-operator-trusts" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167863" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/vfmc-%E2%80%93-corval-land-and-operator-trusts" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-35010.html
+++ b/data/raw/matters/WA-35010.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="On 27 February 2026, Rocket Purchaser, L.L.C. (an affiliate of various funds advised and/or managed by affiliates of Blackstone, Inc. (Blackstone)) entered into an Agreement and Plan of Merger to acquire all the issued shares in Advanced Cooling Technologies, Inc. (ACT)." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/blackstone-advanced-cooling-technologies" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167845" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/blackstone-advanced-cooling-technologies" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-40002.html
+++ b/data/raw/matters/WA-40002.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Star Hotels is an independently owned and operated pub and liquor retail group, primarily operating pubs along the eastern seaboard of QLD as well in South Australia. It currently operates over 50 venues in QLD, including two pubs in the Sunshine Coast area. The Yandina Hotel is owned by the Trustee for Kingston Family Trust (trading as Yandina Hotel), a single-site operator. The Yandina Hotel offers dining, accommodation, gaming and a bottle shop." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/star-hotels-group-%E2%80%93-yandina-hotel-qld" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167453" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/star-hotels-group-%E2%80%93-yandina-hotel-qld" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-40003.html
+++ b/data/raw/matters/WA-40003.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="The acquisition is for 100% of the shares of Smiths Detection Group Limited and its subsidiaries from Smiths Group International Holdings Limited by two newly incorporated investment vehicles, Skyshield US Bidco Limited and Skyshield UK Bidco Limited, which are indirectly controlled by funds or vehicles managed and/or advised by affiliates of CVC Capital Partners plc." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/cvc-capital-partners-%E2%80%93-smiths-detection-group" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167444" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/cvc-capital-partners-%E2%80%93-smiths-detection-group" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-40004.html
+++ b/data/raw/matters/WA-40004.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Vets Central Holdings Pty Ltd (together, with its subsidiaries, Vets Central), proposes to acquire 100% of the business assets (both tangible and intangible) of Gawler Animal Hospital and Animalia Vet Clinic (the Targets) from Gawler Animal Hospital Pty Ltd and GAH 2.0 Pty Ltd, respectively." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/vets-central-%E2%80%93-gawler-animal-hospital-and-animalia-vet-clinic" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167505" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/vets-central-%E2%80%93-gawler-animal-hospital-and-animalia-vet-clinic" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-40010.html
+++ b/data/raw/matters/WA-40010.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Permira is a Guernsey registered private equity business engaged, through its subsidiaries and affiliates, in the provision of investment management services to a number of investment funds. Permira ultimately controls a number of private equity funds, which include portfolio companies active across the consumer, services, healthcare and technology sectors." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/permira-and-warburg-pincus-clearwater-analytics" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167913" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/permira-and-warburg-pincus-clearwater-analytics" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-45001.html
+++ b/data/raw/matters/WA-45001.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Clifford Hallam Healthcare Pty Limited, a wholly-owned subsidiary of Paragon Care Limited (Paragon Care), proposes to acquire the Presidental business (Presidental) through an Asset Purchase Agreement from Presidental Pty Limited and Rockpac South Pacific Pty Ltd." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/paragon-care-%E2%80%93-presidental" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167526" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/paragon-care-%E2%80%93-presidental" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-45003.html
+++ b/data/raw/matters/WA-45003.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Aluminium Specialties Group Pty Ltd (Aluminium Specialities Group) has entered into agreements for lease of manufacturing premises owned by Atilol Holdings Pty Ltd (Atilol), located on two lots in the same parcel of land in the Alspec Industrial Business Park in 221–227 Luddenham Road, Orchard Hills NSW. Aluminium Specialities Group manufactures and extrudes aluminium systems supplies such as door and window frames through a related entity known as Alspec." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/aluminium-specialties-group-%E2%80%93-manufacturing-facility-site-in-orchard-hills-nsw" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167673" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/aluminium-specialties-group-%E2%80%93-manufacturing-facility-site-in-orchard-hills-nsw" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-50003.html
+++ b/data/raw/matters/WA-50003.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Francisco Partners Management, L.P. (Francisco Partners) is a global investment firm specialising in technology and technology-enabled businesses, headquartered in San Francisco, United States with offices in New York and London. Francisco Partners has several portfolio companies that operate across multiple different sectors." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/francisco-partners-sermo" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167563" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/francisco-partners-sermo" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-50005.html
+++ b/data/raw/matters/WA-50005.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Allied Beef Group Pty Ltd (Allied Beef) proposes to lease the Yarranbrook Feedlot land (Yarranbrook) from Yarranbrook Property Pty Ltd (Lessor) pursuant to a lease agreement. Yarranbrook is a beef cattle feedlot with associated grazing and cropping activities located at 188 Cremascos Road in Inglewood, Queensland." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/allied-beef-lease-of-yarranbrook-feedlot" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167650" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/allied-beef-lease-of-yarranbrook-feedlot" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-50006.html
+++ b/data/raw/matters/WA-50006.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Airtree Ventures Opportunity Fund V Trusco Pty Ltd as trustee for the Airtree Ventures Opportunity Fund V Stapled Trust (Airtree Fund) proposes to invest in Aegleon Holdco Pty Ltd (Aegleon) by way of subscription for shares, and thereby indirectly acquire a small interest in HotDoc Online Pty Ltd (HotDoc), which is a wholly-owned indirect subsidiary of Aegleon." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/airtree-%E2%80%93-hotdoc" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167781" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/airtree-%E2%80%93-hotdoc" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-50010.html
+++ b/data/raw/matters/WA-50010.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Blackbird FOF25 Pty Ltd as trustee for Blackbird Ventures 2025 Follow-On Fund Trust (Blackbird FOF25) and Blackbird FSA Pty Ltd as trustee for Blackbird FSA Coinvestment Trust (Blackbird FSA) each propose to purchase shares in Halter USA Inc&#039;s (Halter) capital raise, as described in the transaction documents provided as part of the application." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/blackbird-ventures-%E2%80%93-halter" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167914" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/blackbird-ventures-%E2%80%93-halter" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-55004.html
+++ b/data/raw/matters/WA-55004.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Blackbird FOF25 Pty Ltd as trustee for Blackbird Ventures 2025 Follow-On Fund Trust (Blackbird FOF25) proposes to purchase shares of Series E Preferred Stock in a capital raise by Baseten Labs, Inc (Baseten)." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/blackbird-ventures-%E2%80%93-baseten-labs" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167494" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/blackbird-ventures-%E2%80%93-baseten-labs" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-55005.html
+++ b/data/raw/matters/WA-55005.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Funds managed by each of General Atlantic (GA) and Canada Pension Plan Investment Board (CPP Investments) propose to indirectly acquire interests in Boats Group Holdings, Inc (Boats Group) through acquiring interests in Bimini Holdings, LP, which indirectly owns 100% of Boats Group (the Acquisition)." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/general-atlantic-and-cpp-investments-led-consortium-boats-group" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167547" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/general-atlantic-and-cpp-investments-led-consortium-boats-group" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-55009.html
+++ b/data/raw/matters/WA-55009.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Resonetics, LLC (Resonetics) proposes to acquire: (i) 100% of the issued and outstanding voting securities of Arcline Resolution Blocker, Inc. (Blocker), which owns minority non-corporate interests of Resolution Medical MidCo, LLC (Resolution Medical) and  (ii) the remaining non-corporate interests of Resolution Medical. " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/resonetics-%E2%80%93-resolution-medical" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167675" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/resonetics-%E2%80%93-resolution-medical" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-55011.html
+++ b/data/raw/matters/WA-55011.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="OEP IX Master Coöperatief U.A. (OEP IX) will acquire from certain wholly owned subsidiaries of CRH PLC shares representing 100% of the total voting rights of the Leviat Group (Leviat), pursuant to a share purchase agreement. OEP IX is a financial holding company forming part of One Equity Partners Fund Complex IX that is managed and advised by OEP Group. The OEP Group focuses on investments in industrial, healthcare and technology sector businesses across North America and Europe." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/oep-ix-%E2%80%93-leviat" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167750" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/oep-ix-%E2%80%93-leviat" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-60006.html
+++ b/data/raw/matters/WA-60006.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Re.Group (via its associated entity Re.Turn-It Pty Ltd) (Re.Group) is proposing to: acquire leasehold interests over the land and buildings currently occupied by the Scouts Recycling Centre in Slacks Creek, Queensland, which is owned by a not-for-profit organisation called The Scout Association of Australia, South Australian Branch Incorporated (Scouts SA);" />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/regroup-%E2%80%93-scouts-queensland-recycling-centre-site" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167432" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/regroup-%E2%80%93-scouts-queensland-recycling-centre-site" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-60008.html
+++ b/data/raw/matters/WA-60008.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Achronite Bidco Limited, a special purpose vehicle owned and controlled by funds managed or advised by Warburg Pincus LLC (Warburg Pincus) and its affiliates, is proposing to acquire 80-100% of the issued share capital of Acclime Holdings HK Limited (Acclime)." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/warburg-pincus-%E2%80%93-acclime" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167445" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/warburg-pincus-%E2%80%93-acclime" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-60010.html
+++ b/data/raw/matters/WA-60010.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="The Michelin Group is a multinational tyre manufacturer and distributor headquartered in Clermont-Ferrand in the Auvergne-Rhône-Alpes region of France. The Michelin Group is the owner of UK-based Fenner PLC, which includes Fenner America, Inc. Fenner is a manufacturer of engineered products, specifically conveyor solutions and polymer products. " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/michelin-flexitallic" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167874" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/michelin-flexitallic" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-65003.html
+++ b/data/raw/matters/WA-65003.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Henkel AG &amp; Co. KGaA (Henkel) proposes to acquire all the shares in Aqua Adhesives I GmbH (Aqua Adhesives). Through that, Henkel will acquire control of Aqua Adhesives’ subsidiary, ATP adhesive systems Group GmbH (ATP)." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/henkel-%E2%80%93-atp-adhesive-systems-group" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167480" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/henkel-%E2%80%93-atp-adhesive-systems-group" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-65004.html
+++ b/data/raw/matters/WA-65004.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Cielo Topco Limited, through its wholly owned subsidiary Kee Safety (Australia) Pty Ltd (Kee Safety), proposes to acquire RISSafety Enterprises Pty Ltd and its subsidiaries (together, RIS Safety). Kee Safety provides working at height solutions enabling safe access for building, plant and equipment maintenance outside Australia including throughout the United Kingdom and the United States. Safe access solutions include design, installation, inspection and training of permanent and personal fall protection equipment." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/kee-safety-ris-safety" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167513" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/kee-safety-ris-safety" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-65010.html
+++ b/data/raw/matters/WA-65010.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Honda Motor Co., Ltd (Honda) proposes to acquire an additional 21% of issued shares in Astemo, Ltd (Astemo) from Hitachi, Ltd. (Hitachi) (the Acquisition). On 16 December 2025, Honda and Hitachi entered into a share purchase agreement for this purpose. Astemo was a company integrated and merged as a jointly owned company by Honda and Hitachi. Now, Honda, Hitachi and JIC Capital, Ltd (JICC) hold 40%, 40% and 20% of issued shares in Astemo respectively. The Acquisition will result in:" />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/honda-%E2%80%93-additional-shareholding-in-astemo" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167908" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/honda-%E2%80%93-additional-shareholding-in-astemo" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-70002.html
+++ b/data/raw/matters/WA-70002.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Ethos Bidco, Ltd (Ethos) proposes to indirectly acquire the following from affiliates of UnitedHealth Group Incorporated (UHG) pursuant to a Share and Asset Purchase Agreement (EMIS SAPA): 100% of the shares of EMIS Group Limited (EMIS); and Certain healthcare technology assets used in the UK by UHG&#039;s wholly owned subsidiary, Optum Health Solutions (UK) Limited (Transferred Assets)." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/ethos-tpg-%E2%80%93-emis-and-certain-related-assets" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167380" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/ethos-tpg-%E2%80%93-emis-and-certain-related-assets" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-70003.html
+++ b/data/raw/matters/WA-70003.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="This application relates to the Acquisition by Intrepid Travel Pty Ltd (Intrepid) of 100% shares in Wild Bush Luxury Experience Pty Ltd (Wild Bush Luxury) held by Experience Co Limited (ExCo).  Intrepid Group Pty Ltd (IG) is a global, purpose-led experiential travel company, specialising in small group tours and travel experiences. IG has 31 offices around the world and operates more than 1,000 small group adventures in 118 countries. Intrepid is a subsidiary of IG. " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/intrepid-travel-%E2%80%93-wild-bush-luxury" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167479" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/intrepid-travel-%E2%80%93-wild-bush-luxury" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-70004.html
+++ b/data/raw/matters/WA-70004.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="General Dental Holdings Pty Ltd, trading as Impression Dental Group (IDG), proposes to acquire 100% of the assets of the dental practice known as Happy Rock Dental (Happy Rock Dental Practice), through a business sale agreement. Happy Rock Dental Practice is owned and operated by Dr Wei-Jie Jiang and Wei-Jie Jiang Pty Ltd and supplies general dental services to the public from its premises in Cronulla, NSW." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/impression-dental-group-happy-rock-dental-practice" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167583" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/impression-dental-group-happy-rock-dental-practice" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-70006.html
+++ b/data/raw/matters/WA-70006.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Scopely, Inc. (Scopely) proposes to acquire:  an initial 51% of the shares of Loom Games Oyun Yazılım ve Pazarlama Anonim Şirketi (Loom Games), and 4 related 12.25% stakes, up to 100% of the shares of Loom Games." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/scopely-%E2%80%93-loom-games" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167647" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/scopely-%E2%80%93-loom-games" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-70007.html
+++ b/data/raw/matters/WA-70007.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Advance Holdings II, LLC (a vehicle ultimately controlled by Platinum Equity, LLC (Platinum Equity)) proposes to acquire BCI Acquisitions, Inc. (together with its direct and indirect subsidiaries, Burke). Burke designs, manufactures and supplies outdoor playground and recreational equipment, as well as ancillary products for recreational spaces." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/platinum-equity-group-%E2%80%93-burke" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167648" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/platinum-equity-group-%E2%80%93-burke" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-70008.html
+++ b/data/raw/matters/WA-70008.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Tetra Tech Australia Group Holdings Pty Ltd (Tetra Tech) proposes to acquire 100% of the shares in Providence Consulting Group Pty Ltd (Providence Consulting) through a Share Purchase Agreement. Tetra Tech is a wholly owned subsidiary of Tetra Tech, Inc., a publicly listed corporation (NASDAQ:TTEK), and is the holding company for various subsidiaries." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/tetra-tech-%E2%80%93-providence-consulting" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167910" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/tetra-tech-%E2%80%93-providence-consulting" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-70009.html
+++ b/data/raw/matters/WA-70009.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Infotrust Ltd (ASX:ITS) (Infotrust) proposes to acquire 100% of the shares in Catalyst Cyber." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/infotrust-%E2%80%93-catalyst-cyber" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167862" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/infotrust-%E2%80%93-catalyst-cyber" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-75006.html
+++ b/data/raw/matters/WA-75006.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="EGYM SE (together with its subsidiaries, EGYM) and Mindbody, Inc. (together with its controlled subsidiaries, Playlist) intend to combine in a newly established company, Saturn NewCo, Inc. (Saturn), and transfer shares in Saturn to the existing shareholders of EGYM and Playlist." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/playlist-%E2%80%93-egym" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167553" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/playlist-%E2%80%93-egym" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-75008.html
+++ b/data/raw/matters/WA-75008.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="BetterGrow Holdings Pty Ltd (Bettergrow) proposes to acquire 100% of the shares in Hygain Holdco Pty Ltd (HYG). " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/bettergrow-hyg" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167591" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/bettergrow-hyg" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-75010.html
+++ b/data/raw/matters/WA-75010.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Zendesk, Inc. (Zendesk) proposes to acquire 100% of the business of Forethought Technologies, Inc. (Forethought) through a reverse triangular merger whereby Forethought will acquire 100% of the issued shares in a subsidiary of Zendesk which has been newly incorporated for the purpose of the merger. Through this process, Forethought will become a wholly owned subsidiary of Zendesk." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/zendesk-%E2%80%93-forethought" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167646" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/zendesk-%E2%80%93-forethought" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-75011.html
+++ b/data/raw/matters/WA-75011.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Autosports Group Limited (ASX: ASG) (ASG) proposes to acquire 100% of the Solitaire Automotive Group business from vendors Toja Investments Pty Ltd as trustee for the Bill Holst Family Trust and David Smoker (the Acquisition). The Acquisition will occur through ASG acquiring 100% interests in the following Solitaire Automotive Group entities: Cambridge Motors Pty Ltd, which is the entity owned by David Smoker and holds shares in Russleigh Pty Ltd (Russleigh) and units in the Russleigh Unit Trust," />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/autosports-group-solitaire-automotive-group" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167674" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/autosports-group-solitaire-automotive-group" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-75013.html
+++ b/data/raw/matters/WA-75013.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Aldus Group (Aldus) is an Australian diversified industrial group. In Australia, Aldus primarily distributes digital printing and industrial coding equipment, manufactures and supplies industrial inks, decorative foils and thermal transfer ribbons, and provides label applicator systems and associated servicing. Aldus also operates a small precision engineering division providing computer numerical control (CNC) machining services and medical engineering division." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/aldus-hilton-manufacturing" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167911" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/aldus-hilton-manufacturing" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-75015.html
+++ b/data/raw/matters/WA-75015.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="The transaction involves the acquisition by Migaloo QLD Pty Ltd, a subsidiary of Star Consolidated Holdings Pty Ltd and its controlled entities (Star Hotels Group), of: the leasehold interest in the land that the Liquor Legends Berserker and Liquor Legends Highway A1 stores operate on; and business assets including goodwill, fixtures, fittings and all licences involved with the Liquor Legends Berserker and Liquor Legends Highway A1 stores." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/star-hotels-group-%E2%80%93-liquor-legends-berserker-liquor-legends-highway-a1-qld" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167930" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/star-hotels-group-%E2%80%93-liquor-legends-berserker-liquor-legends-highway-a1-qld" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-80001.html
+++ b/data/raw/matters/WA-80001.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Arena HoldCo Pty Ltd, through its subsidiary, Arena BidCo Pty Ltd (Arena) proposes to acquire:  (a) 100% of the issued share capital in GameOn Holdings Pty Ltd (GameOn) and its subsidiaries PlayHQ Sports Pty Ltd (PlayHQ), PlayHQ Sports UK Limited and PlayHQ Sports Ltd from its current shareholders; and  (b) 100% of the issued share capital in RFGI Group Pty Ltd, a shareholder of GameOn,  (together, the Acquisition). " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/alpine-software-group-asg-%E2%80%93-playhq" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167433" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/alpine-software-group-asg-%E2%80%93-playhq" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-80006.html
+++ b/data/raw/matters/WA-80006.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Russell Investment Group Pty Ltd (Russell) proposes to acquire 100 per cent of the issued and outstanding shares of Zurich Investment Management Limited (Zurich) through a share sale agreement (the Acquisition). Russell provides investment and asset management services in Australia." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/russell-investment-group-%E2%80%93-zurich-investment-management" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167693" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/russell-investment-group-%E2%80%93-zurich-investment-management" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-85004.html
+++ b/data/raw/matters/WA-85004.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Treysta Wealth Management Pty Ltd (Treysta) proposes to acquire the businesses and related assets of Locumsgroup Asset Management Services Pty Ltd, Locumsgroup Private Accounting Services Pty Limited and Locums Nominees Pty Limited (together, Locumsgroup)." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/treysta-wealth-management-%E2%80%93-locumsgroup" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167428" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/treysta-wealth-management-%E2%80%93-locumsgroup" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-85005.html
+++ b/data/raw/matters/WA-85005.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Altor Fund Manager AB (Altor), through CAVE BidCo Oy (Cave), proposes to acquire 100% of the issued shares in Evac Holding Oy (Evac).  Altor is a Swedish-based private equity group. Altor is a well-established investment firm with a portfolio of companies across various sectors. Cave is a Finnish limited liability investment vehicle controlled by Altor that does not supply any goods or services. " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/altor-fund-manager-evac-holding-oy" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167446" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/altor-fund-manager-evac-holding-oy" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-85008.html
+++ b/data/raw/matters/WA-85008.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Sony Pictures Entertainment Inc. (SPE) and Sony Music Entertainment (Japan) Inc. (SMEJ) (together with Sony Group Corporation, Sony) propose to acquire 100% of the voting securities of DHX Entertainment (USA) Inc. (DHX). " />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/sony-%E2%80%93-peanuts-worldwide" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167550" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/sony-%E2%80%93-peanuts-worldwide" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-85011.html
+++ b/data/raw/matters/WA-85011.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="TDR Capital LLP (TDR) and Estoril Coinvest SCSp (Estoril) propose to enter a Shareholders Agreement, pursuant to which TDR will hold a majority interest while Estoril will hold a minority interest in Escode. TDR is a private equity firm based in the United Kingdom. Estoril is a co-investment vehicle managed by a private equity firm." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/tdr-and-estoril-%E2%80%93-escode" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167754" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/tdr-and-estoril-%E2%80%93-escode" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-85013.html
+++ b/data/raw/matters/WA-85013.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="NDC HoldCo Pty Ltd (together with its subsidiaries, National Dental Care), through its wholly-owned subsidiary, NDC Australia Pty Limited, proposes to acquire from Tan Dental Pty Ltd 100% of the business assets comprising the DDTA Dental clinic (DDTA Dental). National Dental Care is a dental services organisation that operates a network of dental clinics that provide a range of general dentistry services. National Dental Care has dental clinics in all Australian states and territories except Tasmania." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/national-dental-care-%E2%80%93-ddta-dental-clinic-in-launceston-tas" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167663" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/national-dental-care-%E2%80%93-ddta-dental-clinic-in-launceston-tas" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-85014.html
+++ b/data/raw/matters/WA-85014.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Genesis Minerals Limited (ASX: GMD) (Genesis Minerals) is an ASX-listed gold producer and explorer with gold mining operations selling gold bullion produced from its operations and processing hubs at Leonora and Laverton in Western Australia. Magnetic Resources NL (ASX:MAU) (Magnetic Resources) is a gold explorer and developer, with activities focused on advancing the Lady Julie and Laverton district projects in Western Australia. Magnetic does not have any active mining or gold production operations." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/genesis-minerals-%E2%80%93-magnetic-resources" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167782" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/genesis-minerals-%E2%80%93-magnetic-resources" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-90002.html
+++ b/data/raw/matters/WA-90002.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="NEC Corporation (NEC) proposes to acquire the entire issued and outstanding share capital of CSG Systems International, Inc. (CSG) (the Acquisition). The Acquisition will be implemented by way of a reverse triangular merger pursuant to an Agreement and Plan of Merger between NEC, CSG and Canvas Transaction Company, Inc. This will involve CSG merging with NEC’s wholly-owned Delaware subsidiary (Canvas Transaction Company, Inc.) and then surviving the merger as a wholly owned subsidiary of NEC." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/nec-corporation-%E2%80%93-csg-systems-international" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167575" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/nec-corporation-%E2%80%93-csg-systems-international" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-90004.html
+++ b/data/raw/matters/WA-90004.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Crossmuller Pty. Limited (Crossmuller) proposes to acquire 100% of the issued share capital of GEMCORP Holdings Pty Ltd (GEM).  Crossmuller designs, engineers and delivers manufacturing, electrical and industrial automation solutions for industrial clients. Crossmuller provides project delivery services, from concept and detailed engineering through to electrical installation, software and systems integration, fitting and machining commissioning, and ongoing support across a range of manufacturing sectors." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/crossmuller-%E2%80%93-gem" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167633" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/crossmuller-%E2%80%93-gem" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-95005.html
+++ b/data/raw/matters/WA-95005.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="HCL Technologies Limited (HCLTech) proposes to acquire Jaspersoft, a business unit of Cloud Software Group that supplies a reporting software platform (including JasperReports®)." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/hcltech-jaspersoft" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167541" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/hcltech-jaspersoft" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-95006.html
+++ b/data/raw/matters/WA-95006.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Spike Media Pty Ltd, a newly-formed entity under the control of Arthur Laundy, proposes to acquire 100% of the shares in Nine Radio Pty Limited (Nine Radio) from Fairfax Media Limited, a wholly-owned subsidiary of Nine Entertainment Co. Holdings Limited.  Arthur Laundy currently controls the Laundy Group, which operates over 40 hospitality venues throughout New South Wales through Laundy Hotels Pty Ltd and invests in Australian assets, including in commercial property, sports, tourism, hospitality, events and accommodation." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/laundy-group-%E2%80%93-nine-radio" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167561" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/laundy-group-%E2%80%93-nine-radio" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-95008.html
+++ b/data/raw/matters/WA-95008.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Vets Central Holdings Pty Ltd (together, with its subsidiaries, Vets Central), proposes to acquire 100% of the business assets (both tangible and intangible) of West Toowoomba Veterinary Surgery from Cicuration Pty Ltd as trustee for Burke Family Trust." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/vets-central-%E2%80%93-west-toowoomba-veterinary-surgery-in-qld" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167662" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/vets-central-%E2%80%93-west-toowoomba-veterinary-surgery-in-qld" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/data/raw/matters/WA-95009.html
+++ b/data/raw/matters/WA-95009.html
@@ -5,8 +5,8 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S5TGQHQ4G8"></script>
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="McDonald’s Australia Limited (McDonald’s Australia) owns 1,076 McDonald’s restaurants around Australia. It generally operates around 15% of these restaurants (Corporate Restaurants) and licenses the right to operate and occupy the remainder (Franchised Restaurants). Both the Corporate Restaurants and Franchised Restaurants supply McDonald’s branded fast-food products through dine in, takeaway, drive through and/or digital ordering channels." />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/mcdonald%E2%80%99s-australia-%E2%80%93-mcdonald%E2%80%99s-restaurants-in-bankstown-and-yagoona-nsw" />
 <link rel="shortlink" href="https://www.accc.gov.au/node/167912" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/mcdonald%E2%80%99s-australia-%E2%80%93-mcdonald%E2%80%99s-restaurants-in-bankstown-and-yagoona-nsw" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />

--- a/scripts/scrape.sh
+++ b/scripts/scrape.sh
@@ -73,6 +73,9 @@ clean_file() {
   # and dcterms.modified between requests, causing spurious diffs. Always put created first.
   perl -i -0pe 's{(<meta name="dcterms\.modified"[^\n]*/>\n)(<meta name="dcterms\.created"[^\n]*/>\n)}{$2$1}g' "$file"
 
+  # Normalize canonical/shortlink order: always put shortlink before canonical.
+  perl -i -0pe 's{(<link rel="canonical"[^\n]*/>\n)(<link rel="shortlink"[^\n]*/>\n)}{$2$1}g' "$file"
+
   # Use a second sed pass for complex multi-line replacements.
   sed -i -E -e ':a;N;$!ba;s#(<a[^>]*class="[^"]*megamenu-page-link-level-3[^"]*"[^>]*href=")[^"]*("[^>]*>[[:space:]]*<span>)[^<]*(</span>)#\1STATIC_HREF\2STATIC_TEXT\3#g' "$file"
 


### PR DESCRIPTION
## Summary
Added HTML normalization to ensure consistent ordering of `<link>` tags for canonical and shortlink relations in scraped HTML files.

## Changes
- **scripts/scrape.sh**: Added a new normalization rule in the `clean_file()` function that reorders `<link rel="canonical">` and `<link rel="shortlink">` tags to always place shortlink before canonical. This prevents spurious diffs when the source HTML varies the order of these tags.

## Details
The new normalization uses a Perl regex pattern similar to the existing dcterms metadata ordering logic. This ensures that all HTML files in the data directory have a consistent, predictable structure regardless of how the source website orders these link elements, reducing noise in version control diffs.

https://claude.ai/code/session_012uZZWzDHaNaC3aAexc4j1A