### PR TITLE
Add HTML cleaning verification and post-rebase re-cleaning

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -68,6 +68,40 @@ jobs:
             ./scripts/scrape.sh
           fi
 
+      - name: Verify HTML cleaning
+        run: |
+          # Report any matter HTML files modified by this scrape run that still
+          # contain known uncleaned dynamic tokens. This catches cases where
+          # clean_file did not run, or where a git rebase will later undo its
+          # substitutions when two concurrent runs touched the same file.
+          modified_html=()
+          while IFS= read -r f; do
+            modified_html+=("$f")
+          done < <(git status --porcelain data/raw/matters/ 2>/dev/null \
+                    | awk '{print $NF}' | grep '\.html$' || true)
+
+          if [ ${#modified_html[@]} -eq 0 ]; then
+            echo "No matter HTML files were modified by this scrape run."
+          else
+            echo "Checking ${#modified_html[@]} modified matter page(s) for uncleaned tokens..."
+            bad_files=()
+            for f in "${modified_html[@]}"; do
+              if grep -qE \
+                'js-view-dom-id-[a-f0-9]{64}|/(css|js)/[a-zA-Z]+_[A-Za-z0-9_-]{30,}\.(css|js)(\?|")' \
+                "$f" 2>/dev/null; then
+                bad_files+=("$f")
+              fi
+            done
+            if [ ${#bad_files[@]} -gt 0 ]; then
+              echo "WARNING: The following matter pages appear to have uncleaned dynamic content:"
+              printf '  %s\n' "${bad_files[@]}"
+              echo "This may indicate clean_file did not run, or a concurrent pipeline run"
+              echo "touching the same file will cause a rebase to reintroduce raw tokens."
+            else
+              echo "HTML cleaning check passed (${#modified_html[@]} file(s) verified)."
+            fi
+          fi
+
       - name: Check for scrape changes
         id: scrape-changes
         run: |
@@ -185,5 +219,26 @@ jobs:
           else
             git commit -m "Update merger data: ${timestamp}"
             git pull --rebase || { git rebase --abort; exit 1; }
+
+            # After rebase, re-clean any HTML files that changed. A 3-way merge
+            # during rebase can reintroduce raw dynamic tokens if both the local
+            # commit and the pulled commits touched the same file.
+            rebase_html=$(git diff HEAD^..HEAD --name-only 2>/dev/null | grep '\.html$' || true)
+            if [ -n "$rebase_html" ]; then
+              echo "HTML files in rebased commit:"
+              echo "$rebase_html" | sed 's/^/  /'
+              while IFS= read -r f; do
+                if [ -f "$f" ]; then
+                  ./scripts/scrape.sh --clean-file "$f"
+                  git add "$f"
+                  echo "Re-cleaned: $f"
+                fi
+              done <<< "$rebase_html"
+              if ! git diff --staged --quiet; then
+                echo "WARNING: Rebase introduced uncleaned HTML — amending commit to fix"
+                git commit --amend --no-edit
+              fi
+            fi
+
             git push
           fi

--- a/scripts/scrape.sh
+++ b/scripts/scrape.sh
@@ -4,25 +4,39 @@
 #
 # Usage:
 #   ./scrape.sh [--all]
+#   ./scrape.sh --clean-file <path>
 #
 # Options:
-#   --all    Scrape all mergers, ignoring cutoff dates (by default, mergers
-#            are skipped 3 weeks after an approved notification or waiver decision)
+#   --all              Scrape all mergers, ignoring cutoff dates (by default,
+#                      mergers are skipped 3 weeks after an approved notification
+#                      or waiver decision)
+#   --clean-file <path>  Apply HTML cleaning to a single file and exit. Used by
+#                        the pipeline to re-clean files after a git rebase.
 
 # Exit immediately if a command exits with a non-zero status.
 set -e
 
 # --- Parse Arguments ---
 SCRAPE_ALL=false
+CLEAN_FILE_PATH=""
 while [[ $# -gt 0 ]]; do
   case $1 in
     --all)
       SCRAPE_ALL=true
       shift
       ;;
+    --clean-file)
+      if [[ -z "${2:-}" ]]; then
+        echo "Error: --clean-file requires a file path argument"
+        echo "Usage: $0 --clean-file <path>"
+        exit 1
+      fi
+      CLEAN_FILE_PATH="$2"
+      shift 2
+      ;;
     *)
       echo "Unknown option: $1"
-      echo "Usage: $0 [--all]"
+      echo "Usage: $0 [--all] | $0 --clean-file <path>"
       exit 1
       ;;
   esac
@@ -159,11 +173,19 @@ fetch_matter_page() {
     echo "    Warning: Could not find matter number for $full_url. Used fallback name: $fallback_name"
   fi
 
+  echo "Fetching: $full_url → $filename"
   clean_file "$filename"
+  echo "Cleaned:  $filename"
 }
 # Export the function so it's available to subshells spawned by xargs
 export -f fetch_matter_page
 
+# If called with --clean-file, just clean the specified file and exit.
+# This mode is used by the pipeline to re-clean files after a git rebase.
+if [ -n "$CLEAN_FILE_PATH" ]; then
+  clean_file "$CLEAN_FILE_PATH"
+  exit 0
+fi
 
 # --- Main Script ---
 


### PR DESCRIPTION
## Summary
This PR adds safeguards to detect and fix uncleaned dynamic tokens in HTML files that may be introduced during concurrent pipeline runs or git rebases. It includes verification checks in the pipeline and a mechanism to re-clean HTML files after rebases.

## Key Changes

- **HTML Cleaning Verification Step**: Added a new pipeline job step that checks modified matter HTML files for uncleaned dynamic tokens (e.g., `js-view-dom-id-*` and versioned asset paths). This catches cases where the cleaning process didn't run or where concurrent runs may have caused issues.

- **Post-Rebase Re-cleaning**: After a git rebase in the pipeline, the script now automatically re-cleans any HTML files that were modified in the rebased commit. This prevents 3-way merge conflicts from reintroducing raw dynamic tokens.

- **Enhanced scrape.sh Script**: 
  - Added `--clean-file <path>` option to allow cleaning individual files without running a full scrape
  - Updated usage documentation to reflect the new option
  - Added logging output for fetch and clean operations

- **Commit Amendment on Re-clean**: If re-cleaning after a rebase introduces changes, the commit is automatically amended to include the fixes before pushing.

## Implementation Details

- The verification step uses regex patterns to detect known uncleaned tokens: `js-view-dom-id-[a-f0-9]{64}` and versioned asset paths like `/(css|js)/[a-zA-Z]+_[A-Za-z0-9_-]{30,}\.(css|js)`
- The post-rebase re-cleaning only processes HTML files that were actually modified in the rebased commit
- All changes are staged and committed atomically to maintain a clean git history
- Warning messages are logged to alert operators of potential issues

https://claude.ai/code/session_01CeB4q3sQS4ahgyEpzkDeyv