### PR TITLE
Rebrand weekly digest emails to Australian Merger Tracker

### DIFF
--- a/.github/workflows/send-weekly-email.yml
+++ b/.github/workflows/send-weekly-email.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Upload rendered HTML preview
         if: ${{ inputs.dry_run == true }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digest-email-preview
           path: /tmp/digest_email_preview.html

--- a/.github/workflows/send-weekly-email.yml
+++ b/.github/workflows/send-weekly-email.yml
@@ -42,3 +42,11 @@ jobs:
           RESEND_AUDIENCE_ID: ${{ secrets.RESEND_AUDIENCE_ID }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: python scripts/send_weekly_email.py
+
+      - name: Upload rendered HTML preview
+        if: ${{ inputs.dry_run == true }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-email-preview
+          path: /tmp/digest_email_preview.html
+          if-no-files-found: error

--- a/scripts/send_weekly_email.py
+++ b/scripts/send_weekly_email.py
@@ -236,8 +236,9 @@ def stat_card(count: int, label: str, color: dict, anchor: str, width: str = "16
         f'<td width="{width}" style="padding:4px 3px;">'
         f'<a href="{url}" style="text-decoration:none;display:block;">'
         f'<table width="100%" cellpadding="0" cellspacing="0" border="0">'
-        f'<tr><td style="background:{color["pale"]};border-radius:8px;'
-        f'padding:12px 6px;text-align:center;border:1px solid {color["border"]}33;">'
+        f'<tr><td height="86" style="background:{color["pale"]};border-radius:8px;'
+        f'padding:12px 6px;text-align:center;border:1px solid {color["border"]}33;'
+        f'height:86px;vertical-align:middle;">'
         f'<div style="color:{color["border"]};font-size:26px;font-weight:700;line-height:1;">'
         f"{count}</div>"
         f'<div style="color:{color["dark"]};font-size:11px;font-weight:500;'

--- a/scripts/send_weekly_email.py
+++ b/scripts/send_weekly_email.py
@@ -32,7 +32,7 @@ from date_utils import parse_iso_datetime
 
 SITE_BASE = "https://mergers.fyi"
 RESEND_API_BASE = "https://api.resend.com"
-SEND_FROM = os.environ.get("SEND_FROM", "mergers.fyi weekly digest <digest@mergers.fyi>")
+SEND_FROM = os.environ.get("SEND_FROM", "Australian Merger Tracker <digest@mergers.fyi>")
 
 # Colour palette matching tailwind.config.js
 COLORS = {
@@ -146,7 +146,7 @@ def build_text_email(digest: dict) -> str:
     referred = digest.get("deals_referred_to_phase_2") or []
 
     lines = [
-        "mergers.fyi weekly digest",
+        "Australian Merger Tracker weekly digest",
         f"Week of {date_range}",
         f"{SITE_BASE}/digest",
         "",
@@ -492,7 +492,7 @@ def build_html_email(digest: dict) -> str:
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>mergers.fyi weekly digest for {esc(date_range)}</title>
+  <title>Weekly mergers digest for {esc(date_range)} | Australian Merger Tracker</title>
 </head>
 <body style="margin:0;padding:0;background-color:#f1f5f9;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,Helvetica,sans-serif;">
 
@@ -507,15 +507,15 @@ def build_html_email(digest: dict) -> str:
 
         <!-- HEADER -->
         <tr>
-          <td style="background:#335145;border-radius:12px 12px 0 0;padding:26px 28px 22px;">
-            <span style="font-size:18px;font-weight:700;color:#ffffff;letter-spacing:-0.3px;">
-              mergers.fyi weekly digest
+          <td style="background:#ffffff;border:1px solid #e5e7eb;border-bottom:none;border-radius:12px 12px 0 0;padding:26px 28px 22px;">
+            <span style="font-size:18px;letter-spacing:-0.3px;">
+              <span style="font-weight:700;color:#335145;">australian merger tracker</span><span style="font-weight:400;color:#335145;"> weekly digest</span>
             </span>
             <br>
-            <span style="font-size:13px;color:#a3c4b3;margin-top:6px;display:block;">
+            <span style="font-size:13px;color:#6b7280;margin-top:6px;display:block;">
               Week of {esc(date_range)}
               &nbsp;&middot;&nbsp;
-              <a href="{SITE_BASE}/digest" style="color:#a3c4b3;text-decoration:underline;">
+              <a href="{SITE_BASE}/digest" style="color:#335145;text-decoration:underline;">
                 View online
               </a>
             </span>
@@ -656,7 +656,7 @@ def main() -> None:
     digest = load_digest()
 
     date_range = format_date_range(digest["period_start"], digest["period_end"])
-    subject = f"mergers.fyi weekly digest for {date_range}"
+    subject = f"Weekly mergers digest for {date_range} | Australian Merger Tracker"
     broadcast_name = f"Weekly digest \u2013 {date_range}"
 
     print(f"Period: {date_range}")


### PR DESCRIPTION
## Summary
This PR updates the weekly digest email branding from "mergers.fyi" to "Australian Merger Tracker" across all email templates and configurations.

## Key Changes
- Updated the default sender name from "mergers.fyi weekly digest" to "Australian Merger Tracker"
- Rebranded email subject lines to use "Weekly mergers digest for [date] | Australian Merger Tracker" format
- Redesigned the email header:
  - Changed background from dark green (#335145) to white
  - Updated text styling to split "australian merger tracker" (bold) and "weekly digest" (regular weight)
  - Adjusted text colors for better contrast on white background
  - Updated secondary text color from light green to gray (#6b7280)
  - Changed "View online" link color to match the new dark green accent
- Improved stat card styling by adding explicit height and vertical alignment for better consistency
- Updated HTML email title tag to reflect new branding

## Implementation Details
- All branding changes maintain the existing color palette (dark green #335145 remains as accent)
- Email layout and structure remain unchanged; only visual styling and text content updated
- Changes applied consistently across HTML email, text email, and email metadata

https://claude.ai/code/session_01XNMtdc2AC3gM1xgZcZkrR4