### PR TITLE
Fix missing questionnaire event date for WIN Television merger

### DIFF
--- a/data/frozen_events_mergers.json
+++ b/data/frozen_events_mergers.json
@@ -1,3 +1,7 @@
 {
   "_comment": "Override data for specific mergers. An entry with an empty dict or 'freeze_events: true' preserves the existing events array rather than overwriting from the scraped page (use this when the ACCC events table is incorrect). Any other keys are treated as field overrides — the scraper will use these values instead of whatever it finds on the page.",
+  "MN-50008": {
+    "_comment": "Questionnaire event date (28 Apr 2026) is missing from the ACCC page; freezing events to preserve the manually set date.",
+    "freeze_events": true
+  }
 }

--- a/data/processed/mergers.json
+++ b/data/processed/mergers.json
@@ -4904,7 +4904,7 @@
     "merger_description": "WIN Television Network Pty Ltd (**WIN TV**) proposes to acquire 100% of the shares in NBN Enterprises Pty Limited (**NBN**) from Nine Network Australia Holdings Pty Ltd and 100% of the shares in Television Holdings Darwin Pty Limited (**NTD**) from Nine Network Australia Pty Limited (the **Acquisition**).  \n\nNBN and NTD are wholly owned subsidiaries of the Nine Network Australia Holdings Pty Ltd and Nine Network Australia Pty Limited respectively, and are ultimately controlled by Nine Entertainment Co. Holdings Limited (the parent company of a group of companies known as the Nine Group). Both NBN and NTD, via their respective wholly owned subsidiaries, operate regional free-to-air television stations. NBN broadcasts across the Northern NSW (**NNSW**) and Gold Coast regions, while NTD broadcasts to Darwin, Palmerston and the surrounding areas in the Northern Territory.\n\nWIN TV is the parent company of a group of wholly owned subsidiaries which broadcast free-to-air television in other parts of regional Australia.\n\nThere is no geographic overlap between the local broadcasting areas of WIN TV, NBN and NTD.",
     "events": [
       {
-        "date": "",
+        "date": "2026-04-28T12:00:00Z",
         "title": "Questionnaire - WIN Television Network - NBN Enterprises & Television Holdings Darwin",
         "display_title": "Questionnaire - WIN Television Network - NBN Enterprises & Television Holdings Darwin",
         "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/WIN%20Network%20-%20NBN%20Enterprises%20%26%20Television%20Holdings%20Darwin%20-%20Third%20party%20questionnaire.docx",


### PR DESCRIPTION
## Summary
Added the missing questionnaire event date for the WIN Television Network merger (MN-50008) and configured the merger data to preserve this manually-set date during future scrapes.

## Changes
- **frozen_events_mergers.json**: Added override entry for MN-50008 with `freeze_events: true` to prevent the ACCC scraper from overwriting the events array, since the questionnaire event date is missing from the ACCC page
- **mergers.json**: Set the questionnaire event date to `2026-04-28T12:00:00Z` for the WIN Television Network - NBN Enterprises & Television Holdings Darwin merger

## Details
The ACCC merger register page for this transaction was missing the questionnaire event date in its events table. Rather than relying on the scraper to populate this field, the date has been manually set and the merger is now configured to freeze its events array, ensuring the correct date is preserved across future data updates.

https://claude.ai/code/session_01B7bLykT3E21apBfFV2StsG