### PR TITLE
Add keyboard shortcut to focus navbar search

### DIFF
--- a/merger-tracker/frontend/src/components/Navbar.jsx
+++ b/merger-tracker/frontend/src/components/Navbar.jsx
@@ -65,6 +65,22 @@ function Navbar() {
   }, [searchOpen]);
 
   useEffect(() => {
+    const handleFocusNavbarSearch = () => {
+      if (window.matchMedia('(min-width: 640px)').matches) {
+        setSearchOpen(true);
+        if (searchInputRef.current) {
+          searchInputRef.current.focus();
+        }
+      } else {
+        focusMobileSearchRef.current = true;
+        setMobileMenuOpen(true);
+      }
+    };
+    window.addEventListener('focus-navbar-search', handleFocusNavbarSearch);
+    return () => window.removeEventListener('focus-navbar-search', handleFocusNavbarSearch);
+  }, []);
+
+  useEffect(() => {
     if (mobileMenuOpen && focusMobileSearchRef.current && mobileSearchInputRef.current) {
       mobileSearchInputRef.current.focus();
       focusMobileSearchRef.current = false;

--- a/merger-tracker/frontend/src/hooks/useKeyboardShortcuts.js
+++ b/merger-tracker/frontend/src/hooks/useKeyboardShortcuts.js
@@ -71,12 +71,15 @@ export function useKeyboardShortcuts({ onToggleHelp } = {}) {
         return;
       }
 
-      // "/" to focus search
+      // "/" to focus search — prefer an in-page search input if the page has
+      // one (Mergers, Industries); otherwise fall back to the navbar search.
       if (e.key === '/') {
+        e.preventDefault();
         const searchInput = document.getElementById('search');
         if (searchInput) {
-          e.preventDefault();
           searchInput.focus();
+        } else {
+          window.dispatchEvent(new CustomEvent('focus-navbar-search'));
         }
         return;
       }


### PR DESCRIPTION
## Summary
Improved keyboard navigation by enabling the "/" shortcut to focus the navbar search when no in-page search input is available.

## Key Changes
- **Navbar.jsx**: Added a new `useEffect` hook that listens for a custom `focus-navbar-search` event. When triggered, it opens the search bar on desktop (≥640px) or opens the mobile menu on smaller screens and focuses the mobile search input.
- **useKeyboardShortcuts.js**: Enhanced the "/" key handler to:
  - First check for an in-page search input (used on Mergers and Industries pages)
  - If found, focus that input
  - If not found, dispatch the custom `focus-navbar-search` event to trigger navbar search focus
  - Moved `preventDefault()` outside the conditional to ensure the default behavior is always blocked

## Implementation Details
- Uses a custom DOM event (`focus-navbar-search`) to communicate between the keyboard shortcut hook and the Navbar component
- Respects responsive design by handling desktop and mobile layouts differently
- Maintains backward compatibility with existing in-page search inputs while providing a fallback for pages without them

https://claude.ai/code/session_01Ctafh25KBafUuYEPZzYcQW