### PR TITLE
Support day names in deadline extraction regex

### DIFF
--- a/scripts/parse_questionnaire.py
+++ b/scripts/parse_questionnaire.py
@@ -33,7 +33,7 @@ def extract_deadline(text: str) -> Optional[str]:
     # Pattern handles both formats:
     # 1. "Deadline to respond: 25 August 2025"
     # 2. "Deadline to respond: 5.00pm (AEDT) on 20 October 2025"
-    pattern = r'Deadline to respond:\s*(?:[\d:.apm]+\s*\([A-Z]+\)\s+on\s+)?(\d{1,2}\s+[A-Za-z]+\s+\d{4})'
+    pattern = r'Deadline to respond:\s*(?:[\d:.apm]+\s*\([A-Z]+\)\s+on\s+)?(?:[A-Za-z]+,\s*)?(\d{1,2}\s+[A-Za-z]+\s+\d{4})'
     match = re.search(pattern, text, re.IGNORECASE | re.DOTALL)
 
     if match:

--- a/scripts/tests/test_pipeline.py
+++ b/scripts/tests/test_pipeline.py
@@ -170,6 +170,11 @@ class TestExtractDeadline:
     def test_empty_text(self):
         assert extract_deadline("") is None
 
+    def test_deadline_with_day_name_and_comma(self):
+        text = "Deadline to respond: Wednesday, 6 May 2026"
+        result = extract_deadline(text)
+        assert result == "6 May 2026"
+
     def test_deadline_with_newline_in_date(self):
         text = "Deadline to respond: 25\nAugust 2025"
         # The regex uses DOTALL so \s+ matches newlines


### PR DESCRIPTION
## Summary
Updated the deadline extraction regex pattern to handle dates that include day names (e.g., "Wednesday, 6 May 2026"), which are common in questionnaire responses.

## Changes
- Modified the regex pattern in `extract_deadline()` to optionally match day names followed by a comma before the date
- Added `(?:[A-Za-z]+,\s*)?` non-capturing group to the pattern to handle the day name format
- Added test case `test_deadline_with_day_name_and_comma()` to verify the new functionality correctly extracts dates with day names

## Implementation Details
The regex now supports three deadline formats:
1. Simple date: "Deadline to respond: 25 August 2025"
2. Time with timezone: "Deadline to respond: 5.00pm (AEDT) on 20 October 2025"
3. Day name with date: "Deadline to respond: Wednesday, 6 May 2026"

The day name pattern uses a non-capturing group with `?` quantifier to make it optional, ensuring backward compatibility with existing deadline formats.

https://claude.ai/code/session_011Pzq2FXkGhybbM68PAQzo6