### PR TITLE
Fix git restore command to clean both staged and working tree

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -218,7 +218,7 @@ jobs:
             echo "No changes to commit"
           else
             git commit -m "Update merger data: ${timestamp}"
-            git pull --rebase || { git rebase --abort; exit 1; }
+            git pull --rebase --autostash || { git rebase --abort; exit 1; }
 
             # After rebase, re-clean any HTML files that changed. A 3-way merge
             # during rebase can reintroduce raw dynamic tokens if both the local

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -116,7 +116,7 @@ jobs:
             if [ "$non_register" -gt 0 ]; then
               echo "changed=true" >> $GITHUB_OUTPUT
             else
-              git restore --staged data/raw/acquisitions-register.html
+              git restore --staged --worktree data/raw/acquisitions-register.html
               echo "changed=false" >> $GITHUB_OUTPUT
             fi
           fi
@@ -218,7 +218,7 @@ jobs:
             echo "No changes to commit"
           else
             git commit -m "Update merger data: ${timestamp}"
-            git pull --rebase --autostash || { git rebase --abort; exit 1; }
+            git pull --rebase || { git rebase --abort; exit 1; }
 
             # After rebase, re-clean any HTML files that changed. A 3-way merge
             # during rebase can reintroduce raw dynamic tokens if both the local


### PR DESCRIPTION
## Summary
Updated the `git restore` command in the pipeline workflow to properly clean up the acquisitions register file from both the staging area and the working tree.

## Key Changes
- Modified `git restore --staged` to `git restore --staged --worktree` for the acquisitions-register.html file
  - This ensures the file is restored in both the Git index (staging area) and the working directory
  - Prevents potential issues where the file could remain modified in the working tree even after staging changes are discarded

## Implementation Details
The change affects the pipeline's change detection logic. When no non-registered changes are detected, the workflow now properly cleans up the acquisitions register file from both Git's staging area and the actual working directory, ensuring a consistent state for subsequent pipeline steps.

https://claude.ai/code/session_01BAyqvKt3pZnrAb7zmbiomD