### PR TITLE
Prevent spurious commits of acquisitions-register.html

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -217,28 +217,54 @@ jobs:
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else
-            git commit -m "Update merger data: ${timestamp}"
-            git pull --rebase || { git rebase --abort; exit 1; }
+            # Guard: skip the commit if only acquisitions-register.html is staged.
+            # The scrape-changes filter above handles the obvious case (register is
+            # the only scraped change), but it can be bypassed when a matter page
+            # changes cosmetically (non_register > 0 → filter skipped, changed=true)
+            # yet extraction produces output identical to HEAD, leaving the register
+            # as the sole meaningful staged diff.
+            staged_non_register=$(git diff --staged --name-only \
+              | grep -v "^data/raw/acquisitions-register\.html$" | wc -l)
+            if [ "$staged_non_register" -eq 0 ]; then
+              echo "Only acquisitions-register.html staged — skipping commit"
+            else
+              git commit -m "Update merger data: ${timestamp}"
+              git pull --rebase || { git rebase --abort; exit 1; }
 
-            # After rebase, re-clean any HTML files that changed. A 3-way merge
-            # during rebase can reintroduce raw dynamic tokens if both the local
-            # commit and the pulled commits touched the same file.
-            rebase_html=$(git diff HEAD^..HEAD --name-only 2>/dev/null | grep '\.html$' || true)
-            if [ -n "$rebase_html" ]; then
-              echo "HTML files in rebased commit:"
-              echo "$rebase_html" | sed 's/^/  /'
-              while IFS= read -r f; do
-                if [ -f "$f" ]; then
-                  ./scripts/scrape.sh --clean-file "$f"
-                  git add "$f"
-                  echo "Re-cleaned: $f"
+              # After rebase, re-clean any HTML files that changed. A 3-way merge
+              # during rebase can reintroduce raw dynamic tokens if both the local
+              # commit and the pulled commits touched the same file.
+              rebase_html=$(git diff HEAD^..HEAD --name-only 2>/dev/null | grep '\.html$' || true)
+              if [ -n "$rebase_html" ]; then
+                echo "HTML files in rebased commit:"
+                echo "$rebase_html" | sed 's/^/  /'
+                while IFS= read -r f; do
+                  if [ -f "$f" ]; then
+                    ./scripts/scrape.sh --clean-file "$f"
+                    git add "$f"
+                    echo "Re-cleaned: $f"
+                  fi
+                done <<< "$rebase_html"
+                if ! git diff --staged --quiet; then
+                  echo "WARNING: Rebase introduced uncleaned HTML — amending commit to fix"
+                  git commit --amend --no-edit
                 fi
-              done <<< "$rebase_html"
-              if ! git diff --staged --quiet; then
-                echo "WARNING: Rebase introduced uncleaned HTML — amending commit to fix"
-                git commit --amend --no-edit
+              fi
+
+              # After rebase (and any amend), check whether our commit was reduced to
+              # only acquisitions-register.html. This can happen if a concurrent run
+              # already committed the shared matter-page/processed-data changes, leaving
+              # only the slightly-different acquisitions-register.html in our rebased
+              # commit. Drop it rather than push noise.
+              post_rebase_non_register=$(git diff HEAD^..HEAD --name-only 2>/dev/null \
+                | grep -v "^data/raw/acquisitions-register\.html$" | wc -l)
+              if git diff HEAD^..HEAD --name-only 2>/dev/null \
+                  | grep -q "acquisitions-register" \
+                  && [ "$post_rebase_non_register" -eq 0 ]; then
+                echo "Rebase reduced commit to acquisitions-register.html only — dropping, not pushing"
+                git reset --hard HEAD^
+              else
+                git push
               fi
             fi
-
-            git push
           fi


### PR DESCRIPTION
## Summary
This change adds guards to prevent committing and pushing when only the acquisitions-register.html file has staged changes, which can occur due to cosmetic changes in matter pages or concurrent runs. This reduces noise in the git history and prevents unnecessary pushes.

## Key Changes
- **Pre-commit guard**: Check if only acquisitions-register.html is staged before committing. If so, skip the entire commit/push workflow.
- **Post-rebase guard**: After rebasing and amending, check again if the commit has been reduced to only acquisitions-register.html changes. If so, reset the commit rather than pushing it.
- **Improved logic flow**: Wrap the commit, rebase, and push operations in a conditional block that only executes when there are meaningful (non-register) changes staged.

## Implementation Details
- The pre-commit check counts staged files excluding acquisitions-register.html; if the count is zero, the commit is skipped entirely.
- The post-rebase check handles the scenario where concurrent runs may have already committed shared changes (matter pages/processed data), leaving only the register file with minor differences in the rebased commit.
- Both guards use the same file pattern matching (`grep -v "^data/raw/acquisitions-register\.html$"`) for consistency.
- The post-rebase reset uses `git reset --hard HEAD^` to discard the register-only commit without pushing.

https://claude.ai/code/session_01XCh1n6pmAHDH4pDHoESU1e