### PR TITLE
Optimize HTML parsing: switch to lxml and use regex for merger ID extraction

### DIFF
--- a/scripts/extract_mergers.py
+++ b/scripts/extract_mergers.py
@@ -609,7 +609,7 @@ def parse_merger_file(filepath, existing_merger_data=None, frozen_events_mergers
         with open(filepath, 'r', encoding='utf-8') as f:
             html_content = f.read()
 
-        soup = BeautifulSoup(html_content, 'html.parser')
+        soup = BeautifulSoup(html_content, 'lxml')
 
         merger_data = _extract_basic_info(soup)
         merger_id = merger_data['merger_id']
@@ -640,14 +640,15 @@ def parse_merger_file(filepath, existing_merger_data=None, frozen_events_mergers
 
 
 def get_merger_id_from_file(filepath):
-    """Extracts the merger ID from the HTML file without full parsing."""
+    """Extracts the merger ID from the HTML file using regex, avoiding a full HTML parse."""
     with open(filepath, 'r', encoding='utf-8') as f:
         html_content = f.read()
-    soup = BeautifulSoup(html_content, 'html.parser')
-    id_tag = soup.select_one('.field--name-dynamic-token-fieldnode-acccgov-merger-id .field__item')
-    if id_tag:
-        return id_tag.get_text(strip=True)
-    return None
+    match = re.search(
+        r'field--name-dynamic-token-fieldnode-acccgov-merger-id[^>]*>.*?'
+        r'class="field__item"[^>]*>.*?([A-Z]{2}-\d+)',
+        html_content, re.DOTALL
+    )
+    return match.group(1) if match else None
 
 
 def enrich_with_questionnaire_data(mergers_data):

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,4 +1,5 @@
 beautifulsoup4==4.12.3
+lxml==6.1.0
 requests==2.32.3
 markdownify==0.14.1
 pdfplumber==0.11.9


### PR DESCRIPTION
## Summary
This PR improves the performance and efficiency of HTML parsing in the merger extraction script by switching to the lxml parser and replacing full HTML parsing with regex-based extraction where appropriate.

## Key Changes
- **Parser upgrade**: Changed BeautifulSoup parser from `html.parser` to `lxml` in `parse_merger_file()` for faster HTML parsing performance
- **Optimized merger ID extraction**: Refactored `get_merger_id_from_file()` to use regex pattern matching instead of full HTML parsing, avoiding unnecessary DOM traversal for a simple field extraction
- **Updated docstring**: Clarified that `get_merger_id_from_file()` now uses regex to avoid full HTML parsing

## Implementation Details
The regex pattern in `get_merger_id_from_file()` directly matches the merger ID field structure (`field--name-dynamic-token-fieldnode-acccgov-merger-id`) and extracts the ID value using a capture group that matches the expected format (`[A-Z]{2}-\d+`). This approach is more efficient than instantiating a BeautifulSoup object and performing CSS selector queries for a single field extraction.

https://claude.ai/code/session_01WjiG2XVK7fC5dMeavDJ9BM