### PR TITLE
Add NOCC (Notice of Competition Concerns) parsing and display

### DIFF
--- a/data/processed/nocc_data.json
+++ b/data/processed/nocc_data.json
@@ -1,0 +1,936 @@
+{
+  "MN-01019": {
+    "date": "2 March 2026",
+    "date_iso": "2026-03-02",
+    "document_type": "Notice of Competition Concerns \u2013 Summary",
+    "file_name": "Ampol_EG - NOCC summary - AR version - 2 March 2026.pdf",
+    "file_path": "matters/MN-01019/Ampol_EG - NOCC summary - AR version - 2 March 2026.pdf",
+    "matter_id": "MN-01019",
+    "sections": [
+      {
+        "blocks": [
+          {
+            "number": "1.1",
+            "text": "On 10 October 2025, Ampol Limited lodged a notification in respect of Ampol Retail Holding Pty Ltd\u2019s proposed acquisition of 100% of the share capital in EG Group Australia Pty Ltd and EG AsiaPac Holdings Limited (the Acquisition) with the Australian Competition and Consumer Commission (ACCC).",
+            "type": "paragraph"
+          },
+          {
+            "number": "1.2",
+            "text": "On 20 January 2026, the ACCC decided that the Acquisition is to be subject to Phase 2 review.",
+            "type": "paragraph"
+          },
+          {
+            "number": "1.3",
+            "text": "On 27 February 2026, the ACCC issued a Notice of Competition Concerns (NOCC) to Ampol.",
+            "type": "paragraph"
+          },
+          {
+            "number": "1.4",
+            "text": "The NOCC sets out the ACCC\u2019s preliminary assessment of whether the acquisition, if put into effect, would have the effect, or be likely to have the effect, of substantially lessening competition in any market, and the grounds on which the ACCC makes its assessment, referring to the evidence or other material on which those grounds are based.",
+            "type": "paragraph"
+          },
+          {
+            "number": "1.5",
+            "text": "This is a summary of the NOCC as required to be published on the Acquisitions Register.",
+            "type": "paragraph"
+          }
+        ],
+        "number": "1",
+        "title": "Introduction"
+      },
+      {
+        "blocks": [
+          {
+            "text": "The acquirer \u2013 Ampol",
+            "type": "heading"
+          },
+          {
+            "number": "2.1",
+            "text": "Ampol Retail Holding Pty Ltd is a wholly-owned subsidiary of Ampol Limited (Ampol), which is listed on the ASX. Ampol is a vertically integrated fuel company with upstream fuel production and importing assets, wholesale supply and distribution facilities and a network of fuel and retail convenience sites across Australia.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.2",
+            "text": "Ampol owns the Lytton refinery in Brisbane, Queensland, where it refines imported crude oil, and a number of terminals nationwide through which it imports finished petrol products from overseas refineries and trading houses.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.3",
+            "text": "Ampol operates retail sites under both the Ampol brand and the U-GO brand. Ampol branded sites are full-service sites with fuel and convenience offerings. Launched in 2023, the U-GO branded sites are low cost, unstaffed self-service sites selling only fuel and with no convenience offering. Ampol owns and operates 576 sites under the Ampol brand and 46 under the U-GO brand.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.4",
+            "text": "Ampol also has 50% interests in the following two fuel distributors and retailers:",
+            "type": "paragraph"
+          },
+          {
+            "items": [
+              "Bonney Energy Group Pty Ltd (Bonney Energy) is a distributor of Ampol fuel. Bonney Energy operates 45 retail fuel sites across regional Victoria and Tasmania under the Ampol brand.",
+              "Geraldton Fuel Company Pty Ltd (trading as Refuel Australia) is a fuel distributor operating in Western Australia and the Northern Territory. Twenty-eight of Refuel Australia\u2019s 38 locations operate under the Ampol brand."
+            ],
+            "type": "bullet_list"
+          },
+          {
+            "text": "The target \u2013 EG Australia",
+            "type": "heading"
+          },
+          {
+            "number": "2.5",
+            "text": "EG Group Australia and EG AsiaPac Holdings are the entities that carry on EG Group\u2019s business in Australia (together, EG Australia), which includes the retail supply of fuel, food to go and convenience products. EG Australia is owned by EG Group, a UK-based independent fuel and convenience retailer with sites across Europe and North America.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.6",
+            "text": "EG Australia commenced operations in Australia in April 2019 when EG Group acquired Woolworths\u2019 retail fuel and convenience sites. EG Australia owns and operates 512 retail fuel sites.",
+            "type": "paragraph"
+          },
+          {
+            "text": "Relationship between the Parties",
+            "type": "heading"
+          },
+          {
+            "number": "2.7",
+            "text": "Ampol and EG Australia (together, the Parties) have a fuel supply agreement (FSA) whereby Ampol is EG Australia\u2019s exclusive wholesale supplier of fuel until 2033. Pursuant to the FSA and other agreements which were novated from Woolworths to EG Group in 2019, EG Australia\u2019s retail fuel sites must carry the \u2018Ampol\u2019 brand, while its convenience stores carry the \u2018EG\u2019 brand.",
+            "type": "paragraph"
+          },
+          {
+            "text": "The Acquisition",
+            "type": "heading"
+          },
+          {
+            "number": "2.8",
+            "text": "Ampol proposes to acquire 100% of the share capital in EG Australia for $1.1 billion.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.9",
+            "text": "In public statements about the Acquisition, Ampol states that the Acquisition will enable it to expand its national footprint (to 1,134 sites) and accelerate Ampol\u2019s retail growth strategy through segmented offers.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.10",
+            "text": "As part of this, a key stated rationale for the Acquisition is to accelerate the rollout of U-GO sites. In particular, Ampol states that it would progressively convert 125 EG Australia sites to U-GO sites over a two year period (with the remainder to be rebranded as Ampol Foodary sites). Ampol currently has 46 U-GO sites and plans to convert 14 additional Ampol sites by the end of 2026. Taken together, Ampol would have close to 200 U-GO sites in 2 to 3 years\u2019 time.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.11",
+            "text": "EG Group has stated that it is seeking to exit the Australian market with the proceeds from the sale to be used to reduce the Group\u2019s debt and focus on global markets where it sees growth opportunities.",
+            "type": "paragraph"
+          },
+          {
+            "text": "Industry background",
+            "type": "heading"
+          },
+          {
+            "number": "2.12",
+            "text": "In assessing the competitive effects of the Acquisition, it is relevant to understand that Australia\u2019s fuel industry consists of three broad levels \u2013 the import of refined fuel and the domestic refining of crude oil (suppliers), the sale or resale and distribution of wholesale fuel (primary and secondary wholesalers), and retail supply. This structure is depicted at Figure 1 below. Figure 1. Fuel industry structure",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.13",
+            "text": "Further industry background relevant to the ACCC\u2019s competition assessment is set out below.",
+            "type": "paragraph"
+          },
+          {
+            "text": "Refining and wholesale supply",
+            "type": "heading"
+          },
+          {
+            "number": "2.14",
+            "text": "A number of Australian fuel suppliers, including Ampol, are vertically integrated, refining and/or importing fuel and supplying fuel to downstream retail sites.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.15",
+            "text": "Refineries process and transform crude oil into refined petroleum products (including petrol, diesel, jet fuel, fuel oil and other fuel products). Currently, there are 2 refineries operating in Australia \u2013 Viva Energy\u2019s Geelong refinery in Victoria and Ampol\u2019s Lytton refinery in Queensland. However, other market participants such as Chevron have refinery operations in the Asia-Pacific region. Chevron has interests in refineries in South Korea, Thailand and Singapore, which are sources of refined product for some retailers in Australia.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.16",
+            "text": "Import terminals receive refined petroleum products by ship, store them and distribute them to retailers. A number of parties import finished products into Australia from overseas including Ampol, BP, Chevron, ExxonMobil, United, Viva Energy, IOR, PetroChina and Freedom Fuels.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.17",
+            "text": "Refiners and many importers supply fuel to secondary wholesalers or directly to retailers on a wholesale basis. Currently, the four major wholesalers in Australia are Ampol, BP, ExxonMobil and Viva Energy.",
+            "type": "paragraph"
+          },
+          {
+            "text": "Retail supply and competition in fuel retailing",
+            "type": "heading"
+          },
+          {
+            "number": "2.18",
+            "text": "The ACCC has a monitoring role in fuel markets and reports on fuel prices and industry issues as a part of that role. In various reports, the ACCC has identified certain trends in relation to competition in fuel retailing. These trends are relevant to the assessment of the competitive impact of the Acquisition and are set out below.",
+            "type": "paragraph"
+          },
+          {
+            "text": "Composition of retail fuel markets",
+            "type": "heading"
+          },
+          {
+            "number": "2.19",
+            "text": "Australia\u2019s downstream retail supply has evolved over the past decade with market consolidation through acquisitions, expansion by several retailers and other retail brands opening in Australia. The net result of these changes is that the number of retail sites increased from around 7,500 in 2018 to over 8,000 in 2026.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.20",
+            "text": "Fuel retailers in Australia have varied business models and structures. They can be broadly categorised as follows:",
+            "type": "paragraph"
+          },
+          {
+            "items": [
+              "Larger, national, vertically integrated retailers: Ampol, Viva Energy (including the Reddy Express and On The Run retail networks), BP and Chevron (operating under the Caltex and Puma Energy retail brands) (major fuel retailers).",
+              "Larger, national independent retailers with or without branded fuel supplier: EG Australia, United Petroleum, and 7 Eleven (major independent fuel retailers).",
+              "Smaller independent retailers, such as Speedway, Metro Petroleum, Freedom Fuels, Budget, Vibe, and Pearl Energy (small independent fuel retailers).",
+              "Dealers under the national branded retailers (independently priced sites branded BP, Shell, Ampol etc)."
+            ],
+            "type": "bullet_list"
+          },
+          {
+            "number": "2.21",
+            "text": "The brand of the retail site will often, but not always, reflect the owner or fuel price setter of the retail site. Some independent chains use a fuel supplier brand but set their own retail fuel prices, as do some single site retail operations.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.22",
+            "text": "While these different groups of retailers generally offer the same fuel types, they differ in non-fuel offerings, scale of presence across Australia and in each state or territory, and pricing strategy. Major fuel retailers and major independent fuel retailers have a national presence and are likely to compete more on non-fuel offerings, such as convenience products and services. In contrast, smaller independent fuel retailers may have fewer sites across a city and/or are not present in all states/territories and tend to compete primarily on fuel price to attract consumers.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.23",
+            "text": "The aggregated share of national petrol sales volumes of the small independent fuel retailers has gradually increased over time, from 18% in 2017\u201318 to around 26% in 2023-24. The ACCC estimates that, as a group, small independent fuel retailers have the strongest presence in Sydney, Melbourne and Adelaide, and a small presence in Brisbane and Canberra. However, the ACCC has noted that the presence of these independents differs from city to city. For example, Freedom Fuels only has sites in and around Brisbane while Speedway is present mainly in Sydney and Melbourne.",
+            "type": "paragraph"
+          },
+          {
+            "text": "Petrol price movements",
+            "type": "heading"
+          },
+          {
+            "number": "2.24",
+            "text": "As the ACCC\u2019s ongoing monitoring of fuel markets has found, Australian fuel prices are typically influenced by international benchmark crude oil and refined fuel prices and the value of the Australian dollar, as well as the levels of competition in different locations.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.25",
+            "text": "In addition, in the major cities such as Sydney, Melbourne, Brisbane, Adelaide and Perth, petrol prices move up and down in regular patterns. These patterns are known as petrol price cycles. Petrol price cycles are not driven by movements in wholesale prices or underlying costs and not all retailers participate in price cycles. Price cycles do not occur for retail diesel and automotive LPG prices.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.26",
+            "text": "Typically in a price cycle, prices at individual retail sites increase sharply, then decrease more gradually over a longer period before the process repeats. Not all retail sites change prices at the same time, meaning average metropolitan-wide prices can take time to increase (and decrease).",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.27",
+            "text": "Average prices move up and down across two phases. The ACCC has made the following observations regarding these phases:",
+            "type": "paragraph"
+          },
+          {
+            "items": [
+              "In the increase phase, various retailers generally increase prices substantially to the same or a similar price point across different locations within a city. The ACCC has observed some retailers increasing prices to varying levels, including levels below the highest priced retailer.",
+              "In the decrease phase, retailers tend to more gradually match and undercut their rivals\u2019 pricing until prices begin to approach terminal gate prices (indicative wholesale prices), such that they may be making slim margins or not recovering their purchase costs on petrol. At this point, one or more retailers will tend to increase their prices substantially such that the cycle repeats."
+            ],
+            "type": "bullet_list"
+          },
+          {
+            "number": "2.28",
+            "text": "The ACCC has also observed differences in petrol price cycle patterns in Australia\u2019s largest cities over time. For example, in the year to September 2025, cycles in Sydney were around 5 and a half weeks in duration while in Melbourne they were around 6 and a half weeks and in Brisbane around 7 weeks. Previously, in 2018, the ACCC observed that cycles in the same three cities were about a month long.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.29",
+            "text": "Smaller cities such as Canberra, Hobart and Darwin and most regional areas do not have petrol price cycles.",
+            "type": "paragraph"
+          }
+        ],
+        "number": "2",
+        "title": "Background"
+      },
+      {
+        "blocks": [
+          {
+            "number": "3.1",
+            "text": "The Parties are both retail suppliers of fuel and convenience products in all Australian states and territories. Currently:",
+            "type": "paragraph"
+          },
+          {
+            "items": [
+              "Ampol owns and operates 576 sites under the Ampol brand, and 46 under the U-GO brand.",
+              "EG Australia owns and operates 512 retail fuel sites."
+            ],
+            "type": "bullet_list"
+          },
+          {
+            "number": "3.2",
+            "text": "Acquiring EG Australia\u2019s sites would make Ampol the largest fuel retailer in Australia in terms of number of sites.",
+            "type": "paragraph"
+          },
+          {
+            "number": "3.3",
+            "text": "The Parties also overlap in convenience grocery retailing co-located at fuel sites across Australia. However, as the ACCC does not consider that the Acquisition is likely to result in a substantial lessening of competition in the retail supply of groceries given the remaining constraints on Ampol post-acquisition, no further consideration is given to this overlap in this Notice.",
+            "type": "paragraph"
+          },
+          {
+            "text": "Approach to market definition",
+            "type": "heading"
+          },
+          {
+            "number": "3.4",
+            "text": "Adopting the ACCC\u2019s past approach to market definition in the fuel industry, Ampol has submitted that the relevant markets for considering the competitive effects of the Acquisition are:",
+            "type": "paragraph"
+          },
+          {
+            "items": [
+              "Local markets for the supply of fuel through retail outlets in the vicinity of each EG Australia site, applying up to a 5km radius around each site in metropolitan areas and a 10km radius around each site in regional areas.",
+              "Metropolitan-wide markets for the retail supply of fuel in metropolitan areas such as Sydney, Melbourne, Brisbane, Perth and Adelaide."
+            ],
+            "type": "bullet_list"
+          },
+          {
+            "number": "3.5",
+            "text": "The ACCC broadly accepts Ampol\u2019s submission that the competitive effects of the Acquisition are to be assessed at a local level and a metropolitan level. However, as set out further below, the ACCC has considered the relevant geographic dimension in each local area individually. In each local area, the ACCC has applied a broader or narrower radius, having regard to the presence of traffic routes, natural barriers, and/or due to other information provided by the Parties.",
+            "type": "paragraph"
+          },
+          {
+            "number": "3.6",
+            "text": "In addition, the ACCC considers that:",
+            "type": "paragraph"
+          },
+          {
+            "items": [
+              "In terms of the product dimension of the relevant markets, petrol and diesel should be considered separately. From a demand-side perspective, consumers cannot substitute between petrol and diesel without switching vehicles. Additionally, some sites offer only diesel as they aim to cater for trucks and other fleet vehicles that are fuelled only by diesel. Such sites are unlikely to be an alternative option to a petrol site for consumers who have petrol vehicles.",
+              "While within each of the various grades of petrol and diesel, fuel retailers supply a homogeneous product, there is product differentiation in respect of fuel retailers\u2019 non-fuel offerings. Fuel retailers differentiate themselves across various dimensions, including fuel-adjacent offerings (e.g., branding and loyalty schemes, such as reward cards or discount dockets), the other products they supply (e.g., convenience groceries, take away food, dine-in restaurants, car washes, gas bottles and EV charging) and the quality of their sites (including site location, access number and type of pumps, presence and level of staffing)."
+            ],
+            "type": "bullet_list"
+          },
+          {
+            "text": "Geographic dimension of fuel markets",
+            "type": "heading"
+          },
+          {
+            "number": "3.7",
+            "text": "In considering the appropriate radius to apply in defining a local market around an EG Australia site, the ACCC has considered industry surveys regarding how consumers shop for fuel.",
+            "type": "paragraph"
+          },
+          {
+            "number": "3.8",
+            "text": "According to a 2024 industry survey, for many consumers, price remains the top driver of fuel purchasing decisions, with 56% of respondents indicating that price is their primary consideration when choosing a fuel retailer, followed by 12% making a decision to purchase fuel based on service station fuel location and 10% by fuel quality or type. This focus on price has also driven the increased use of fuel price apps, with 40% of consumers using these apps to shop around for fuel.",
+            "type": "paragraph"
+          },
+          {
+            "number": "3.9",
+            "text": "A 2022 industry survey indicated that:",
+            "type": "paragraph"
+          },
+          {
+            "items": [
+              "Around 34% of consumers were willing to travel more than 5 minutes out of their way for cheaper fuel.",
+              "Around 43% of consumers were willing to travel up to 5 minutes out of their way to purchase cheaper fuel.",
+              "Around 20% of consumers would never travel up to 5 minutes out of their way for fuel."
+            ],
+            "type": "bullet_list"
+          },
+          {
+            "number": "3.10",
+            "text": "As this survey indicates, it may still be the case that, for many consumers, the closest substitutes for a given retail fuel site are other retail fuel sites in close geographic proximity. This is because the distance that consumers may be willing to travel to obtain lower prices is likely to be limited by the time and cost of travelling to alternative sites.",
+            "type": "paragraph"
+          },
+          {
+            "number": "3.11",
+            "text": "The emergence of fuel price apps and the increase in their use may have changed these considerations at some level \u2013 for example, it may allow consumers to better plan their fuel purchases. In particular, the ACCC found that consumers are increasingly using apps, such that they can plan both \u2018when\u2019 and \u2018where\u2019 they fill up. Further, the question of where to fill up may also be influenced by work, school and home travel routes such that consumers, depending on the nature of those routes, may have a more geographically dispersed set of fuel sites that they consider are substitutable.",
+            "type": "paragraph"
+          },
+          {
+            "number": "3.12",
+            "text": "As with previous considerations of fuel mergers, and having regard to the above industry surveys, the Parties\u2019 submissions and internal documents, the ACCC considers it appropriate to assess the competitive effects of the Acquisition in both metropolitan-wide and local markets.",
+            "type": "paragraph"
+          },
+          {
+            "number": "3.13",
+            "text": "For each local market, the ACCC has assessed the competitive effects of the Acquisition within a particular radius surrounding the EG Australia target site. The appropriate radius considered for each local market varies, having regard to specific local conditions.",
+            "type": "paragraph"
+          },
+          {
+            "number": "3.14",
+            "text": "The ACCC has considered the following information to determine the appropriate radius for its preliminary competition assessment in each local market:",
+            "type": "paragraph"
+          },
+          {
+            "items": [
+              "The location of competitors.",
+              "Topographical features that may impact demand-side substitution. For example, in some local markets, there may be traffic routes and/or natural barriers that affect the distance consumers are willing to travel to purchase fuel."
+            ],
+            "type": "bullet_list"
+          },
+          {
+            "number": "3.15",
+            "text": "In addition to local market competition, evidence before the ACCC indicates that it is also appropriate to consider the competitive effect of the Acquisition on metropolitan areas in which Ampol and EG Australia are among the largest fuel retail networks. In cities with petrol price cycles, the existence of those price cycles appears to be evidence of, or at least consistent with, retailers monitoring and responding to the pricing behaviour of competitors across a metropolitan area and not just locally.",
+            "type": "paragraph"
+          },
+          {
+            "number": "3.16",
+            "text": "The density of Ampol and EG Australia sites in Brisbane, Melbourne and Sydney also suggests that multiple areas of local competition between the Parties are likely to overlap with each other and are therefore interconnected. This can be observed in Figure 2, which plots the Ampol (blue) and EG Australia (green) sites on the maps of each city along with competitor sites (grey).",
+            "type": "paragraph"
+          },
+          {
+            "number": "3.17",
+            "text": "In considering a metropolitan-wide market, the ACCC is also concerned with the competitive effects of the Acquisition arising outside of, or extending beyond, local market boundaries. An analysis confined to local effects potentially misses those competitive effects in circumstances where the documentary and data evidence suggests that there are competitive dynamics occurring beyond local market boundaries. Figure 2. Maps of Ampol, EG Australia and competitor sites in Brisbane, Melbourne and Sydney (left to right)",
+            "type": "paragraph"
+          }
+        ],
+        "number": "3",
+        "title": "Overlap and relevant areas of competition"
+      },
+      {
+        "blocks": [
+          {
+            "number": "4.1",
+            "text": "The ACCC is considering the effects of the Acquisition by comparing the likely future state of competition if the Acquisition proceeds against the likely future state of competition if the Acquisition does not proceed.",
+            "type": "paragraph"
+          },
+          {
+            "number": "4.2",
+            "text": "The ACCC\u2019s preliminary view is that the future state of competition without the Acquisition is the status quo, which takes into account that EG Australia may continue to close selected sites that it considers are underperforming and that Ampol is likely to continue rolling out U-GO sites organically.",
+            "type": "paragraph"
+          }
+        ],
+        "number": "4",
+        "title": "The future with and without the Acquisition"
+      },
+      {
+        "blocks": [
+          {
+            "text": "Competitive effects in the retail supply of fuel in local markets in Australia",
+            "type": "heading"
+          },
+          {
+            "number": "5.1",
+            "text": "The ACCC initially identified 274 EG Australia sites that overlap with one or more Ampol sites. Following closer analysis of the overlaps, the ACCC identified in the Phase 2 notice published on 20 January 2026 that the Acquisition could have the effect or likely effect of substantially lessening competition in respect of 115 of those EG Australia site overlaps. Since publishing the notice, the ACCC has continued to analyse these overlaps.",
+            "type": "paragraph"
+          },
+          {
+            "number": "5.2",
+            "text": "The ACCC\u2019s preliminary assessment is that the Acquisition would have the effect or be likely to have the effect of substantially lessening competition in 51 local markets where 54 EG Australia sites overlap with Ampol sites.",
+            "type": "paragraph"
+          },
+          {
+            "number": "5.3",
+            "text": "In addition, the ACCC is continuing to consider whether the Acquisition would have the effect, or likely effect, of substantially lessening competition in relation to an additional 20 local markets where 20 EG Australia sites overlap with Ampol sites.",
+            "type": "paragraph"
+          },
+          {
+            "number": "5.4",
+            "text": "The following factors were relevant to the ACCC\u2019s preliminary assessment of competitive effects:",
+            "type": "paragraph"
+          },
+          {
+            "items": [
+              "The increase and the post-acquisition level of concentration by site numbers in a local area. In some areas, the post-acquisition site share is as high as 75% and the increment is as high as 50%.",
+              "The distance between the Ampol and EG Australia sites. In particular, there are 5 EG Australia sites which are located within 200m of an Ampol site and a further 24 which are within 1km of an Ampol.",
+              "The number, identity and location of remaining competitors. The ACCC\u2019s preliminary view is that some competitors may not impose as strong a constraint on Ampol post-acquisition as EG Australia currently does. This is either because they are not proximate to the Ampol and EG Australia sites, do not have equivalent offerings (for example, do not supply all fuel types, or only offer a small number of pumps) and/or Ampol\u2019s current pricing rule or strategy suggests they would not be a strong competitive constraint."
+            ],
+            "type": "bullet_list"
+          },
+          {
+            "number": "5.5",
+            "text": "The table below shows the locations of the relevant local markets.",
+            "type": "paragraph"
+          },
+          {
+            "number": "5.6",
+            "text": "The ACCC will continue to investigate these matters in Phase 2.",
+            "type": "paragraph"
+          },
+          {
+            "text": "Competitive effects in the retail supply of fuel in metropolitan markets",
+            "type": "heading"
+          },
+          {
+            "number": "5.7",
+            "text": "The ACCC\u2019s preliminary assessment is that the Acquisition would have the effect, or likely effect, of substantially lessening competition in the retail supply of fuel in the metropolitan markets of Brisbane, Melbourne, Sydney, and Canberra.",
+            "type": "paragraph"
+          },
+          {
+            "number": "5.8",
+            "text": "In Brisbane, Melbourne and Sydney, 3 cities with petrol price cycles, the ACCC\u2019s preliminary view is that the removal of EG Australia would likely lead to a substantial lessening of competition through unilateral effects, as:",
+            "type": "paragraph"
+          },
+          {
+            "items": [
+              "The Acquisition removes a direct and significant competitor to Ampol and other major fuel retailers. It will lessen the competitive constraints on the fuel retailers that track and respond to price at Ampol and EG Australia sites in these three metropolitan markets.",
+              "The Acquisition increases Ampol\u2019s share of sites in each of these three metropolitan markets, making it the largest fuel retailer in Sydney and Melbourne and second largest retailer in Brisbane.",
+              "The removal of EG Australia as an independent pricing constraint on Ampol may result in higher prices for consumers as Ampol would implement its own pricing strategies to the EG Australia network. In particular, the Acquisition will remove a competitor in these three markets that:",
+              "prices, on average, lower than Ampol across both phases of the price cycle;",
+              "is often the first mover of the major fuel retailers in the decrease phase of price cycles and has, at times, moved a larger proportion of sites more quickly down in the decrease phase than other major retailers; and",
+              "tends to have, on average, lower prices than Ampol when prices across a metropolitan area are increasing."
+            ],
+            "type": "bullet_list"
+          },
+          {
+            "number": "5.9",
+            "text": "In Canberra, which does not have petrol price cycles, the Acquisition would remove a direct competitor to Ampol and lead to Ampol becoming the largest fuel retailer in that metropolitan market. The ACCC\u2019s preliminary assessment is that the Acquisition would have the effect, or likely effect, of substantially lessening competition in the retail supply of fuel in Canberra from coordinated effects becoming more likely, more complete and/or more sustainable across the remaining retailers. The ACCC is continuing to consider the potential for the Acquisition to give rise to unilateral effects in Canberra.",
+            "type": "paragraph"
+          },
+          {
+            "number": "5.10",
+            "text": "The ACCC has also considered whether the Acquisition is likely to give rise to coordinated effects in Brisbane, Melbourne and Sydney where price cycles are a feature of price competition between fuel retailers. This is separate to the (unilateral) mechanism by which competition could be lessened and prices increased. In considering the evidence before it, the ACCC\u2019s preliminary view is that coordinated effects are not sufficiently likely to arise from the Acquisition in these metropolitan areas that have price cycles to consider them further (as distinct from the potential for unilateral effects). It is therefore no longer investigating whether the Acquisition is likely to give rise to coordinated effects in Brisbane, Melbourne and Sydney.",
+            "type": "paragraph"
+          }
+        ],
+        "number": "5",
+        "title": "Summary of preliminary competition concerns"
+      },
+      {
+        "blocks": [
+          {
+            "number": "6.1",
+            "text": "The ACCC\u2019s preliminary assessment is that the Acquisition is not likely to substantially lessen competition in the Adelaide or Perth metropolitan markets as a result of either unilateral effects or coordinated effects.",
+            "type": "paragraph"
+          },
+          {
+            "number": "6.2",
+            "text": "In Perth, ACCC average pricing analysis indicates EG Australia has higher metropolitan-wide average prices compared to Ampol, meaning EG Australia\u2019s pricing strategy is producing higher pricing outcomes than Ampol\u2019s.Consequently, there is unlikely to be a substantial lessening of competition in the Perth metropolitan market.",
+            "type": "paragraph"
+          },
+          {
+            "number": "6.3",
+            "text": "In relation to Adelaide, the average pricing differential between Ampol and EG Australia is relatively small. The ACCC also notes that Viva Energy is the largest retailer in the metropolitan area, with a share of supply of almost 40% by number of sites. While the Acquisition will increase concentration in Adelaide, with Ampol\u2019s share of sites increasing to approximately 18%, the ACCC notes the incremental increase as a result of the Acquisition would be a 5.3% share of sites. Together, these factors (among others) indicate there is unlikely to be a substantial lessening of competition in the Adelaide metropolitan market.",
+            "type": "paragraph"
+          },
+          {
+            "number": "6.4",
+            "text": "As noted above, the ACCC has is also no longer investigating whether the Acquisition is likely to give rise to coordinated effects in the metropolitan markets of Brisbane, Melbourne and Sydney.",
+            "type": "paragraph"
+          }
+        ],
+        "number": "6",
+        "title": "Areas no longer under active investigation"
+      },
+      {
+        "blocks": [
+          {
+            "number": "7.1",
+            "text": "On 10 October 2025, Ampol made a remedy offer to the ACCC with respect to the Acquisition. The remedy offer was in the form of a draft undertaking pursuant to section 87B of the Act. The undertaking was to divest 19 Ampol and EG Australia fuel retail sites to a purchaser approved by the ACCC (the Remedy Offer).",
+            "type": "paragraph"
+          },
+          {
+            "number": "7.2",
+            "text": "The ACCC\u2019s decision that the Acquisition is to be subject to Phase 2 review set out the ACCC\u2019s consideration of the Remedy Offer.",
+            "type": "paragraph"
+          },
+          {
+            "number": "7.3",
+            "text": "Ampol may make further remedy offers within permitted timeframes. Any such further offer will be assessed and the ACCC may provide feedback.",
+            "type": "paragraph"
+          },
+          {
+            "number": "7.4",
+            "text": "The ACCC\u2019s assessment of a remedy offer will include, but is not limited to, whether the offer could address the relevant competition concerns. For divestitures, the ACCC\u2019s consideration will generally also include matters related to the composition of the proposed divestiture, the availability and identification of an appropriate purchaser, management of risk of business or asset degradation and implementation of the remedy.",
+            "type": "paragraph"
+          },
+          {
+            "number": "7.5",
+            "text": "The ACCC has a broad power to determine the nature, form and scope of any conditions included in a determination and is not confined to either accepting or rejecting a remedy offer. There may be differences between a remedy offer and any remedy that the ACCC includes in a determination as one or more conditions.",
+            "type": "paragraph"
+          }
+        ],
+        "number": "7",
+        "title": "Remedy offer"
+      },
+      {
+        "blocks": [
+          {
+            "number": "8.1",
+            "text": "Following the release of the NOCC, and consistent with s 50ABZL of the Act, the Parties have an opportunity to respond to the preliminary issues identified in the NOCC by 8 April 2026.",
+            "type": "paragraph"
+          },
+          {
+            "number": "8.2",
+            "text": "Under the current statutory timeframe, the ACCC must issue a determination in respect of the Acquisition by 5 June 2026.",
+            "type": "paragraph"
+          }
+        ],
+        "number": "8",
+        "title": "Next steps"
+      }
+    ],
+    "title": "Ampol \u2013 EG Australia"
+  },
+  "MN-01068": {
+    "date": "5 March 2026",
+    "date_iso": "2026-03-05",
+    "document_type": "Notice of Competition Concerns \u2013 Summary",
+    "file_name": "Coles_Kalgoorlie - Final - Summary of Notice of Competition Concerns - March 2026.pdf",
+    "file_path": "matters/MN-01068/Coles_Kalgoorlie - Final - Summary of Notice of Competition Concerns - March 2026.pdf",
+    "matter_id": "MN-01068",
+    "sections": [
+      {
+        "blocks": [
+          {
+            "number": "1.1",
+            "text": "On 27 November 2025, Coles Supermarkets Australia Pty Ltd (Coles Supermarkets) lodged a notification with the Australian Competition and Consumer Commission (ACCC) in respect of its proposed acquisition of a leasehold interest for a supermarket and liquor site in Kalgoorlie, WA (the Acquisition). Coles Supermarkets is a subsidiary of Coles Group Limited (Coles).",
+            "type": "paragraph"
+          },
+          {
+            "number": "1.2",
+            "text": "On 29 January 2026, the ACCC decided that the Acquisition is to be subject to Phase 2 review.",
+            "type": "paragraph"
+          },
+          {
+            "number": "1.3",
+            "text": "On 5 March 2026, the ACCC issued a Notice of Competition Concerns (NOCC) to Coles Supermarkets.",
+            "type": "paragraph"
+          },
+          {
+            "number": "1.4",
+            "text": "The NOCC sets out the ACCC\u2019s preliminary assessment of whether the Acquisition, if put into effect, would have the effect, or be likely to have the effect, of substantially lessening competition in any market, and the grounds on which the ACCC makes its assessment, referring to the evidence or other material on which those grounds are based.",
+            "type": "paragraph"
+          },
+          {
+            "number": "1.5",
+            "text": "This is a summary of the NOCC as required to be published on the Acquisitions Register.",
+            "type": "paragraph"
+          }
+        ],
+        "number": "1",
+        "title": "Introduction"
+      },
+      {
+        "blocks": [
+          {
+            "text": "The Acquisition",
+            "type": "heading"
+          },
+          {
+            "number": "2.1",
+            "text": "Coles Supermarkets proposes to acquire a leasehold interest (the Lease) at Lots 95- 106 Great Eastern Highway, in Somerville, WA (the Property) for the purpose of opening a supermarket and liquor store. Somerville is a suburb of Kalgoorlie-Boulder (Kalgoorlie).",
+            "type": "paragraph"
+          },
+          {
+            "text": "The acquirer \u2013 Coles",
+            "type": "heading"
+          },
+          {
+            "number": "2.2",
+            "text": "Coles is an Australian ASX-listed company. Its subsidiary, Coles Supermarkets, operates more than 800 supermarkets nationwide.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.3",
+            "text": "Coles\u2019 standard offering entails large-format supermarkets that are either freestanding or located in shopping centres. Coles\u2019 large-format stores typically offer standard grocery items, as well as a full-service bakery and deli service. Coles also operates smaller format \u2018Coles Local\u2019 supermarkets with a smaller range of grocery items.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.4",
+            "text": "Coles operates an online grocery shopping and delivery platform named \u2018Coles Online\u2019, which allows consumers to shop for groceries with either home delivery or pick up from \u2018Click&Collect\u2019 locations at existing Coles stores.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.5",
+            "text": "Coles also operates three different chains of liquor stores nationally, under the brand names Liquorland, First Choice Liquor Market (soon to be re-branded as Liquorland Warehouse) and Vintage Cellars (soon to be rebranded as Liquorland Cellars).",
+            "type": "paragraph"
+          },
+          {
+            "text": "Leasehold interest in Kalgoorlie",
+            "type": "heading"
+          },
+          {
+            "number": "2.6",
+            "text": "M Holdings 4 Pty Ltd is proposing to develop a neighbourhood centre on the Property, which is currently vacant. A Coles supermarket and Liquorland store will form part of the neighbourhood centre as a result of the Lease.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.7",
+            "text": "Coles proposes to develop a large format supermarket, with a selling floor area of 2,800 square metres (the Proposed Supermarket).",
+            "type": "paragraph"
+          },
+          {
+            "text": "Industry background \u2013 grocery retailing",
+            "type": "heading"
+          },
+          {
+            "text": "Grocery retailing in Australia",
+            "type": "heading"
+          },
+          {
+            "number": "2.8",
+            "text": "Grocery retailing is characterised by a mix of national supermarket chains and independently owned supermarkets with various business models. These different business models result in variation in pricing, product ranges, store format and competitive behaviour in the supply of groceries in Australia.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.9",
+            "text": "Coles and Woolworths Limited (Woolworths) are Australia\u2019s two largest supermarket operators. They are vertically integrated, meaning they procure groceries directly from suppliers, manage their own distribution and logistics networks and operate retail stores under their respective banners.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.10",
+            "text": "In contrast, many independent supermarkets (including those trading under the IGA banner) are supplied by the wholesale distributor, Metcash Limited (Metcash). Metcash owns and operates some supermarkets, but predominantly supplies groceries and provides marketing and support services to independent supermarkets. Under this business model, independent supermarkets retain control over pricing, range and store operation.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.11",
+            "text": "Independent supermarkets differentiate themselves from Coles and Woolworths in a variety of ways including by sourcing some of their products from local suppliers, including local bakeries, restaurants, and producers.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.12",
+            "text": "There are also independent supermarket operators that are partially vertically integrated. Spudshed, for example, sources a proportion of its fresh produce directly from farms it owns.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.13",
+            "text": "These different business models result in variation in pricing, product ranges, store format and competitive behaviour in the supply of groceries.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.14",
+            "text": "In 2025, the ACCC published its Supermarkets Inquiry (the Inquiry) final report, which reviewed grocery retailing markets in Australia. The ACCC found the Australian supermarket industry is generally highly concentrated and that Coles and Woolworths have limited incentive to compete vigorously on price. The Inquiry found that generally, while independent supermarkets also have a limited ability to compete on price, they offer alternative product ranges to major chains that meet local needs, and compete on other non-price aspects of their offer.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.15",
+            "text": "The Inquiry considered competition in Australian grocery retailing markets generally. In considering the Acquisition, the ACCC is considering competition in Kalgoorlie specifically.",
+            "type": "paragraph"
+          },
+          {
+            "text": "Grocery retailing in Kalgoorlie",
+            "type": "heading"
+          },
+          {
+            "number": "2.16",
+            "text": "There are 6 supermarkets in Kalgoorlie, as set out in Table 1 below, of which 4 supply a larger range of groceries in a larger format store: Woolworths, Coles, Spudshed and O\u2019Connor Fresh IGA. These larger supermarkets offer a comprehensive range of groceries\u2014including fresh produce, meat, dairy, bakery, frozen and general merchandise items\u2014and a \u2018one-stop-shop\u2019 experience for consumers.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.17",
+            "text": "Coles and Woolworths are Australia\u2019s largest grocery chain supermarkets and are the two largest supermarkets in Kalgoorlie.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.18",
+            "text": "O\u2019Connor Fresh IGA is an independent supermarket. It has smaller floor space than Coles and Woolworths and it offers a reasonably large range of groceries for customers.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.19",
+            "text": "Spudshed is an independent supermarket that entered Kalgoorlie in November 2025, taking over the space formerly occupied by IGA Hannans Fresh, which was occupied by Coles before that. Spudshed offers a large range of fresh produce, a proportion of which is sourced from its owners\u2019 farms. Spudshed also offers a range of meat, dairy and grocery items.",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.20",
+            "text": "Compared to other supermarkets in Kalgoorlie, the Hannans Marketplace by Foodworks and Lionel St IGA supermarkets have smaller floor space and a smaller product range. Table 1Supermarkets in Kalgoorlie",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.21",
+            "text": "The locations of existing supermarkets and the Proposed Supermarket are illustrated in the figure below. O\u2019Connor Fresh IGA will be the closest store geographically to the Proposed Supermarket (approximately 1.8km driving distance). Figure 1 Map of supermarkets in Kalgoorlie",
+            "type": "paragraph"
+          },
+          {
+            "number": "2.22",
+            "text": "Supermarkets in Kalgoorlie offer different trading hours to each other. Large supermarkets, such as Coles and Woolworths in Kalgoorlie, are subject to trading hour regulations. Other supermarkets, such as Spudshed, O\u2019Connor Fresh IGA, Lionel St IGA and Hannans Marketplace by Foodworks, are not. Table 2 sets out the trading times for the 6 supermarkets in Kalgoorlie. Table 2Opening hours of supermarkets in Kalgoorlie",
+            "type": "paragraph"
+          },
+          {
+            "text": "Overlap and relationship between the parties",
+            "type": "heading"
+          },
+          {
+            "number": "2.23",
+            "text": "The Lease will be an input to Coles\u2019 supermarket retailing operations.",
+            "type": "paragraph"
+          }
+        ],
+        "number": "2",
+        "title": "Background"
+      },
+      {
+        "blocks": [
+          {
+            "number": "3.1",
+            "text": "The area of competition the ACCC is considering for the purpose of assessing the Acquisition is the retail supply of groceries by supermarkets in Kalgoorlie.",
+            "type": "paragraph"
+          },
+          {
+            "number": "3.2",
+            "text": "Market definition is a purposive tool used to help assess whether an acquisition might have anti-competitive effects. At this stage of the review, the ACCC is taking a simple approach to defining the relevant market, by focussing on the most important competitive constraints on Coles.",
+            "type": "paragraph"
+          },
+          {
+            "number": "3.3",
+            "text": "For any given supermarket in Kalgoorlie, the extent of competitive rivalry they face from other participants will depend on a range of factors, including how similar or differentiated their product offerings are and their geographic proximity to each other.",
+            "type": "paragraph"
+          },
+          {
+            "text": "Product market",
+            "type": "heading"
+          },
+          {
+            "number": "3.4",
+            "text": "The ACCC\u2019s preliminary view is the relevant product dimension is the retail supply of groceries by supermarkets. Supermarkets offer consumers the convenience of a one- stop-shop service for their grocery needs and a broad range of products.",
+            "type": "paragraph"
+          },
+          {
+            "number": "3.5",
+            "text": "This product dimension likely includes each of the supermarkets identified in Table 1 above. However, as discussed further in the Preliminary Competition Assessment below, the ACCC is still considering the extent of the competitive rivalry each supermarket in Kalgoorlie imposes on the others.",
+            "type": "paragraph"
+          },
+          {
+            "number": "3.6",
+            "text": "The ACCC\u2019s view is that while the following types of retailers overlap in some product offerings with supermarkets, they are unlikely to be close substitutes for supermarkets for consumers:",
+            "type": "paragraph"
+          },
+          {
+            "items": [
+              "convenience stores\u2014are not likely to be sufficiently close substitutes to supermarkets as they target consumers seeking few items on a convenient basis, and",
+              "speciality and general merchandise stores\u2014retailers such as Chemist Warehouse, Bunnings, butchers, bakeries, green grocers and other specialty or general merchandise stores may stock a limited subset of grocery or household items, but they do not provide a sufficiently broad or substitutable range of grocery products to be close substitutes for supermarkets."
+            ],
+            "type": "bullet_list"
+          },
+          {
+            "number": "3.7",
+            "text": "Coles, Woolworths and other supermarkets supplement their bricks-and-mortar supermarket offerings with online delivery and online order services. The ACCC\u2019s view is that for the purposes of assessing the Acquisition, these services should be included when assessing competition between supermarkets.",
+            "type": "paragraph"
+          },
+          {
+            "number": "3.8",
+            "text": "Kalgoorlie has a substantial population of fly-in-fly-out (FIFO) workers. However, the ACCC\u2019s preliminary view is this customer group does not alter the product market or form a separate market.",
+            "type": "paragraph"
+          },
+          {
+            "text": "Geographic market",
+            "type": "heading"
+          },
+          {
+            "number": "3.9",
+            "text": "The ACCC considers that the geographic market is likely to be Kalgoorlie, though supermarkets in close geographic proximity are likely to compete more closely with each other.",
+            "type": "paragraph"
+          },
+          {
+            "number": "3.10",
+            "text": "Consumers are unlikely to travel beyond Kalgoorlie to shop for grocery products as it is geographically remote. For this reason, supermarkets outside the town are unlikely to be adequate substitutes for consumers.",
+            "type": "paragraph"
+          },
+          {
+            "number": "3.11",
+            "text": "The Inquiry found consumers generally prefer to travel shorter distances to do their grocery shopping. Additionally, feedback from a market participant suggests while it draws consumers from all over Kalgoorlie, the majority of its customers are coming from surrounding suburbs.",
+            "type": "paragraph"
+          }
+        ],
+        "number": "3",
+        "title": "Relevant areas of competition"
+      },
+      {
+        "blocks": [
+          {
+            "number": "4.1",
+            "text": "The ACCC is closely examining the effects of the Acquisition on competition between supermarkets in Kalgoorlie, by comparing the likely future state of competition if the Acquisition proceeds against the likely future state of competition if the Acquisition does not proceed. The ACCC considers the latter would be the status quo, or continuation of the current state of competition.",
+            "type": "paragraph"
+          },
+          {
+            "number": "4.2",
+            "text": "In the status quo and in the future without the Acquisition, the ACCC considers Coles and Woolworths likely have market power in Kalgoorlie. This is the case even though Coles and Woolworths face a degree of rivalry from independent supermarkets via their competitive differentiated offering compared to Coles and Woolworths. Coles and Woolworths each and combined account for a significant proportion of the market and the ACCC has previously found Coles and Woolworths have limited incentive to compete vigorously with each other on price. The ACCC is still considering whether Coles and Woolworths may have substantial market power in Kalgoorlie.",
+            "type": "paragraph"
+          },
+          {
+            "number": "4.3",
+            "text": "Information from market participants shows independent supermarkets in Kalgoorlie compete on the basis of price, range and quality of products, store quality and customer service. Market participants have also provided information to show supermarkets monitor and respond to each other, including with independents matching or beating Coles and Woolworths on key value items.",
+            "type": "paragraph"
+          },
+          {
+            "number": "4.4",
+            "text": "In the future with the Acquisition, the ACCC considers the Acquisition will likely create an over-supply of supermarket capacity and thereby lead to the exit of an effective independent competitor. This will reduce the level of competition faced by remaining rivals, in circumstances where the likelihood of new entry is low. Coles would increase its market power and likely have a substantial degree of market power. This is because:",
+            "type": "paragraph"
+          },
+          {
+            "items": [
+              "Coles\u2019 market share in Kalgoorlie will increase to a high level",
+              "while some supermarkets will continue to compete, their ability to constrain Coles\u2019 market power would be limited, and",
+              "it is likely that Coles would earn high economic profits in Kalgoorlie."
+            ],
+            "type": "bullet_list"
+          },
+          {
+            "number": "4.5",
+            "text": "The ACCC is considering whether Coles\u2019 investment in the Proposed Supermarket is likely to only be profitable if it leads to the exit of an effective competitor.",
+            "type": "paragraph"
+          },
+          {
+            "number": "4.6",
+            "text": "Having regard to the likely future with the Acquisition and the likely future without the Acquisition, the ACCC\u2019s preliminary assessment is that the Acquisition would have the effect or likely effect of substantially lessening competition in Kalgoorlie as it leads to the exit of an effective independent competitor and increases Coles\u2019 market power. This would be likely to, in all the circumstances, create, strengthen or entrench a substantial degree of market power for Coles.",
+            "type": "paragraph"
+          },
+          {
+            "number": "4.7",
+            "text": "The ACCC considers the Kalgoorlie market will likely lose an effective competitor that:",
+            "type": "paragraph"
+          },
+          {
+            "items": [
+              "price matches and price discounts relative to Coles and other supermarkets in Kalgoorlie",
+              "offers a range and quality of products\u2014this includes high-revenue products where an effective competitor competes head-to-head, but also unique and specialised products that provide a differentiated offering valued by customers",
+              "is valued by customers as a high-quality alternative to other competitors\u2014 including in terms of the store\u2019s stock levels and shelf replenishment, store cleanliness and condition, maintenance expenditure and capital refurbishment, and",
+              "provides a high level of customer service\u2014this includes ensuring check outs are staffed and queues are minimised, and offering extended opening hours."
+            ],
+            "type": "bullet_list"
+          },
+          {
+            "number": "4.8",
+            "text": "This is likely to lead to Coles competing less strongly in Kalgoorlie, as it will no longer be concerned with the effective competitor\u2019s activity. Coles and other supermarkets may:",
+            "type": "paragraph"
+          },
+          {
+            "items": [
+              "reduce the extent to which they match competitor discounts i.e. reduce the frequency or extent of altering prices on select product lines, such as fresh produce, or deviate from statewide pricing policies",
+              "have higher incentives to raise statewide prices",
+              "reduce customer service by employing fewer staff at its Kalgoorlie stores and reduce other aspects of quality, and",
+              "reduce the range of products available, particularly where they might have matched the speciality products the exiting competitor used to differentiate itself."
+            ],
+            "type": "bullet_list"
+          },
+          {
+            "number": "4.9",
+            "text": "The ACCC expects Coles sets statewide prices having regard to the likelihood of losing customers\u2019 sales to competitors across its stores in Western Australia. The ACCC is further considering whether, if local competition declines in Kalgoorlie, Coles may increase statewide prices, albeit by a small amount.",
+            "type": "paragraph"
+          },
+          {
+            "number": "4.10",
+            "text": "The ACCC is exploring whether competition will also be substantially lessened, albeit to a lesser extent, where an effective competitor is significantly harmed but does not exit. It is not yet clear whether a competitor would respond to significant harm following the Acquisition by undertaking less competitive activity to reduce their costs or by competing more fiercely to defend its position in the market.",
+            "type": "paragraph"
+          },
+          {
+            "number": "4.11",
+            "text": "The ACCC is also considering whether the Acquisition may harm competition by reducing the competitive rivalry existing competitors impose on Coles. Interested parties have submitted that if the Acquisition reduces the scale of existing competitors, it may increase distribution and wholesale costs in a relatively remote location such as Kalgoorlie.",
+            "type": "paragraph"
+          },
+          {
+            "number": "4.12",
+            "text": "The ACCC will continue considering these issues.",
+            "type": "paragraph"
+          }
+        ],
+        "number": "4",
+        "title": "Summary of preliminary competition assessment"
+      },
+      {
+        "blocks": [
+          {
+            "number": "5.1",
+            "text": "Following the release of the NOCC, and consistent with s 51ABZL of the Act, the notifying party (Coles Supermarkets) has an opportunity to respond to the preliminary issues identified in the NOCC by 14 April 2026.",
+            "type": "paragraph"
+          },
+          {
+            "number": "5.2",
+            "text": "Under the current statutory timeframe, the ACCC must issue a determination in response to the Acquisition by 12 June 2026.",
+            "type": "paragraph"
+          }
+        ],
+        "number": "5",
+        "title": "Next steps"
+      }
+    ],
+    "title": "Coles \u2013 supermarket and liquor site in Kalgoorlie, WA"
+  }
+}

--- a/merger-tracker/frontend/public/data/mergers/MN-01019.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-01019.json
@@ -129,6 +129,7 @@
   "public_benefits_determination": null,
   "public_benefits_determination_date": null,
   "has_questionnaire": true,
+  "has_nocc": true,
   "similar_mergers": [
     {
       "merger_id": "MN-90009",

--- a/merger-tracker/frontend/public/data/mergers/MN-01068.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-01068.json
@@ -83,6 +83,7 @@
   "public_benefits_determination": null,
   "public_benefits_determination_date": null,
   "has_questionnaire": true,
+  "has_nocc": true,
   "similar_mergers": [
     {
       "merger_id": "MN-01090",

--- a/merger-tracker/frontend/public/data/noccs/MN-01019.json
+++ b/merger-tracker/frontend/public/data/noccs/MN-01019.json
@@ -1,0 +1,559 @@
+{
+  "title": "Ampol \u2013 EG Australia",
+  "matter_id": "MN-01019",
+  "document_type": "Notice of Competition Concerns \u2013 Summary",
+  "date": "2 March 2026",
+  "date_iso": "2026-03-02",
+  "file_name": "Ampol_EG - NOCC summary - AR version - 2 March 2026.pdf",
+  "file_path": "matters/MN-01019/Ampol_EG - NOCC summary - AR version - 2 March 2026.pdf",
+  "sections": [
+    {
+      "blocks": [
+        {
+          "number": "1.1",
+          "text": "On 10 October 2025, Ampol Limited lodged a notification in respect of Ampol Retail Holding Pty Ltd\u2019s proposed acquisition of 100% of the share capital in EG Group Australia Pty Ltd and EG AsiaPac Holdings Limited (the Acquisition) with the Australian Competition and Consumer Commission (ACCC).",
+          "type": "paragraph"
+        },
+        {
+          "number": "1.2",
+          "text": "On 20 January 2026, the ACCC decided that the Acquisition is to be subject to Phase 2 review.",
+          "type": "paragraph"
+        },
+        {
+          "number": "1.3",
+          "text": "On 27 February 2026, the ACCC issued a Notice of Competition Concerns (NOCC) to Ampol.",
+          "type": "paragraph"
+        },
+        {
+          "number": "1.4",
+          "text": "The NOCC sets out the ACCC\u2019s preliminary assessment of whether the acquisition, if put into effect, would have the effect, or be likely to have the effect, of substantially lessening competition in any market, and the grounds on which the ACCC makes its assessment, referring to the evidence or other material on which those grounds are based.",
+          "type": "paragraph"
+        },
+        {
+          "number": "1.5",
+          "text": "This is a summary of the NOCC as required to be published on the Acquisitions Register.",
+          "type": "paragraph"
+        }
+      ],
+      "number": "1",
+      "title": "Introduction"
+    },
+    {
+      "blocks": [
+        {
+          "text": "The acquirer \u2013 Ampol",
+          "type": "heading"
+        },
+        {
+          "number": "2.1",
+          "text": "Ampol Retail Holding Pty Ltd is a wholly-owned subsidiary of Ampol Limited (Ampol), which is listed on the ASX. Ampol is a vertically integrated fuel company with upstream fuel production and importing assets, wholesale supply and distribution facilities and a network of fuel and retail convenience sites across Australia.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.2",
+          "text": "Ampol owns the Lytton refinery in Brisbane, Queensland, where it refines imported crude oil, and a number of terminals nationwide through which it imports finished petrol products from overseas refineries and trading houses.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.3",
+          "text": "Ampol operates retail sites under both the Ampol brand and the U-GO brand. Ampol branded sites are full-service sites with fuel and convenience offerings. Launched in 2023, the U-GO branded sites are low cost, unstaffed self-service sites selling only fuel and with no convenience offering. Ampol owns and operates 576 sites under the Ampol brand and 46 under the U-GO brand.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.4",
+          "text": "Ampol also has 50% interests in the following two fuel distributors and retailers:",
+          "type": "paragraph"
+        },
+        {
+          "items": [
+            "Bonney Energy Group Pty Ltd (Bonney Energy) is a distributor of Ampol fuel. Bonney Energy operates 45 retail fuel sites across regional Victoria and Tasmania under the Ampol brand.",
+            "Geraldton Fuel Company Pty Ltd (trading as Refuel Australia) is a fuel distributor operating in Western Australia and the Northern Territory. Twenty-eight of Refuel Australia\u2019s 38 locations operate under the Ampol brand."
+          ],
+          "type": "bullet_list"
+        },
+        {
+          "text": "The target \u2013 EG Australia",
+          "type": "heading"
+        },
+        {
+          "number": "2.5",
+          "text": "EG Group Australia and EG AsiaPac Holdings are the entities that carry on EG Group\u2019s business in Australia (together, EG Australia), which includes the retail supply of fuel, food to go and convenience products. EG Australia is owned by EG Group, a UK-based independent fuel and convenience retailer with sites across Europe and North America.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.6",
+          "text": "EG Australia commenced operations in Australia in April 2019 when EG Group acquired Woolworths\u2019 retail fuel and convenience sites. EG Australia owns and operates 512 retail fuel sites.",
+          "type": "paragraph"
+        },
+        {
+          "text": "Relationship between the Parties",
+          "type": "heading"
+        },
+        {
+          "number": "2.7",
+          "text": "Ampol and EG Australia (together, the Parties) have a fuel supply agreement (FSA) whereby Ampol is EG Australia\u2019s exclusive wholesale supplier of fuel until 2033. Pursuant to the FSA and other agreements which were novated from Woolworths to EG Group in 2019, EG Australia\u2019s retail fuel sites must carry the \u2018Ampol\u2019 brand, while its convenience stores carry the \u2018EG\u2019 brand.",
+          "type": "paragraph"
+        },
+        {
+          "text": "The Acquisition",
+          "type": "heading"
+        },
+        {
+          "number": "2.8",
+          "text": "Ampol proposes to acquire 100% of the share capital in EG Australia for $1.1 billion.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.9",
+          "text": "In public statements about the Acquisition, Ampol states that the Acquisition will enable it to expand its national footprint (to 1,134 sites) and accelerate Ampol\u2019s retail growth strategy through segmented offers.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.10",
+          "text": "As part of this, a key stated rationale for the Acquisition is to accelerate the rollout of U-GO sites. In particular, Ampol states that it would progressively convert 125 EG Australia sites to U-GO sites over a two year period (with the remainder to be rebranded as Ampol Foodary sites). Ampol currently has 46 U-GO sites and plans to convert 14 additional Ampol sites by the end of 2026. Taken together, Ampol would have close to 200 U-GO sites in 2 to 3 years\u2019 time.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.11",
+          "text": "EG Group has stated that it is seeking to exit the Australian market with the proceeds from the sale to be used to reduce the Group\u2019s debt and focus on global markets where it sees growth opportunities.",
+          "type": "paragraph"
+        },
+        {
+          "text": "Industry background",
+          "type": "heading"
+        },
+        {
+          "number": "2.12",
+          "text": "In assessing the competitive effects of the Acquisition, it is relevant to understand that Australia\u2019s fuel industry consists of three broad levels \u2013 the import of refined fuel and the domestic refining of crude oil (suppliers), the sale or resale and distribution of wholesale fuel (primary and secondary wholesalers), and retail supply. This structure is depicted at Figure 1 below. Figure 1. Fuel industry structure",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.13",
+          "text": "Further industry background relevant to the ACCC\u2019s competition assessment is set out below.",
+          "type": "paragraph"
+        },
+        {
+          "text": "Refining and wholesale supply",
+          "type": "heading"
+        },
+        {
+          "number": "2.14",
+          "text": "A number of Australian fuel suppliers, including Ampol, are vertically integrated, refining and/or importing fuel and supplying fuel to downstream retail sites.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.15",
+          "text": "Refineries process and transform crude oil into refined petroleum products (including petrol, diesel, jet fuel, fuel oil and other fuel products). Currently, there are 2 refineries operating in Australia \u2013 Viva Energy\u2019s Geelong refinery in Victoria and Ampol\u2019s Lytton refinery in Queensland. However, other market participants such as Chevron have refinery operations in the Asia-Pacific region. Chevron has interests in refineries in South Korea, Thailand and Singapore, which are sources of refined product for some retailers in Australia.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.16",
+          "text": "Import terminals receive refined petroleum products by ship, store them and distribute them to retailers. A number of parties import finished products into Australia from overseas including Ampol, BP, Chevron, ExxonMobil, United, Viva Energy, IOR, PetroChina and Freedom Fuels.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.17",
+          "text": "Refiners and many importers supply fuel to secondary wholesalers or directly to retailers on a wholesale basis. Currently, the four major wholesalers in Australia are Ampol, BP, ExxonMobil and Viva Energy.",
+          "type": "paragraph"
+        },
+        {
+          "text": "Retail supply and competition in fuel retailing",
+          "type": "heading"
+        },
+        {
+          "number": "2.18",
+          "text": "The ACCC has a monitoring role in fuel markets and reports on fuel prices and industry issues as a part of that role. In various reports, the ACCC has identified certain trends in relation to competition in fuel retailing. These trends are relevant to the assessment of the competitive impact of the Acquisition and are set out below.",
+          "type": "paragraph"
+        },
+        {
+          "text": "Composition of retail fuel markets",
+          "type": "heading"
+        },
+        {
+          "number": "2.19",
+          "text": "Australia\u2019s downstream retail supply has evolved over the past decade with market consolidation through acquisitions, expansion by several retailers and other retail brands opening in Australia. The net result of these changes is that the number of retail sites increased from around 7,500 in 2018 to over 8,000 in 2026.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.20",
+          "text": "Fuel retailers in Australia have varied business models and structures. They can be broadly categorised as follows:",
+          "type": "paragraph"
+        },
+        {
+          "items": [
+            "Larger, national, vertically integrated retailers: Ampol, Viva Energy (including the Reddy Express and On The Run retail networks), BP and Chevron (operating under the Caltex and Puma Energy retail brands) (major fuel retailers).",
+            "Larger, national independent retailers with or without branded fuel supplier: EG Australia, United Petroleum, and 7 Eleven (major independent fuel retailers).",
+            "Smaller independent retailers, such as Speedway, Metro Petroleum, Freedom Fuels, Budget, Vibe, and Pearl Energy (small independent fuel retailers).",
+            "Dealers under the national branded retailers (independently priced sites branded BP, Shell, Ampol etc)."
+          ],
+          "type": "bullet_list"
+        },
+        {
+          "number": "2.21",
+          "text": "The brand of the retail site will often, but not always, reflect the owner or fuel price setter of the retail site. Some independent chains use a fuel supplier brand but set their own retail fuel prices, as do some single site retail operations.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.22",
+          "text": "While these different groups of retailers generally offer the same fuel types, they differ in non-fuel offerings, scale of presence across Australia and in each state or territory, and pricing strategy. Major fuel retailers and major independent fuel retailers have a national presence and are likely to compete more on non-fuel offerings, such as convenience products and services. In contrast, smaller independent fuel retailers may have fewer sites across a city and/or are not present in all states/territories and tend to compete primarily on fuel price to attract consumers.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.23",
+          "text": "The aggregated share of national petrol sales volumes of the small independent fuel retailers has gradually increased over time, from 18% in 2017\u201318 to around 26% in 2023-24. The ACCC estimates that, as a group, small independent fuel retailers have the strongest presence in Sydney, Melbourne and Adelaide, and a small presence in Brisbane and Canberra. However, the ACCC has noted that the presence of these independents differs from city to city. For example, Freedom Fuels only has sites in and around Brisbane while Speedway is present mainly in Sydney and Melbourne.",
+          "type": "paragraph"
+        },
+        {
+          "text": "Petrol price movements",
+          "type": "heading"
+        },
+        {
+          "number": "2.24",
+          "text": "As the ACCC\u2019s ongoing monitoring of fuel markets has found, Australian fuel prices are typically influenced by international benchmark crude oil and refined fuel prices and the value of the Australian dollar, as well as the levels of competition in different locations.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.25",
+          "text": "In addition, in the major cities such as Sydney, Melbourne, Brisbane, Adelaide and Perth, petrol prices move up and down in regular patterns. These patterns are known as petrol price cycles. Petrol price cycles are not driven by movements in wholesale prices or underlying costs and not all retailers participate in price cycles. Price cycles do not occur for retail diesel and automotive LPG prices.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.26",
+          "text": "Typically in a price cycle, prices at individual retail sites increase sharply, then decrease more gradually over a longer period before the process repeats. Not all retail sites change prices at the same time, meaning average metropolitan-wide prices can take time to increase (and decrease).",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.27",
+          "text": "Average prices move up and down across two phases. The ACCC has made the following observations regarding these phases:",
+          "type": "paragraph"
+        },
+        {
+          "items": [
+            "In the increase phase, various retailers generally increase prices substantially to the same or a similar price point across different locations within a city. The ACCC has observed some retailers increasing prices to varying levels, including levels below the highest priced retailer.",
+            "In the decrease phase, retailers tend to more gradually match and undercut their rivals\u2019 pricing until prices begin to approach terminal gate prices (indicative wholesale prices), such that they may be making slim margins or not recovering their purchase costs on petrol. At this point, one or more retailers will tend to increase their prices substantially such that the cycle repeats."
+          ],
+          "type": "bullet_list"
+        },
+        {
+          "number": "2.28",
+          "text": "The ACCC has also observed differences in petrol price cycle patterns in Australia\u2019s largest cities over time. For example, in the year to September 2025, cycles in Sydney were around 5 and a half weeks in duration while in Melbourne they were around 6 and a half weeks and in Brisbane around 7 weeks. Previously, in 2018, the ACCC observed that cycles in the same three cities were about a month long.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.29",
+          "text": "Smaller cities such as Canberra, Hobart and Darwin and most regional areas do not have petrol price cycles.",
+          "type": "paragraph"
+        }
+      ],
+      "number": "2",
+      "title": "Background"
+    },
+    {
+      "blocks": [
+        {
+          "number": "3.1",
+          "text": "The Parties are both retail suppliers of fuel and convenience products in all Australian states and territories. Currently:",
+          "type": "paragraph"
+        },
+        {
+          "items": [
+            "Ampol owns and operates 576 sites under the Ampol brand, and 46 under the U-GO brand.",
+            "EG Australia owns and operates 512 retail fuel sites."
+          ],
+          "type": "bullet_list"
+        },
+        {
+          "number": "3.2",
+          "text": "Acquiring EG Australia\u2019s sites would make Ampol the largest fuel retailer in Australia in terms of number of sites.",
+          "type": "paragraph"
+        },
+        {
+          "number": "3.3",
+          "text": "The Parties also overlap in convenience grocery retailing co-located at fuel sites across Australia. However, as the ACCC does not consider that the Acquisition is likely to result in a substantial lessening of competition in the retail supply of groceries given the remaining constraints on Ampol post-acquisition, no further consideration is given to this overlap in this Notice.",
+          "type": "paragraph"
+        },
+        {
+          "text": "Approach to market definition",
+          "type": "heading"
+        },
+        {
+          "number": "3.4",
+          "text": "Adopting the ACCC\u2019s past approach to market definition in the fuel industry, Ampol has submitted that the relevant markets for considering the competitive effects of the Acquisition are:",
+          "type": "paragraph"
+        },
+        {
+          "items": [
+            "Local markets for the supply of fuel through retail outlets in the vicinity of each EG Australia site, applying up to a 5km radius around each site in metropolitan areas and a 10km radius around each site in regional areas.",
+            "Metropolitan-wide markets for the retail supply of fuel in metropolitan areas such as Sydney, Melbourne, Brisbane, Perth and Adelaide."
+          ],
+          "type": "bullet_list"
+        },
+        {
+          "number": "3.5",
+          "text": "The ACCC broadly accepts Ampol\u2019s submission that the competitive effects of the Acquisition are to be assessed at a local level and a metropolitan level. However, as set out further below, the ACCC has considered the relevant geographic dimension in each local area individually. In each local area, the ACCC has applied a broader or narrower radius, having regard to the presence of traffic routes, natural barriers, and/or due to other information provided by the Parties.",
+          "type": "paragraph"
+        },
+        {
+          "number": "3.6",
+          "text": "In addition, the ACCC considers that:",
+          "type": "paragraph"
+        },
+        {
+          "items": [
+            "In terms of the product dimension of the relevant markets, petrol and diesel should be considered separately. From a demand-side perspective, consumers cannot substitute between petrol and diesel without switching vehicles. Additionally, some sites offer only diesel as they aim to cater for trucks and other fleet vehicles that are fuelled only by diesel. Such sites are unlikely to be an alternative option to a petrol site for consumers who have petrol vehicles.",
+            "While within each of the various grades of petrol and diesel, fuel retailers supply a homogeneous product, there is product differentiation in respect of fuel retailers\u2019 non-fuel offerings. Fuel retailers differentiate themselves across various dimensions, including fuel-adjacent offerings (e.g., branding and loyalty schemes, such as reward cards or discount dockets), the other products they supply (e.g., convenience groceries, take away food, dine-in restaurants, car washes, gas bottles and EV charging) and the quality of their sites (including site location, access number and type of pumps, presence and level of staffing)."
+          ],
+          "type": "bullet_list"
+        },
+        {
+          "text": "Geographic dimension of fuel markets",
+          "type": "heading"
+        },
+        {
+          "number": "3.7",
+          "text": "In considering the appropriate radius to apply in defining a local market around an EG Australia site, the ACCC has considered industry surveys regarding how consumers shop for fuel.",
+          "type": "paragraph"
+        },
+        {
+          "number": "3.8",
+          "text": "According to a 2024 industry survey, for many consumers, price remains the top driver of fuel purchasing decisions, with 56% of respondents indicating that price is their primary consideration when choosing a fuel retailer, followed by 12% making a decision to purchase fuel based on service station fuel location and 10% by fuel quality or type. This focus on price has also driven the increased use of fuel price apps, with 40% of consumers using these apps to shop around for fuel.",
+          "type": "paragraph"
+        },
+        {
+          "number": "3.9",
+          "text": "A 2022 industry survey indicated that:",
+          "type": "paragraph"
+        },
+        {
+          "items": [
+            "Around 34% of consumers were willing to travel more than 5 minutes out of their way for cheaper fuel.",
+            "Around 43% of consumers were willing to travel up to 5 minutes out of their way to purchase cheaper fuel.",
+            "Around 20% of consumers would never travel up to 5 minutes out of their way for fuel."
+          ],
+          "type": "bullet_list"
+        },
+        {
+          "number": "3.10",
+          "text": "As this survey indicates, it may still be the case that, for many consumers, the closest substitutes for a given retail fuel site are other retail fuel sites in close geographic proximity. This is because the distance that consumers may be willing to travel to obtain lower prices is likely to be limited by the time and cost of travelling to alternative sites.",
+          "type": "paragraph"
+        },
+        {
+          "number": "3.11",
+          "text": "The emergence of fuel price apps and the increase in their use may have changed these considerations at some level \u2013 for example, it may allow consumers to better plan their fuel purchases. In particular, the ACCC found that consumers are increasingly using apps, such that they can plan both \u2018when\u2019 and \u2018where\u2019 they fill up. Further, the question of where to fill up may also be influenced by work, school and home travel routes such that consumers, depending on the nature of those routes, may have a more geographically dispersed set of fuel sites that they consider are substitutable.",
+          "type": "paragraph"
+        },
+        {
+          "number": "3.12",
+          "text": "As with previous considerations of fuel mergers, and having regard to the above industry surveys, the Parties\u2019 submissions and internal documents, the ACCC considers it appropriate to assess the competitive effects of the Acquisition in both metropolitan-wide and local markets.",
+          "type": "paragraph"
+        },
+        {
+          "number": "3.13",
+          "text": "For each local market, the ACCC has assessed the competitive effects of the Acquisition within a particular radius surrounding the EG Australia target site. The appropriate radius considered for each local market varies, having regard to specific local conditions.",
+          "type": "paragraph"
+        },
+        {
+          "number": "3.14",
+          "text": "The ACCC has considered the following information to determine the appropriate radius for its preliminary competition assessment in each local market:",
+          "type": "paragraph"
+        },
+        {
+          "items": [
+            "The location of competitors.",
+            "Topographical features that may impact demand-side substitution. For example, in some local markets, there may be traffic routes and/or natural barriers that affect the distance consumers are willing to travel to purchase fuel."
+          ],
+          "type": "bullet_list"
+        },
+        {
+          "number": "3.15",
+          "text": "In addition to local market competition, evidence before the ACCC indicates that it is also appropriate to consider the competitive effect of the Acquisition on metropolitan areas in which Ampol and EG Australia are among the largest fuel retail networks. In cities with petrol price cycles, the existence of those price cycles appears to be evidence of, or at least consistent with, retailers monitoring and responding to the pricing behaviour of competitors across a metropolitan area and not just locally.",
+          "type": "paragraph"
+        },
+        {
+          "number": "3.16",
+          "text": "The density of Ampol and EG Australia sites in Brisbane, Melbourne and Sydney also suggests that multiple areas of local competition between the Parties are likely to overlap with each other and are therefore interconnected. This can be observed in Figure 2, which plots the Ampol (blue) and EG Australia (green) sites on the maps of each city along with competitor sites (grey).",
+          "type": "paragraph"
+        },
+        {
+          "number": "3.17",
+          "text": "In considering a metropolitan-wide market, the ACCC is also concerned with the competitive effects of the Acquisition arising outside of, or extending beyond, local market boundaries. An analysis confined to local effects potentially misses those competitive effects in circumstances where the documentary and data evidence suggests that there are competitive dynamics occurring beyond local market boundaries. Figure 2. Maps of Ampol, EG Australia and competitor sites in Brisbane, Melbourne and Sydney (left to right)",
+          "type": "paragraph"
+        }
+      ],
+      "number": "3",
+      "title": "Overlap and relevant areas of competition"
+    },
+    {
+      "blocks": [
+        {
+          "number": "4.1",
+          "text": "The ACCC is considering the effects of the Acquisition by comparing the likely future state of competition if the Acquisition proceeds against the likely future state of competition if the Acquisition does not proceed.",
+          "type": "paragraph"
+        },
+        {
+          "number": "4.2",
+          "text": "The ACCC\u2019s preliminary view is that the future state of competition without the Acquisition is the status quo, which takes into account that EG Australia may continue to close selected sites that it considers are underperforming and that Ampol is likely to continue rolling out U-GO sites organically.",
+          "type": "paragraph"
+        }
+      ],
+      "number": "4",
+      "title": "The future with and without the Acquisition"
+    },
+    {
+      "blocks": [
+        {
+          "text": "Competitive effects in the retail supply of fuel in local markets in Australia",
+          "type": "heading"
+        },
+        {
+          "number": "5.1",
+          "text": "The ACCC initially identified 274 EG Australia sites that overlap with one or more Ampol sites. Following closer analysis of the overlaps, the ACCC identified in the Phase 2 notice published on 20 January 2026 that the Acquisition could have the effect or likely effect of substantially lessening competition in respect of 115 of those EG Australia site overlaps. Since publishing the notice, the ACCC has continued to analyse these overlaps.",
+          "type": "paragraph"
+        },
+        {
+          "number": "5.2",
+          "text": "The ACCC\u2019s preliminary assessment is that the Acquisition would have the effect or be likely to have the effect of substantially lessening competition in 51 local markets where 54 EG Australia sites overlap with Ampol sites.",
+          "type": "paragraph"
+        },
+        {
+          "number": "5.3",
+          "text": "In addition, the ACCC is continuing to consider whether the Acquisition would have the effect, or likely effect, of substantially lessening competition in relation to an additional 20 local markets where 20 EG Australia sites overlap with Ampol sites.",
+          "type": "paragraph"
+        },
+        {
+          "number": "5.4",
+          "text": "The following factors were relevant to the ACCC\u2019s preliminary assessment of competitive effects:",
+          "type": "paragraph"
+        },
+        {
+          "items": [
+            "The increase and the post-acquisition level of concentration by site numbers in a local area. In some areas, the post-acquisition site share is as high as 75% and the increment is as high as 50%.",
+            "The distance between the Ampol and EG Australia sites. In particular, there are 5 EG Australia sites which are located within 200m of an Ampol site and a further 24 which are within 1km of an Ampol.",
+            "The number, identity and location of remaining competitors. The ACCC\u2019s preliminary view is that some competitors may not impose as strong a constraint on Ampol post-acquisition as EG Australia currently does. This is either because they are not proximate to the Ampol and EG Australia sites, do not have equivalent offerings (for example, do not supply all fuel types, or only offer a small number of pumps) and/or Ampol\u2019s current pricing rule or strategy suggests they would not be a strong competitive constraint."
+          ],
+          "type": "bullet_list"
+        },
+        {
+          "number": "5.5",
+          "text": "The table below shows the locations of the relevant local markets.",
+          "type": "paragraph"
+        },
+        {
+          "number": "5.6",
+          "text": "The ACCC will continue to investigate these matters in Phase 2.",
+          "type": "paragraph"
+        },
+        {
+          "text": "Competitive effects in the retail supply of fuel in metropolitan markets",
+          "type": "heading"
+        },
+        {
+          "number": "5.7",
+          "text": "The ACCC\u2019s preliminary assessment is that the Acquisition would have the effect, or likely effect, of substantially lessening competition in the retail supply of fuel in the metropolitan markets of Brisbane, Melbourne, Sydney, and Canberra.",
+          "type": "paragraph"
+        },
+        {
+          "number": "5.8",
+          "text": "In Brisbane, Melbourne and Sydney, 3 cities with petrol price cycles, the ACCC\u2019s preliminary view is that the removal of EG Australia would likely lead to a substantial lessening of competition through unilateral effects, as:",
+          "type": "paragraph"
+        },
+        {
+          "items": [
+            "The Acquisition removes a direct and significant competitor to Ampol and other major fuel retailers. It will lessen the competitive constraints on the fuel retailers that track and respond to price at Ampol and EG Australia sites in these three metropolitan markets.",
+            "The Acquisition increases Ampol\u2019s share of sites in each of these three metropolitan markets, making it the largest fuel retailer in Sydney and Melbourne and second largest retailer in Brisbane.",
+            "The removal of EG Australia as an independent pricing constraint on Ampol may result in higher prices for consumers as Ampol would implement its own pricing strategies to the EG Australia network. In particular, the Acquisition will remove a competitor in these three markets that:",
+            "prices, on average, lower than Ampol across both phases of the price cycle;",
+            "is often the first mover of the major fuel retailers in the decrease phase of price cycles and has, at times, moved a larger proportion of sites more quickly down in the decrease phase than other major retailers; and",
+            "tends to have, on average, lower prices than Ampol when prices across a metropolitan area are increasing."
+          ],
+          "type": "bullet_list"
+        },
+        {
+          "number": "5.9",
+          "text": "In Canberra, which does not have petrol price cycles, the Acquisition would remove a direct competitor to Ampol and lead to Ampol becoming the largest fuel retailer in that metropolitan market. The ACCC\u2019s preliminary assessment is that the Acquisition would have the effect, or likely effect, of substantially lessening competition in the retail supply of fuel in Canberra from coordinated effects becoming more likely, more complete and/or more sustainable across the remaining retailers. The ACCC is continuing to consider the potential for the Acquisition to give rise to unilateral effects in Canberra.",
+          "type": "paragraph"
+        },
+        {
+          "number": "5.10",
+          "text": "The ACCC has also considered whether the Acquisition is likely to give rise to coordinated effects in Brisbane, Melbourne and Sydney where price cycles are a feature of price competition between fuel retailers. This is separate to the (unilateral) mechanism by which competition could be lessened and prices increased. In considering the evidence before it, the ACCC\u2019s preliminary view is that coordinated effects are not sufficiently likely to arise from the Acquisition in these metropolitan areas that have price cycles to consider them further (as distinct from the potential for unilateral effects). It is therefore no longer investigating whether the Acquisition is likely to give rise to coordinated effects in Brisbane, Melbourne and Sydney.",
+          "type": "paragraph"
+        }
+      ],
+      "number": "5",
+      "title": "Summary of preliminary competition concerns"
+    },
+    {
+      "blocks": [
+        {
+          "number": "6.1",
+          "text": "The ACCC\u2019s preliminary assessment is that the Acquisition is not likely to substantially lessen competition in the Adelaide or Perth metropolitan markets as a result of either unilateral effects or coordinated effects.",
+          "type": "paragraph"
+        },
+        {
+          "number": "6.2",
+          "text": "In Perth, ACCC average pricing analysis indicates EG Australia has higher metropolitan-wide average prices compared to Ampol, meaning EG Australia\u2019s pricing strategy is producing higher pricing outcomes than Ampol\u2019s.Consequently, there is unlikely to be a substantial lessening of competition in the Perth metropolitan market.",
+          "type": "paragraph"
+        },
+        {
+          "number": "6.3",
+          "text": "In relation to Adelaide, the average pricing differential between Ampol and EG Australia is relatively small. The ACCC also notes that Viva Energy is the largest retailer in the metropolitan area, with a share of supply of almost 40% by number of sites. While the Acquisition will increase concentration in Adelaide, with Ampol\u2019s share of sites increasing to approximately 18%, the ACCC notes the incremental increase as a result of the Acquisition would be a 5.3% share of sites. Together, these factors (among others) indicate there is unlikely to be a substantial lessening of competition in the Adelaide metropolitan market.",
+          "type": "paragraph"
+        },
+        {
+          "number": "6.4",
+          "text": "As noted above, the ACCC has is also no longer investigating whether the Acquisition is likely to give rise to coordinated effects in the metropolitan markets of Brisbane, Melbourne and Sydney.",
+          "type": "paragraph"
+        }
+      ],
+      "number": "6",
+      "title": "Areas no longer under active investigation"
+    },
+    {
+      "blocks": [
+        {
+          "number": "7.1",
+          "text": "On 10 October 2025, Ampol made a remedy offer to the ACCC with respect to the Acquisition. The remedy offer was in the form of a draft undertaking pursuant to section 87B of the Act. The undertaking was to divest 19 Ampol and EG Australia fuel retail sites to a purchaser approved by the ACCC (the Remedy Offer).",
+          "type": "paragraph"
+        },
+        {
+          "number": "7.2",
+          "text": "The ACCC\u2019s decision that the Acquisition is to be subject to Phase 2 review set out the ACCC\u2019s consideration of the Remedy Offer.",
+          "type": "paragraph"
+        },
+        {
+          "number": "7.3",
+          "text": "Ampol may make further remedy offers within permitted timeframes. Any such further offer will be assessed and the ACCC may provide feedback.",
+          "type": "paragraph"
+        },
+        {
+          "number": "7.4",
+          "text": "The ACCC\u2019s assessment of a remedy offer will include, but is not limited to, whether the offer could address the relevant competition concerns. For divestitures, the ACCC\u2019s consideration will generally also include matters related to the composition of the proposed divestiture, the availability and identification of an appropriate purchaser, management of risk of business or asset degradation and implementation of the remedy.",
+          "type": "paragraph"
+        },
+        {
+          "number": "7.5",
+          "text": "The ACCC has a broad power to determine the nature, form and scope of any conditions included in a determination and is not confined to either accepting or rejecting a remedy offer. There may be differences between a remedy offer and any remedy that the ACCC includes in a determination as one or more conditions.",
+          "type": "paragraph"
+        }
+      ],
+      "number": "7",
+      "title": "Remedy offer"
+    },
+    {
+      "blocks": [
+        {
+          "number": "8.1",
+          "text": "Following the release of the NOCC, and consistent with s 50ABZL of the Act, the Parties have an opportunity to respond to the preliminary issues identified in the NOCC by 8 April 2026.",
+          "type": "paragraph"
+        },
+        {
+          "number": "8.2",
+          "text": "Under the current statutory timeframe, the ACCC must issue a determination in respect of the Acquisition by 5 June 2026.",
+          "type": "paragraph"
+        }
+      ],
+      "number": "8",
+      "title": "Next steps"
+    }
+  ]
+}

--- a/merger-tracker/frontend/public/data/noccs/MN-01068.json
+++ b/merger-tracker/frontend/public/data/noccs/MN-01068.json
@@ -1,0 +1,375 @@
+{
+  "title": "Coles \u2013 supermarket and liquor site in Kalgoorlie, WA",
+  "matter_id": "MN-01068",
+  "document_type": "Notice of Competition Concerns \u2013 Summary",
+  "date": "5 March 2026",
+  "date_iso": "2026-03-05",
+  "file_name": "Coles_Kalgoorlie - Final - Summary of Notice of Competition Concerns - March 2026.pdf",
+  "file_path": "matters/MN-01068/Coles_Kalgoorlie - Final - Summary of Notice of Competition Concerns - March 2026.pdf",
+  "sections": [
+    {
+      "blocks": [
+        {
+          "number": "1.1",
+          "text": "On 27 November 2025, Coles Supermarkets Australia Pty Ltd (Coles Supermarkets) lodged a notification with the Australian Competition and Consumer Commission (ACCC) in respect of its proposed acquisition of a leasehold interest for a supermarket and liquor site in Kalgoorlie, WA (the Acquisition). Coles Supermarkets is a subsidiary of Coles Group Limited (Coles).",
+          "type": "paragraph"
+        },
+        {
+          "number": "1.2",
+          "text": "On 29 January 2026, the ACCC decided that the Acquisition is to be subject to Phase 2 review.",
+          "type": "paragraph"
+        },
+        {
+          "number": "1.3",
+          "text": "On 5 March 2026, the ACCC issued a Notice of Competition Concerns (NOCC) to Coles Supermarkets.",
+          "type": "paragraph"
+        },
+        {
+          "number": "1.4",
+          "text": "The NOCC sets out the ACCC\u2019s preliminary assessment of whether the Acquisition, if put into effect, would have the effect, or be likely to have the effect, of substantially lessening competition in any market, and the grounds on which the ACCC makes its assessment, referring to the evidence or other material on which those grounds are based.",
+          "type": "paragraph"
+        },
+        {
+          "number": "1.5",
+          "text": "This is a summary of the NOCC as required to be published on the Acquisitions Register.",
+          "type": "paragraph"
+        }
+      ],
+      "number": "1",
+      "title": "Introduction"
+    },
+    {
+      "blocks": [
+        {
+          "text": "The Acquisition",
+          "type": "heading"
+        },
+        {
+          "number": "2.1",
+          "text": "Coles Supermarkets proposes to acquire a leasehold interest (the Lease) at Lots 95- 106 Great Eastern Highway, in Somerville, WA (the Property) for the purpose of opening a supermarket and liquor store. Somerville is a suburb of Kalgoorlie-Boulder (Kalgoorlie).",
+          "type": "paragraph"
+        },
+        {
+          "text": "The acquirer \u2013 Coles",
+          "type": "heading"
+        },
+        {
+          "number": "2.2",
+          "text": "Coles is an Australian ASX-listed company. Its subsidiary, Coles Supermarkets, operates more than 800 supermarkets nationwide.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.3",
+          "text": "Coles\u2019 standard offering entails large-format supermarkets that are either freestanding or located in shopping centres. Coles\u2019 large-format stores typically offer standard grocery items, as well as a full-service bakery and deli service. Coles also operates smaller format \u2018Coles Local\u2019 supermarkets with a smaller range of grocery items.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.4",
+          "text": "Coles operates an online grocery shopping and delivery platform named \u2018Coles Online\u2019, which allows consumers to shop for groceries with either home delivery or pick up from \u2018Click&Collect\u2019 locations at existing Coles stores.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.5",
+          "text": "Coles also operates three different chains of liquor stores nationally, under the brand names Liquorland, First Choice Liquor Market (soon to be re-branded as Liquorland Warehouse) and Vintage Cellars (soon to be rebranded as Liquorland Cellars).",
+          "type": "paragraph"
+        },
+        {
+          "text": "Leasehold interest in Kalgoorlie",
+          "type": "heading"
+        },
+        {
+          "number": "2.6",
+          "text": "M Holdings 4 Pty Ltd is proposing to develop a neighbourhood centre on the Property, which is currently vacant. A Coles supermarket and Liquorland store will form part of the neighbourhood centre as a result of the Lease.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.7",
+          "text": "Coles proposes to develop a large format supermarket, with a selling floor area of 2,800 square metres (the Proposed Supermarket).",
+          "type": "paragraph"
+        },
+        {
+          "text": "Industry background \u2013 grocery retailing",
+          "type": "heading"
+        },
+        {
+          "text": "Grocery retailing in Australia",
+          "type": "heading"
+        },
+        {
+          "number": "2.8",
+          "text": "Grocery retailing is characterised by a mix of national supermarket chains and independently owned supermarkets with various business models. These different business models result in variation in pricing, product ranges, store format and competitive behaviour in the supply of groceries in Australia.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.9",
+          "text": "Coles and Woolworths Limited (Woolworths) are Australia\u2019s two largest supermarket operators. They are vertically integrated, meaning they procure groceries directly from suppliers, manage their own distribution and logistics networks and operate retail stores under their respective banners.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.10",
+          "text": "In contrast, many independent supermarkets (including those trading under the IGA banner) are supplied by the wholesale distributor, Metcash Limited (Metcash). Metcash owns and operates some supermarkets, but predominantly supplies groceries and provides marketing and support services to independent supermarkets. Under this business model, independent supermarkets retain control over pricing, range and store operation.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.11",
+          "text": "Independent supermarkets differentiate themselves from Coles and Woolworths in a variety of ways including by sourcing some of their products from local suppliers, including local bakeries, restaurants, and producers.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.12",
+          "text": "There are also independent supermarket operators that are partially vertically integrated. Spudshed, for example, sources a proportion of its fresh produce directly from farms it owns.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.13",
+          "text": "These different business models result in variation in pricing, product ranges, store format and competitive behaviour in the supply of groceries.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.14",
+          "text": "In 2025, the ACCC published its Supermarkets Inquiry (the Inquiry) final report, which reviewed grocery retailing markets in Australia. The ACCC found the Australian supermarket industry is generally highly concentrated and that Coles and Woolworths have limited incentive to compete vigorously on price. The Inquiry found that generally, while independent supermarkets also have a limited ability to compete on price, they offer alternative product ranges to major chains that meet local needs, and compete on other non-price aspects of their offer.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.15",
+          "text": "The Inquiry considered competition in Australian grocery retailing markets generally. In considering the Acquisition, the ACCC is considering competition in Kalgoorlie specifically.",
+          "type": "paragraph"
+        },
+        {
+          "text": "Grocery retailing in Kalgoorlie",
+          "type": "heading"
+        },
+        {
+          "number": "2.16",
+          "text": "There are 6 supermarkets in Kalgoorlie, as set out in Table 1 below, of which 4 supply a larger range of groceries in a larger format store: Woolworths, Coles, Spudshed and O\u2019Connor Fresh IGA. These larger supermarkets offer a comprehensive range of groceries\u2014including fresh produce, meat, dairy, bakery, frozen and general merchandise items\u2014and a \u2018one-stop-shop\u2019 experience for consumers.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.17",
+          "text": "Coles and Woolworths are Australia\u2019s largest grocery chain supermarkets and are the two largest supermarkets in Kalgoorlie.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.18",
+          "text": "O\u2019Connor Fresh IGA is an independent supermarket. It has smaller floor space than Coles and Woolworths and it offers a reasonably large range of groceries for customers.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.19",
+          "text": "Spudshed is an independent supermarket that entered Kalgoorlie in November 2025, taking over the space formerly occupied by IGA Hannans Fresh, which was occupied by Coles before that. Spudshed offers a large range of fresh produce, a proportion of which is sourced from its owners\u2019 farms. Spudshed also offers a range of meat, dairy and grocery items.",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.20",
+          "text": "Compared to other supermarkets in Kalgoorlie, the Hannans Marketplace by Foodworks and Lionel St IGA supermarkets have smaller floor space and a smaller product range. Table 1Supermarkets in Kalgoorlie",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.21",
+          "text": "The locations of existing supermarkets and the Proposed Supermarket are illustrated in the figure below. O\u2019Connor Fresh IGA will be the closest store geographically to the Proposed Supermarket (approximately 1.8km driving distance). Figure 1 Map of supermarkets in Kalgoorlie",
+          "type": "paragraph"
+        },
+        {
+          "number": "2.22",
+          "text": "Supermarkets in Kalgoorlie offer different trading hours to each other. Large supermarkets, such as Coles and Woolworths in Kalgoorlie, are subject to trading hour regulations. Other supermarkets, such as Spudshed, O\u2019Connor Fresh IGA, Lionel St IGA and Hannans Marketplace by Foodworks, are not. Table 2 sets out the trading times for the 6 supermarkets in Kalgoorlie. Table 2Opening hours of supermarkets in Kalgoorlie",
+          "type": "paragraph"
+        },
+        {
+          "text": "Overlap and relationship between the parties",
+          "type": "heading"
+        },
+        {
+          "number": "2.23",
+          "text": "The Lease will be an input to Coles\u2019 supermarket retailing operations.",
+          "type": "paragraph"
+        }
+      ],
+      "number": "2",
+      "title": "Background"
+    },
+    {
+      "blocks": [
+        {
+          "number": "3.1",
+          "text": "The area of competition the ACCC is considering for the purpose of assessing the Acquisition is the retail supply of groceries by supermarkets in Kalgoorlie.",
+          "type": "paragraph"
+        },
+        {
+          "number": "3.2",
+          "text": "Market definition is a purposive tool used to help assess whether an acquisition might have anti-competitive effects. At this stage of the review, the ACCC is taking a simple approach to defining the relevant market, by focussing on the most important competitive constraints on Coles.",
+          "type": "paragraph"
+        },
+        {
+          "number": "3.3",
+          "text": "For any given supermarket in Kalgoorlie, the extent of competitive rivalry they face from other participants will depend on a range of factors, including how similar or differentiated their product offerings are and their geographic proximity to each other.",
+          "type": "paragraph"
+        },
+        {
+          "text": "Product market",
+          "type": "heading"
+        },
+        {
+          "number": "3.4",
+          "text": "The ACCC\u2019s preliminary view is the relevant product dimension is the retail supply of groceries by supermarkets. Supermarkets offer consumers the convenience of a one- stop-shop service for their grocery needs and a broad range of products.",
+          "type": "paragraph"
+        },
+        {
+          "number": "3.5",
+          "text": "This product dimension likely includes each of the supermarkets identified in Table 1 above. However, as discussed further in the Preliminary Competition Assessment below, the ACCC is still considering the extent of the competitive rivalry each supermarket in Kalgoorlie imposes on the others.",
+          "type": "paragraph"
+        },
+        {
+          "number": "3.6",
+          "text": "The ACCC\u2019s view is that while the following types of retailers overlap in some product offerings with supermarkets, they are unlikely to be close substitutes for supermarkets for consumers:",
+          "type": "paragraph"
+        },
+        {
+          "items": [
+            "convenience stores\u2014are not likely to be sufficiently close substitutes to supermarkets as they target consumers seeking few items on a convenient basis, and",
+            "speciality and general merchandise stores\u2014retailers such as Chemist Warehouse, Bunnings, butchers, bakeries, green grocers and other specialty or general merchandise stores may stock a limited subset of grocery or household items, but they do not provide a sufficiently broad or substitutable range of grocery products to be close substitutes for supermarkets."
+          ],
+          "type": "bullet_list"
+        },
+        {
+          "number": "3.7",
+          "text": "Coles, Woolworths and other supermarkets supplement their bricks-and-mortar supermarket offerings with online delivery and online order services. The ACCC\u2019s view is that for the purposes of assessing the Acquisition, these services should be included when assessing competition between supermarkets.",
+          "type": "paragraph"
+        },
+        {
+          "number": "3.8",
+          "text": "Kalgoorlie has a substantial population of fly-in-fly-out (FIFO) workers. However, the ACCC\u2019s preliminary view is this customer group does not alter the product market or form a separate market.",
+          "type": "paragraph"
+        },
+        {
+          "text": "Geographic market",
+          "type": "heading"
+        },
+        {
+          "number": "3.9",
+          "text": "The ACCC considers that the geographic market is likely to be Kalgoorlie, though supermarkets in close geographic proximity are likely to compete more closely with each other.",
+          "type": "paragraph"
+        },
+        {
+          "number": "3.10",
+          "text": "Consumers are unlikely to travel beyond Kalgoorlie to shop for grocery products as it is geographically remote. For this reason, supermarkets outside the town are unlikely to be adequate substitutes for consumers.",
+          "type": "paragraph"
+        },
+        {
+          "number": "3.11",
+          "text": "The Inquiry found consumers generally prefer to travel shorter distances to do their grocery shopping. Additionally, feedback from a market participant suggests while it draws consumers from all over Kalgoorlie, the majority of its customers are coming from surrounding suburbs.",
+          "type": "paragraph"
+        }
+      ],
+      "number": "3",
+      "title": "Relevant areas of competition"
+    },
+    {
+      "blocks": [
+        {
+          "number": "4.1",
+          "text": "The ACCC is closely examining the effects of the Acquisition on competition between supermarkets in Kalgoorlie, by comparing the likely future state of competition if the Acquisition proceeds against the likely future state of competition if the Acquisition does not proceed. The ACCC considers the latter would be the status quo, or continuation of the current state of competition.",
+          "type": "paragraph"
+        },
+        {
+          "number": "4.2",
+          "text": "In the status quo and in the future without the Acquisition, the ACCC considers Coles and Woolworths likely have market power in Kalgoorlie. This is the case even though Coles and Woolworths face a degree of rivalry from independent supermarkets via their competitive differentiated offering compared to Coles and Woolworths. Coles and Woolworths each and combined account for a significant proportion of the market and the ACCC has previously found Coles and Woolworths have limited incentive to compete vigorously with each other on price. The ACCC is still considering whether Coles and Woolworths may have substantial market power in Kalgoorlie.",
+          "type": "paragraph"
+        },
+        {
+          "number": "4.3",
+          "text": "Information from market participants shows independent supermarkets in Kalgoorlie compete on the basis of price, range and quality of products, store quality and customer service. Market participants have also provided information to show supermarkets monitor and respond to each other, including with independents matching or beating Coles and Woolworths on key value items.",
+          "type": "paragraph"
+        },
+        {
+          "number": "4.4",
+          "text": "In the future with the Acquisition, the ACCC considers the Acquisition will likely create an over-supply of supermarket capacity and thereby lead to the exit of an effective independent competitor. This will reduce the level of competition faced by remaining rivals, in circumstances where the likelihood of new entry is low. Coles would increase its market power and likely have a substantial degree of market power. This is because:",
+          "type": "paragraph"
+        },
+        {
+          "items": [
+            "Coles\u2019 market share in Kalgoorlie will increase to a high level",
+            "while some supermarkets will continue to compete, their ability to constrain Coles\u2019 market power would be limited, and",
+            "it is likely that Coles would earn high economic profits in Kalgoorlie."
+          ],
+          "type": "bullet_list"
+        },
+        {
+          "number": "4.5",
+          "text": "The ACCC is considering whether Coles\u2019 investment in the Proposed Supermarket is likely to only be profitable if it leads to the exit of an effective competitor.",
+          "type": "paragraph"
+        },
+        {
+          "number": "4.6",
+          "text": "Having regard to the likely future with the Acquisition and the likely future without the Acquisition, the ACCC\u2019s preliminary assessment is that the Acquisition would have the effect or likely effect of substantially lessening competition in Kalgoorlie as it leads to the exit of an effective independent competitor and increases Coles\u2019 market power. This would be likely to, in all the circumstances, create, strengthen or entrench a substantial degree of market power for Coles.",
+          "type": "paragraph"
+        },
+        {
+          "number": "4.7",
+          "text": "The ACCC considers the Kalgoorlie market will likely lose an effective competitor that:",
+          "type": "paragraph"
+        },
+        {
+          "items": [
+            "price matches and price discounts relative to Coles and other supermarkets in Kalgoorlie",
+            "offers a range and quality of products\u2014this includes high-revenue products where an effective competitor competes head-to-head, but also unique and specialised products that provide a differentiated offering valued by customers",
+            "is valued by customers as a high-quality alternative to other competitors\u2014 including in terms of the store\u2019s stock levels and shelf replenishment, store cleanliness and condition, maintenance expenditure and capital refurbishment, and",
+            "provides a high level of customer service\u2014this includes ensuring check outs are staffed and queues are minimised, and offering extended opening hours."
+          ],
+          "type": "bullet_list"
+        },
+        {
+          "number": "4.8",
+          "text": "This is likely to lead to Coles competing less strongly in Kalgoorlie, as it will no longer be concerned with the effective competitor\u2019s activity. Coles and other supermarkets may:",
+          "type": "paragraph"
+        },
+        {
+          "items": [
+            "reduce the extent to which they match competitor discounts i.e. reduce the frequency or extent of altering prices on select product lines, such as fresh produce, or deviate from statewide pricing policies",
+            "have higher incentives to raise statewide prices",
+            "reduce customer service by employing fewer staff at its Kalgoorlie stores and reduce other aspects of quality, and",
+            "reduce the range of products available, particularly where they might have matched the speciality products the exiting competitor used to differentiate itself."
+          ],
+          "type": "bullet_list"
+        },
+        {
+          "number": "4.9",
+          "text": "The ACCC expects Coles sets statewide prices having regard to the likelihood of losing customers\u2019 sales to competitors across its stores in Western Australia. The ACCC is further considering whether, if local competition declines in Kalgoorlie, Coles may increase statewide prices, albeit by a small amount.",
+          "type": "paragraph"
+        },
+        {
+          "number": "4.10",
+          "text": "The ACCC is exploring whether competition will also be substantially lessened, albeit to a lesser extent, where an effective competitor is significantly harmed but does not exit. It is not yet clear whether a competitor would respond to significant harm following the Acquisition by undertaking less competitive activity to reduce their costs or by competing more fiercely to defend its position in the market.",
+          "type": "paragraph"
+        },
+        {
+          "number": "4.11",
+          "text": "The ACCC is also considering whether the Acquisition may harm competition by reducing the competitive rivalry existing competitors impose on Coles. Interested parties have submitted that if the Acquisition reduces the scale of existing competitors, it may increase distribution and wholesale costs in a relatively remote location such as Kalgoorlie.",
+          "type": "paragraph"
+        },
+        {
+          "number": "4.12",
+          "text": "The ACCC will continue considering these issues.",
+          "type": "paragraph"
+        }
+      ],
+      "number": "4",
+      "title": "Summary of preliminary competition assessment"
+    },
+    {
+      "blocks": [
+        {
+          "number": "5.1",
+          "text": "Following the release of the NOCC, and consistent with s 51ABZL of the Act, the notifying party (Coles Supermarkets) has an opportunity to respond to the preliminary issues identified in the NOCC by 14 April 2026.",
+          "type": "paragraph"
+        },
+        {
+          "number": "5.2",
+          "text": "Under the current statutory timeframe, the ACCC must issue a determination in response to the Acquisition by 12 June 2026.",
+          "type": "paragraph"
+        }
+      ],
+      "number": "5",
+      "title": "Next steps"
+    }
+  ]
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -29,6 +29,7 @@ scrape.sh ──► extract_mergers.py ──► generate_static_data.py ──�
 | --- | --- |
 | `extract_mergers.py` | Parse `data/raw/` HTML and supporting PDFs into `data/processed/mergers.json`. |
 | `parse_determination.py` | Extract structured info (decision, division, tables) from determination PDFs. |
+| `parse_nocc.py` | Extract structured sections (numbered paragraphs, headings, bullets) from Notice of Competition Concerns summary PDFs. |
 | `parse_questionnaire.py` | Extract consultation deadlines and questions from questionnaire PDFs. |
 | `normalization.py` | Shared string/value normalisation (e.g. determination labels). |
 | `date_utils.py` | Date parsing helpers shared across the pipeline. |

--- a/scripts/extract_mergers.py
+++ b/scripts/extract_mergers.py
@@ -11,6 +11,7 @@ import re
 from datetime import datetime
 from markdownify import markdownify as md
 from parse_determination import parse_determination_pdf
+from parse_nocc import process_all_noccs
 from parse_questionnaire import process_all_questionnaires
 from normalization import normalize_determination
 from cutoff import should_skip_merger, get_skipped_merger_ids, is_waiver_merger
@@ -742,6 +743,39 @@ def enrich_with_questionnaire_data(mergers_data):
 
     return mergers_data
 
+
+def extract_nocc_data():
+    """Parse all NOCC summary PDFs and write the standalone JSON manifest.
+
+    Returns the parsed dict, or an empty dict on failure / when no NOCCs are
+    present.
+    """
+    print("Extracting NOCC summary data...", file=sys.stderr)
+
+    try:
+        nocc_data = process_all_noccs(MATTERS_DIR)
+    except Exception as e:
+        print(f"Error extracting NOCC data: {e}", file=sys.stderr)
+        import traceback
+        traceback.print_exc(file=sys.stderr)
+        return {}
+
+    if not nocc_data:
+        print("No NOCC summaries found.", file=sys.stderr)
+        return {}
+
+    print(f"Found {len(nocc_data)} NOCC summary/summaries", file=sys.stderr)
+
+    try:
+        with open('data/processed/nocc_data.json', 'w', encoding='utf-8') as f:
+            json.dump(nocc_data, f, indent=2, sort_keys=True)
+        print("Wrote data/processed/nocc_data.json", file=sys.stderr)
+    except IOError as e:
+        print(f"Error writing nocc_data.json: {e}", file=sys.stderr)
+
+    return nocc_data
+
+
 def run_parse_merger_file(task):
     """Helper function to unpack arguments for parse_merger_file."""
     return parse_merger_file(*task)
@@ -853,6 +887,11 @@ def main():
 
     # 8. Enrich with questionnaire data (consultation deadlines)
     all_mergers_data = enrich_with_questionnaire_data(all_mergers_data)
+
+    # 8b. Parse NOCC summary PDFs to a standalone manifest. NOCCs do not feed
+    # back into per-merger fields (their date is already on the event), but
+    # downstream pipelines load the manifest separately.
+    extract_nocc_data()
 
     # 9. Add is_waiver field to each merger
     for merger in all_mergers_data:

--- a/scripts/generate_static_data.py
+++ b/scripts/generate_static_data.py
@@ -22,6 +22,7 @@ Output files:
   - commentary.json             - Mergers with user commentary
   - analysis.json               - Pre-computed analysis data
   - questionnaires/{id}.json    - Lazy-loaded questionnaire files
+  - noccs/{id}.json             - Lazy-loaded NOCC summary files
 """
 
 import json
@@ -31,6 +32,7 @@ from static_data.enrichment import enrich_merger, link_related_mergers, link_sim
 from static_data.loaders import (
     load_commentary,
     load_mergers,
+    load_nocc_data,
     load_questionnaire_data,
     load_related_mergers,
     load_similar_mergers,
@@ -41,6 +43,7 @@ from static_data.outputs import (
     individual,
     industries,
     list as list_out,
+    noccs,
     questionnaires,
     stats,
     timeline,
@@ -70,6 +73,13 @@ def main():
         if questionnaire_data else "No questionnaire data found"
     )
 
+    print("Loading nocc_data.json...")
+    nocc_data = load_nocc_data()
+    print(
+        f"Loaded NOCC data for {len(nocc_data)} merger(s)"
+        if nocc_data else "No NOCC data found"
+    )
+
     related_mergers = load_related_mergers()
     if related_mergers:
         print(f"Loaded {len(related_mergers) // 2} related merger pair(s)")
@@ -79,7 +89,9 @@ def main():
         print(f"Loaded similar merger suggestions for {len(similar_mergers)} merger(s)")
 
     print("Enriching mergers...")
-    enriched = [enrich_merger(m, commentary, questionnaire_data) for m in mergers]
+    enriched = [
+        enrich_merger(m, commentary, questionnaire_data, nocc_data) for m in mergers
+    ]
     linked = link_related_mergers(enriched, related_mergers)
     if linked:
         print(f"  Linked {linked} related merger pairs")
@@ -131,6 +143,11 @@ def main():
         print("\nGenerating questionnaire files...")
         q_count = questionnaires.generate(questionnaire_data, OUTPUT_DIR)
         print(f"✓ Generated {q_count} questionnaire files in {OUTPUT_DIR / 'questionnaires'}")
+
+    if nocc_data:
+        print("\nGenerating NOCC files...")
+        n_count = noccs.generate(nocc_data, OUTPUT_DIR)
+        print(f"✓ Generated {n_count} NOCC files in {OUTPUT_DIR / 'noccs'}")
 
     print("\nDone!")
 

--- a/scripts/parse_nocc.py
+++ b/scripts/parse_nocc.py
@@ -1,0 +1,536 @@
+#!/usr/bin/env python3
+"""
+Parse Notice of Competition Concerns (NOCC) summary PDFs to extract structured
+content.
+
+NOCC summaries are published during Phase 2 review (around business day 25 of
+Phase 2). The published version is a ~10-15 page document with a cover page,
+optional table of contents, and numbered top-level sections (e.g.
+"1. Introduction", "2. Background", ...) each containing numbered paragraphs
+("1.1.", "1.2.", ...), bold sub-headings, bullet lists and lettered lists.
+
+The structure mirrors Phase 1 detailed-determination "Statement of reasons"
+content, so we reuse the line/heading helpers from ``parse_determination``.
+The shape of the output, however, is NOCC-specific: a list of top-level
+sections, each with its own ordered block stream.
+"""
+
+import json
+import re
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import pdfplumber
+
+from parse_determination import _group_chars_into_lines
+from date_utils import parse_text_to_iso
+
+# Lines with font size below this threshold (footnote anchors/bodies, page
+# numbers and the running page header) are discarded before parsing.
+_BODY_MIN_FONT_SIZE = 10.0
+
+# Top-level numbered headings (e.g. "1. Introduction") render at this size in
+# the published NOCCs we have seen; sub-section headings ("The Acquisition")
+# render around 14pt. The threshold sits between the two.
+_TOP_LEVEL_HEADING_MIN_SIZE = 15.0
+_SUB_HEADING_MIN_SIZE = 12.5
+
+_TOC_DOT_LEADER_RE = re.compile(r'\.{4,}')
+_TOP_LEVEL_HEADING_RE = re.compile(r'^(\d+)\.\s*(.+?)\s*$')
+
+
+def _is_top_level_heading(line: Dict) -> bool:
+    return (
+        line['size'] >= _TOP_LEVEL_HEADING_MIN_SIZE
+        and bool(_TOP_LEVEL_HEADING_RE.match(line['text']))
+    )
+
+
+def _is_sub_heading(line: Dict) -> bool:
+    text = line['text']
+    size = line['size']
+    if _is_top_level_heading(line):
+        return False
+    # Numbered paragraphs and list markers are body content even if they pick
+    # up bold styling.
+    if re.match(r'^\d+\.\d+', text):
+        return False
+    if re.match(r'^[•▪]\s', text):
+        return False
+    if re.match(r'^\([a-z]\)\s', text):
+        return False
+    # Any line noticeably larger than body text (≈11pt) is a heading. This
+    # covers regular-weight 14pt sub-sub-headings such as "Grocery retailing
+    # in Australia" that the published NOCCs render unbolded.
+    if size >= 13.5 and len(text) <= 200:
+        return True
+    # Body-sized but bold or italic: standard sub-heading style. Limit length
+    # so we don't promote a stray bold inline phrase to a heading.
+    if line['bold'] and _SUB_HEADING_MIN_SIZE <= size < 13.5 and len(text) <= 120:
+        return True
+    if (
+        line['italic']
+        and not line['bold']
+        and 10 <= size < 13.5
+        and len(text) <= 60
+        and not text.endswith('.')
+        and not text.endswith(',')
+    ):
+        return True
+    return False
+
+
+def _extract_cover_metadata(page) -> Dict[str, Optional[str]]:
+    """Pull title, matter id and publication date from the cover page.
+
+    The cover layout is consistent across the NOCCs we have:
+        <Title>                                   18pt bold
+        <MN-XXXXX>                                14pt
+        Notice of                                 ~40pt bold
+        Competition Concerns –                    ~40pt bold
+        Summary                                   ~40pt bold
+        <DD Month YYYY>                           14pt
+    """
+    title: Optional[str] = None
+    matter_id: Optional[str] = None
+    date_text: Optional[str] = None
+    document_type: Optional[str] = None
+
+    big_title_parts: List[str] = []
+
+    for line in _group_chars_into_lines(page):
+        text = line['text'].strip()
+        if not text:
+            continue
+        size = line['size']
+
+        m = re.match(r'^(MN-\d+)$', text)
+        if m and matter_id is None:
+            matter_id = m.group(1)
+            continue
+
+        if size >= 30:
+            big_title_parts.append(text)
+            continue
+
+        # Title is the largest line that isn't the giant document-type banner;
+        # take the first such line we see.
+        if title is None and 16 <= size < 30:
+            title = text
+            continue
+
+        if 12 <= size < 16 and re.match(
+            r'^\d{1,2}\s+[A-Za-z]+\s+\d{4}$', text
+        ):
+            date_text = text
+            continue
+
+    if big_title_parts:
+        joined = ' '.join(big_title_parts)
+        # Normalise the dash and trailing whitespace; collapse to a canonical
+        # short form for downstream callers.
+        joined = re.sub(r'\s+', ' ', joined).strip()
+        document_type = joined
+
+    return {
+        'title': title,
+        'matter_id': matter_id,
+        'date': date_text,
+        'document_type': document_type,
+    }
+
+
+def _collect_body_lines(pdf) -> List[Dict]:
+    """Return formatted lines from the body pages, skipping page chrome.
+
+    Filters applied:
+      - Font size below ``_BODY_MIN_FONT_SIZE`` (page header, page number,
+        footnote anchor superscripts, footnote bodies).
+      - Lines that consist solely of a TOC dot leader plus page number.
+      - The TOC page itself, identified by a ``Contents`` heading.
+    """
+    lines: List[Dict] = []
+    for page_idx, page in enumerate(pdf.pages):
+        if page_idx == 0:
+            # Cover page — handled separately for metadata.
+            continue
+
+        page_lines = _group_chars_into_lines(page)
+        # Detect TOC page: starts with a large "Contents" heading.
+        if any(
+            line['text'].strip().lower() == 'contents' and line['size'] >= 18
+            for line in page_lines
+        ):
+            continue
+
+        for line in page_lines:
+            if line['size'] < _BODY_MIN_FONT_SIZE:
+                continue
+            text = line['text']
+            # Skip stray TOC entries if they ever survive past the page filter
+            # (defensive — leading digit + dot-leader + trailing page number).
+            if _TOC_DOT_LEADER_RE.search(text):
+                continue
+            lines.append(line)
+
+    return lines
+
+
+def _parse_blocks(lines: List[Dict]) -> List[Dict]:
+    """Turn formatted lines into a flat block stream.
+
+    Block types:
+      - ``heading``  with ``text`` and ``level`` (1 = top-level numbered
+        section, 2 = sub-heading)
+      - ``paragraph`` with ``text`` and optional ``number`` (e.g. "2.4")
+      - ``bullet_list`` with ``items`` (list of strings)
+      - ``lettered_list`` with ``items`` (list of {'letter', 'text'})
+    """
+    blocks: List[Dict] = []
+    current: Optional[Dict] = None
+
+    def flush():
+        nonlocal current
+        if current is not None:
+            blocks.append(current)
+            current = None
+
+    def append_continuation(text: str) -> None:
+        nonlocal current
+        if current is None:
+            current = {'type': 'paragraph', 'text': text}
+            return
+        if current['type'] == 'paragraph':
+            current['text'] = (current['text'] + ' ' + text).strip()
+        elif current['type'] == 'bullet_list':
+            if current['items']:
+                current['items'][-1] = (current['items'][-1] + ' ' + text).strip()
+            else:
+                current['items'].append(text)
+        elif current['type'] == 'lettered_list':
+            if current['items']:
+                current['items'][-1]['text'] = (
+                    current['items'][-1]['text'] + ' ' + text
+                ).strip()
+
+    for line in lines:
+        text = line['text'].strip()
+        if not text:
+            continue
+
+        if _is_top_level_heading(line):
+            flush()
+            blocks.append({'type': 'heading', 'level': 1, 'text': text})
+            continue
+
+        if _is_sub_heading(line):
+            flush()
+            # Merge with the previous sub-heading only if it shares the same
+            # visual style — handles a single sub-heading wrapping across two
+            # PDF lines, while keeping a sub-heading and a sub-sub-heading
+            # (different bold/italic) distinct.
+            prev = blocks[-1] if blocks else None
+            if (
+                prev
+                and prev['type'] == 'heading'
+                and prev.get('level') == 2
+                and prev.get('_bold') == line['bold']
+                and prev.get('_italic') == line['italic']
+            ):
+                prev['text'] = (prev['text'] + ' ' + text).strip()
+            else:
+                blocks.append({
+                    'type': 'heading',
+                    'level': 2,
+                    'text': text,
+                    '_bold': line['bold'],
+                    '_italic': line['italic'],
+                })
+            continue
+
+        # Numbered paragraph: "2.4. text" or "2.4text" (no space) or "2.4 text".
+        para_match = re.match(r'^(\d+)\.(\d+)\.?\s*(.+)$', text)
+        if para_match:
+            flush()
+            current = {
+                'type': 'paragraph',
+                'number': f"{para_match.group(1)}.{para_match.group(2)}",
+                'text': para_match.group(3).strip(),
+            }
+            continue
+
+        # Bullet item — accepts the standard ACCC bullet markers as well as
+        # the en-dash / minus-sign characters used for nested sub-bullets.
+        # A marker on a line by itself is allowed (the next line will supply
+        # the item text via the continuation path).
+        bullet_match = re.match(r'^([•▪−–])\s*(.*)$', text)
+        if bullet_match:
+            if current is None or current.get('type') != 'bullet_list':
+                flush()
+                current = {'type': 'bullet_list', 'items': []}
+            current['items'].append(bullet_match.group(2).strip())
+            continue
+
+        # Lettered list "(a) text".
+        letter_match = re.match(r'^\(([a-z])\)\s*(.+)$', text)
+        if letter_match:
+            if current is None or current.get('type') != 'lettered_list':
+                flush()
+                current = {'type': 'lettered_list', 'items': []}
+            current['items'].append({
+                'letter': letter_match.group(1),
+                'text': letter_match.group(2).strip(),
+            })
+            continue
+
+        # Continuation of the previous block.
+        append_continuation(text)
+
+    flush()
+    return blocks
+
+
+def _group_blocks_into_sections(blocks: List[Dict]) -> List[Dict]:
+    """Group the flat block stream by top-level numbered sections."""
+    sections: List[Dict] = []
+    preamble: List[Dict] = []
+    current: Optional[Dict] = None
+
+    for block in blocks:
+        if block['type'] == 'heading' and block.get('level') == 1:
+            if current is not None:
+                sections.append(current)
+            m = _TOP_LEVEL_HEADING_RE.match(block['text'])
+            number = m.group(1) if m else None
+            heading_text = m.group(2).strip() if m else block['text']
+            current = {
+                'number': number,
+                'title': heading_text,
+                'blocks': [],
+            }
+            continue
+
+        if current is None:
+            preamble.append(block)
+        else:
+            # Strip the synthetic heading-level markers from sub-headings on
+            # the way out so consumers see a stable schema.
+            if block['type'] == 'heading':
+                block = {'type': 'heading', 'text': block['text']}
+            current['blocks'].append(block)
+
+    if current is not None:
+        sections.append(current)
+
+    if preamble:
+        # Anything before the first numbered section is unusual but should not
+        # be silently dropped. Keep it as a synthetic leading section.
+        cleaned_preamble = []
+        for block in preamble:
+            if block['type'] == 'heading':
+                block = {'type': 'heading', 'text': block['text']}
+            cleaned_preamble.append(block)
+        sections.insert(0, {
+            'number': None,
+            'title': None,
+            'blocks': cleaned_preamble,
+        })
+
+    return sections
+
+
+def parse_nocc_pdf(pdf_path: str) -> Dict[str, object]:
+    """Parse a NOCC summary PDF.
+
+    Returns a dictionary with the cover-page metadata and a structured list
+    of sections.
+    """
+    pdf_file = Path(pdf_path)
+    if not pdf_file.exists():
+        raise FileNotFoundError(f"PDF file not found: {pdf_path}")
+
+    with pdfplumber.open(pdf_path) as pdf:
+        if not pdf.pages:
+            raise ValueError(f"PDF has no pages: {pdf_path}")
+
+        metadata = _extract_cover_metadata(pdf.pages[0])
+        body_lines = _collect_body_lines(pdf)
+
+    blocks = _parse_blocks(body_lines)
+    sections = _group_blocks_into_sections(blocks)
+
+    date_iso = parse_text_to_iso(metadata['date'], include_time=False) if metadata.get('date') else None
+
+    return {
+        'title': metadata.get('title'),
+        'matter_id': metadata.get('matter_id'),
+        'document_type': metadata.get('document_type'),
+        'date': metadata.get('date'),
+        'date_iso': date_iso,
+        'sections': sections,
+    }
+
+
+def _is_nocc_filename(name: str) -> bool:
+    lower = name.lower()
+    if not lower.endswith('.pdf'):
+        return False
+    # Match either the full phrase or the common abbreviation.
+    return 'notice of competition concerns' in lower or 'nocc' in lower
+
+
+def process_all_noccs(matters_dir: str = "data/raw/matters") -> Dict[str, Dict]:
+    """Process all NOCC PDFs in the matters directory.
+
+    Mirrors the questionnaire pipeline: when a matter has multiple NOCC PDFs,
+    the latest by publication date wins, with duplicates (same normalised
+    filename and date) collapsed.
+    """
+    matters_path = Path(matters_dir)
+    if not matters_path.exists():
+        raise FileNotFoundError(f"Matters directory not found: {matters_dir}")
+
+    candidates = [pdf for pdf in matters_path.glob("*/*.pdf") if _is_nocc_filename(pdf.name)]
+
+    pdfs_by_matter: Dict[str, List[Path]] = {}
+    for pdf_path in candidates:
+        matter_id = pdf_path.parent.name
+        pdfs_by_matter.setdefault(matter_id, []).append(pdf_path)
+
+    def _norm(name: str) -> str:
+        return re.sub(r'_\d+(\.[^.]+)$', r'\1', name)
+
+    results: Dict[str, Dict] = {}
+    for matter_id, pdf_paths in pdfs_by_matter.items():
+        parsed: List[Dict] = []
+        last_error: Optional[Dict] = None
+
+        for pdf_path in sorted(pdf_paths):
+            try:
+                data = parse_nocc_pdf(str(pdf_path))
+                data['file_path'] = str(pdf_path.relative_to(matters_path.parent))
+                data['file_name'] = pdf_path.name
+                parsed.append(data)
+            except Exception as e:
+                print(f"Error processing {pdf_path}: {e}")
+                last_error = {
+                    'error': str(e),
+                    'file_path': str(pdf_path.relative_to(matters_path.parent)),
+                }
+
+        if not parsed:
+            if last_error:
+                results[matter_id] = last_error
+            continue
+
+        seen: set = set()
+        unique: List[Dict] = []
+        for p in parsed:
+            key = (_norm(p['file_name']), p.get('date_iso') or '')
+            if key not in seen:
+                seen.add(key)
+                unique.append(p)
+
+        unique.sort(
+            key=lambda p: p.get('date_iso') or '0000-00-00',
+            reverse=True,
+        )
+
+        primary = unique[0].copy()
+        if len(unique) > 1:
+            primary['all_noccs'] = unique
+        results[matter_id] = primary
+
+    return results
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) > 1 and sys.argv[1] == '--debug-lines':
+        pdf_path = sys.argv[2]
+        with pdfplumber.open(pdf_path) as pdf:
+            for i, page in enumerate(pdf.pages):
+                print(f"--- Page {i + 1} ---")
+                for line in _group_chars_into_lines(page):
+                    flag = ''
+                    if _is_top_level_heading(line):
+                        flag = ' [H1]'
+                    elif _is_sub_heading(line):
+                        flag = ' [H2]'
+                    print(
+                        f"  size={line['size']:5.2f} bold={int(line['bold'])} "
+                        f"italic={int(line['italic'])}{flag}: {line['text']!r}"
+                    )
+        sys.exit(0)
+
+    if len(sys.argv) > 1:
+        pdf_path = sys.argv[1]
+        try:
+            result = parse_nocc_pdf(pdf_path)
+        except Exception as e:
+            print(f"Error parsing PDF: {e}")
+            import traceback
+            traceback.print_exc()
+            sys.exit(1)
+
+        print("=" * 80)
+        print(f"Title:          {result['title']}")
+        print(f"Matter ID:      {result['matter_id']}")
+        print(f"Document type:  {result['document_type']}")
+        print(f"Date:           {result['date']}  ({result['date_iso']})")
+        print(f"Sections:       {len(result['sections'])}")
+        print("=" * 80)
+        for sec in result['sections']:
+            heading = (
+                f"{sec['number']}. {sec['title']}" if sec['number'] else sec['title'] or '<preamble>'
+            )
+            print(f"\n## {heading}")
+            for block in sec['blocks']:
+                t = block['type']
+                if t == 'heading':
+                    print(f"  ### {block['text']}")
+                elif t == 'paragraph':
+                    num = block.get('number')
+                    prefix = f"{num}. " if num else ""
+                    print(f"  {prefix}{block['text']}")
+                elif t == 'bullet_list':
+                    for item in block['items']:
+                        print(f"    • {item}")
+                elif t == 'lettered_list':
+                    for item in block['items']:
+                        print(f"    ({item['letter']}) {item['text']}")
+        sys.exit(0)
+
+    # Process every NOCC under data/raw/matters and write the JSON manifest.
+    print("Processing all NOCC PDFs in matters directory...")
+    print()
+
+    try:
+        results = process_all_noccs()
+        for matter_id, data in sorted(results.items()):
+            print("=" * 80)
+            print(f"Matter: {matter_id}")
+            print("=" * 80)
+            if 'error' in data:
+                print(f"ERROR: {data['error']}")
+            else:
+                print(f"File:     {data.get('file_name')}")
+                print(f"Title:    {data.get('title')}")
+                print(f"Date:     {data.get('date')}  ({data.get('date_iso')})")
+                print(f"Sections: {len(data.get('sections', []))}")
+
+        output_file = "data/processed/nocc_data.json"
+        Path(output_file).parent.mkdir(parents=True, exist_ok=True)
+        with open(output_file, 'w') as f:
+            json.dump(results, f, indent=2, sort_keys=True)
+
+        print()
+        print("=" * 80)
+        print(f"Results saved to {output_file}")
+        print(f"Processed {len(results)} NOCC summaries")
+    except Exception as e:
+        print(f"Error processing NOCCs: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)

--- a/scripts/static_data/enrichment.py
+++ b/scripts/static_data/enrichment.py
@@ -46,7 +46,12 @@ def is_phase_2_referral_event(event_title: str) -> bool:
     )
 
 
-def enrich_merger(merger: dict, commentary: dict = None, questionnaire_data: dict = None) -> dict:
+def enrich_merger(
+    merger: dict,
+    commentary: dict = None,
+    questionnaire_data: dict = None,
+    nocc_data: dict = None,
+) -> dict:
     """Add computed fields to a merger (phase determinations, etc.)."""
     m = merger.copy()
 
@@ -133,6 +138,12 @@ def enrich_merger(merger: dict, commentary: dict = None, questionnaire_data: dic
         q_data = questionnaire_data[merger_id]
         if q_data.get('questions'):
             m['has_questionnaire'] = True
+
+    # Flag whether a parsed NOCC summary exists for this merger
+    if nocc_data and merger_id in nocc_data:
+        n_data = nocc_data[merger_id]
+        if n_data.get('sections'):
+            m['has_nocc'] = True
 
     return m
 

--- a/scripts/static_data/loaders.py
+++ b/scripts/static_data/loaders.py
@@ -8,6 +8,7 @@ REPO_ROOT = SCRIPT_DIR.parent
 MERGERS_JSON = REPO_ROOT / "data" / "processed" / "mergers.json"
 COMMENTARY_JSON = REPO_ROOT / "data" / "processed" / "commentary.json"
 QUESTIONNAIRE_JSON = REPO_ROOT / "data" / "processed" / "questionnaire_data.json"
+NOCC_JSON = REPO_ROOT / "data" / "processed" / "nocc_data.json"
 RELATED_MERGERS_JSON = REPO_ROOT / "data" / "processed" / "related_mergers.json"
 SIMILAR_MERGERS_JSON = REPO_ROOT / "data" / "processed" / "similar_mergers.json"
 
@@ -96,4 +97,17 @@ def load_questionnaire_data() -> dict:
             return json.load(f)
     except (json.JSONDecodeError, IOError) as e:
         print(f"Warning: Could not load questionnaire_data.json: {e}")
+        return {}
+
+
+def load_nocc_data() -> dict:
+    """Load NOCC summary data from nocc_data.json if it exists."""
+    if not NOCC_JSON.exists():
+        return {}
+
+    try:
+        with open(NOCC_JSON, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except (json.JSONDecodeError, IOError) as e:
+        print(f"Warning: Could not load nocc_data.json: {e}")
         return {}

--- a/scripts/static_data/outputs/noccs.py
+++ b/scripts/static_data/outputs/noccs.py
@@ -1,0 +1,52 @@
+"""Individual NOCC (Notice of Competition Concerns) summary JSON files for
+lazy loading by the frontend.
+
+Writes one ``<output_dir>/noccs/{merger_id}.json`` per merger that has a
+parsed NOCC summary.
+"""
+
+import json
+from pathlib import Path
+
+
+def _nocc_record(data: dict) -> dict:
+    return {
+        'title': data.get('title'),
+        'matter_id': data.get('matter_id'),
+        'document_type': data.get('document_type'),
+        'date': data.get('date'),
+        'date_iso': data.get('date_iso'),
+        'file_name': data.get('file_name'),
+        'file_path': data.get('file_path'),
+        'sections': data.get('sections', []),
+    }
+
+
+def generate(nocc_data: dict, output_dir: Path) -> int:
+    """Write individual NOCC files. Returns count written."""
+    noccs_dir = Path(output_dir) / "noccs"
+    noccs_dir.mkdir(parents=True, exist_ok=True)
+
+    count = 0
+    for merger_id, data in nocc_data.items():
+        # Skip error entries (which contain only ``error`` and ``file_path``).
+        if not data.get('sections'):
+            continue
+
+        output = _nocc_record(data)
+
+        # When a matter has multiple distinct NOCC summaries (e.g. a re-issue),
+        # include them all sorted latest-first so consumers can access older
+        # versions.
+        all_noccs = data.get('all_noccs', [])
+        if len(all_noccs) > 1:
+            output['all_noccs'] = [
+                _nocc_record(n) for n in all_noccs if n.get('sections')
+            ]
+
+        out_path = noccs_dir / f"{merger_id}.json"
+        with open(out_path, 'w', encoding='utf-8') as f:
+            json.dump(output, f, indent=2)
+        count += 1
+
+    return count

--- a/scripts/tests/test_pipeline.py
+++ b/scripts/tests/test_pipeline.py
@@ -716,6 +716,14 @@ from static_data.loaders import load_questionnaire_data
 from static_data.outputs.commentary import generate as generate_commentary_json
 from static_data.outputs.industries import generate_index as generate_industries_json
 from static_data.outputs.questionnaires import generate as generate_questionnaire_files
+from static_data.outputs.noccs import generate as generate_nocc_files
+from parse_nocc import (
+    _parse_blocks,
+    _group_blocks_into_sections,
+    _is_top_level_heading,
+    _is_sub_heading,
+    _is_nocc_filename,
+)
 
 
 class TestIsChristmasNewYearPeriod:
@@ -1241,3 +1249,337 @@ class TestGenerateQuestionnaireFiles:
         with open(tmp_path / "questionnaires" / "MN-01016.json") as f:
             data = json.load(f)
         assert 'file_path' not in data
+
+
+# ---------------------------------------------------------------------------
+# parse_nocc: filename detection
+# ---------------------------------------------------------------------------
+
+class TestIsNoccFilename:
+    def test_full_phrase(self):
+        assert _is_nocc_filename(
+            'Coles_Kalgoorlie - Final - Summary of Notice of Competition Concerns - March 2026.pdf'
+        )
+
+    def test_abbreviation(self):
+        assert _is_nocc_filename('Ampol_EG - NOCC summary - AR version - 2 March 2026.pdf')
+
+    def test_case_insensitive(self):
+        assert _is_nocc_filename('NOTICE OF COMPETITION CONCERNS.PDF')
+
+    def test_must_be_pdf(self):
+        assert not _is_nocc_filename('Notice of Competition Concerns.docx')
+
+    def test_unrelated_pdf_rejected(self):
+        assert not _is_nocc_filename('Phase 2 Notice - Redacted.pdf')
+
+    def test_questionnaire_rejected(self):
+        assert not _is_nocc_filename('Questionnaire - Coles - 28.11.2025.pdf')
+
+
+# ---------------------------------------------------------------------------
+# parse_nocc: heading detection from font metadata
+# ---------------------------------------------------------------------------
+
+def _line(text, size=11.04, bold=False, italic=False):
+    return {'text': text, 'size': size, 'bold': bold, 'italic': italic, 'y': 0}
+
+
+class TestIsTopLevelHeading:
+    def test_numbered_heading_at_h1_size(self):
+        assert _is_top_level_heading(_line('1. Introduction', size=18.0, bold=True))
+
+    def test_numbered_heading_no_space(self):
+        # Real NOCCs sometimes drop the space between "1." and the title.
+        assert _is_top_level_heading(_line('1.Introduction', size=18.0, bold=True))
+
+    def test_body_sized_numbered_line_is_not_h1(self):
+        assert not _is_top_level_heading(_line('1.1. Some paragraph', size=11.04))
+
+    def test_unnumbered_heading_is_not_h1(self):
+        assert not _is_top_level_heading(_line('The Acquisition', size=14.0, bold=True))
+
+
+class TestIsSubHeading:
+    def test_bold_14pt(self):
+        assert _is_sub_heading(_line('The Acquisition', size=14.04, bold=True))
+
+    def test_regular_14pt(self):
+        # Sub-sub-headings such as "Grocery retailing in Australia" render at
+        # 14pt without bold and must still be detected.
+        assert _is_sub_heading(_line('Grocery retailing in Australia', size=14.04))
+
+    def test_top_level_heading_excluded(self):
+        # An H1-sized numbered line is the top-level case and must not also
+        # match the sub-heading rule.
+        assert not _is_sub_heading(_line('1. Introduction', size=18.0, bold=True))
+
+    def test_numbered_paragraph_excluded(self):
+        assert not _is_sub_heading(_line('1.1 Some paragraph', size=14.04, bold=True))
+
+    def test_bullet_excluded(self):
+        assert not _is_sub_heading(_line('▪ a point', size=14.04, bold=True))
+
+
+# ---------------------------------------------------------------------------
+# parse_nocc: _parse_blocks
+# ---------------------------------------------------------------------------
+
+class TestParseNoccBlocks:
+    def test_top_level_heading_then_paragraph(self):
+        lines = [
+            _line('1. Introduction', size=18.0, bold=True),
+            _line('1.1. The ACCC received a notification.', size=11.04),
+        ]
+        blocks = _parse_blocks(lines)
+        assert blocks[0] == {'type': 'heading', 'level': 1, 'text': '1. Introduction'}
+        assert blocks[1]['type'] == 'paragraph'
+        assert blocks[1]['number'] == '1.1'
+        assert 'received a notification' in blocks[1]['text']
+
+    def test_sub_heading_between_paragraphs(self):
+        lines = [
+            _line('2.1. First paragraph.', size=11.04),
+            _line('The Acquisition', size=14.04, bold=True),
+            _line('2.2. Second paragraph.', size=11.04),
+        ]
+        blocks = _parse_blocks(lines)
+        assert blocks[0]['type'] == 'paragraph' and blocks[0]['number'] == '2.1'
+        assert blocks[1] == {
+            'type': 'heading', 'level': 2, 'text': 'The Acquisition',
+            '_bold': True, '_italic': False,
+        }
+        assert blocks[2]['type'] == 'paragraph' and blocks[2]['number'] == '2.2'
+
+    def test_no_space_after_paragraph_number(self):
+        lines = [_line('2.4.Coles operates...', size=11.04)]
+        blocks = _parse_blocks(lines)
+        assert blocks[0]['number'] == '2.4'
+        assert blocks[0]['text'] == 'Coles operates...'
+
+    def test_continuation_lines_joined(self):
+        lines = [
+            _line('1.1. First half', size=11.04),
+            _line('and second half.', size=11.04),
+        ]
+        blocks = _parse_blocks(lines)
+        assert len(blocks) == 1
+        assert blocks[0]['text'] == 'First half and second half.'
+
+    def test_bullet_list(self):
+        lines = [
+            _line('1.1. The ACCC considers:', size=11.04),
+            _line('▪ first point', size=11.04),
+            _line('▪ second point', size=11.04),
+        ]
+        blocks = _parse_blocks(lines)
+        assert blocks[1]['type'] == 'bullet_list'
+        assert blocks[1]['items'] == ['first point', 'second point']
+
+    def test_lone_bullet_marker_collects_continuation(self):
+        # Some bullet markers render on their own line with the body text on
+        # the following line; the parser must keep them as a single item.
+        lines = [
+            _line('▪', size=11.04),
+            _line('the bullet body.', size=11.04),
+        ]
+        blocks = _parse_blocks(lines)
+        assert blocks[0]['type'] == 'bullet_list'
+        assert blocks[0]['items'] == ['the bullet body.']
+
+    def test_minus_sign_sub_bullet(self):
+        # Nested sub-bullets in NOCCs use the minus-sign character.
+        lines = [
+            _line('1.1. Headline:', size=11.04),
+            _line('−', size=11.04),
+            _line('first sub-point', size=11.04),
+            _line('−', size=11.04),
+            _line('second sub-point', size=11.04),
+        ]
+        blocks = _parse_blocks(lines)
+        # Paragraph followed by a bullet list of two items.
+        assert blocks[0]['type'] == 'paragraph'
+        assert blocks[1]['type'] == 'bullet_list'
+        assert blocks[1]['items'] == ['first sub-point', 'second sub-point']
+
+    def test_lettered_list(self):
+        lines = [
+            _line('1.1. Examples include:', size=11.04),
+            _line('(a) first example', size=11.04),
+            _line('(b) second example', size=11.04),
+        ]
+        blocks = _parse_blocks(lines)
+        assert blocks[1]['type'] == 'lettered_list'
+        assert [it['letter'] for it in blocks[1]['items']] == ['a', 'b']
+
+    def test_two_line_sub_heading_merged(self):
+        lines = [
+            _line('Reduced competition arising from', size=14.04, bold=True),
+            _line('access to rival information', size=14.04, bold=True),
+            _line('1.1. Body.', size=11.04),
+        ]
+        blocks = _parse_blocks(lines)
+        # The two adjacent same-style sub-heading lines collapse to one.
+        sub_headings = [b for b in blocks if b['type'] == 'heading' and b.get('level') == 2]
+        assert len(sub_headings) == 1
+        assert sub_headings[0]['text'] == (
+            'Reduced competition arising from access to rival information'
+        )
+
+    def test_different_style_sub_headings_kept_separate(self):
+        # A bold 14pt section heading immediately followed by an unbold 14pt
+        # sub-sub-heading must stay distinct.
+        lines = [
+            _line('Industry background – grocery retailing', size=14.04, bold=True),
+            _line('Grocery retailing in Australia', size=14.04, bold=False),
+        ]
+        blocks = _parse_blocks(lines)
+        sub_headings = [b for b in blocks if b['type'] == 'heading']
+        assert len(sub_headings) == 2
+        assert sub_headings[0]['text'] == 'Industry background – grocery retailing'
+        assert sub_headings[1]['text'] == 'Grocery retailing in Australia'
+
+
+# ---------------------------------------------------------------------------
+# parse_nocc: _group_blocks_into_sections
+# ---------------------------------------------------------------------------
+
+class TestGroupBlocksIntoSections:
+    def test_groups_under_top_level_headings(self):
+        blocks = [
+            {'type': 'heading', 'level': 1, 'text': '1. Introduction'},
+            {'type': 'paragraph', 'number': '1.1', 'text': 'First.'},
+            {'type': 'heading', 'level': 1, 'text': '2. Background'},
+            {'type': 'paragraph', 'number': '2.1', 'text': 'Second.'},
+        ]
+        sections = _group_blocks_into_sections(blocks)
+        assert len(sections) == 2
+        assert sections[0]['number'] == '1'
+        assert sections[0]['title'] == 'Introduction'
+        assert sections[0]['blocks'][0]['number'] == '1.1'
+        assert sections[1]['number'] == '2'
+        assert sections[1]['title'] == 'Background'
+
+    def test_strips_internal_heading_level_and_style_fields(self):
+        blocks = [
+            {'type': 'heading', 'level': 1, 'text': '1. Introduction'},
+            {
+                'type': 'heading', 'level': 2, 'text': 'A sub-heading',
+                '_bold': True, '_italic': False,
+            },
+            {'type': 'paragraph', 'number': '1.1', 'text': 'Body.'},
+        ]
+        sections = _group_blocks_into_sections(blocks)
+        sub = sections[0]['blocks'][0]
+        # Internal level and style markers are dropped from the public output.
+        assert sub == {'type': 'heading', 'text': 'A sub-heading'}
+
+    def test_preamble_kept_when_blocks_precede_first_section(self):
+        blocks = [
+            {'type': 'paragraph', 'text': 'Stray preamble.'},
+            {'type': 'heading', 'level': 1, 'text': '1. Introduction'},
+            {'type': 'paragraph', 'number': '1.1', 'text': 'Body.'},
+        ]
+        sections = _group_blocks_into_sections(blocks)
+        assert len(sections) == 2
+        assert sections[0]['number'] is None
+        assert sections[0]['blocks'][0]['text'] == 'Stray preamble.'
+        assert sections[1]['number'] == '1'
+
+
+# ---------------------------------------------------------------------------
+# enrichment: has_nocc flag
+# ---------------------------------------------------------------------------
+
+class TestEnrichMergerNocc:
+    def _base_merger(self):
+        return {
+            'merger_id': 'MN-01068',
+            'merger_name': 'Test Merger',
+            'accc_determination': None,
+            'determination_publication_date': None,
+            'stage': 'Phase 2',
+            'status': 'Under assessment',
+            'events': [],
+            'effective_notification_datetime': '2025-11-27T12:00:00Z',
+        }
+
+    def test_flag_set_when_sections_present(self):
+        m = self._base_merger()
+        nocc = {'MN-01068': {'sections': [{'number': '1', 'title': 'Introduction', 'blocks': []}]}}
+        result = enrich_merger(m, nocc_data=nocc)
+        assert result.get('has_nocc') is True
+
+    def test_no_flag_when_nocc_data_missing(self):
+        m = self._base_merger()
+        result = enrich_merger(m, nocc_data={})
+        assert 'has_nocc' not in result
+
+    def test_no_flag_when_merger_not_in_nocc_data(self):
+        m = self._base_merger()
+        result = enrich_merger(m, nocc_data={'MN-99999': {'sections': [{'blocks': []}]}})
+        assert 'has_nocc' not in result
+
+    def test_no_flag_when_sections_empty(self):
+        m = self._base_merger()
+        result = enrich_merger(m, nocc_data={'MN-01068': {'sections': []}})
+        assert 'has_nocc' not in result
+
+    def test_nocc_data_not_embedded(self):
+        m = self._base_merger()
+        nocc = {'MN-01068': {'sections': [{'number': '1', 'title': 'Introduction', 'blocks': []}]}}
+        result = enrich_merger(m, nocc_data=nocc)
+        # Only a flag is added; the parsed content is loaded separately.
+        assert 'sections' not in result
+        assert 'nocc' not in result
+
+
+# ---------------------------------------------------------------------------
+# generate_static_data: NOCC files
+# ---------------------------------------------------------------------------
+
+class TestGenerateNoccFiles:
+    def test_generates_files(self, tmp_path):
+        nocc_data = {
+            'MN-01068': {
+                'title': 'Coles – Kalgoorlie',
+                'matter_id': 'MN-01068',
+                'document_type': 'Notice of Competition Concerns – Summary',
+                'date': '5 March 2026',
+                'date_iso': '2026-03-05',
+                'file_name': 'NOCC.pdf',
+                'file_path': 'matters/MN-01068/NOCC.pdf',
+                'sections': [
+                    {'number': '1', 'title': 'Introduction', 'blocks': [
+                        {'type': 'paragraph', 'number': '1.1', 'text': 'Body.'},
+                    ]},
+                ],
+            },
+        }
+        count = generate_nocc_files(nocc_data, tmp_path)
+        assert count == 1
+        nocc_path = tmp_path / 'noccs' / 'MN-01068.json'
+        assert nocc_path.exists()
+
+        import json
+        with open(nocc_path) as f:
+            data = json.load(f)
+        assert data['title'] == 'Coles – Kalgoorlie'
+        assert data['date_iso'] == '2026-03-05'
+        assert len(data['sections']) == 1
+        assert data['sections'][0]['number'] == '1'
+
+    def test_skips_entries_without_sections(self, tmp_path):
+        nocc_data = {
+            'MN-01068': {'sections': [{'number': '1', 'title': 'X', 'blocks': []}]},
+            'MN-01069': {'sections': []},
+            'MN-01070': {'error': 'parse failed', 'file_path': 'matters/MN-01070/x.pdf'},
+        }
+        count = generate_nocc_files(nocc_data, tmp_path)
+        assert count == 1
+        assert (tmp_path / 'noccs' / 'MN-01068.json').exists()
+        assert not (tmp_path / 'noccs' / 'MN-01069.json').exists()
+        assert not (tmp_path / 'noccs' / 'MN-01070.json').exists()
+
+    def test_empty_data(self, tmp_path):
+        assert generate_nocc_files({}, tmp_path) == 0

--- a/scripts/tests/test_utils.py
+++ b/scripts/tests/test_utils.py
@@ -14,6 +14,7 @@ from normalization import normalize_determination
 # extract_mergers has heavy transitive imports (pdfplumber, etc.)
 # Mock them so we can import just the filename functions
 sys.modules['parse_determination'] = unittest.mock.MagicMock()
+sys.modules['parse_nocc'] = unittest.mock.MagicMock()
 sys.modules['parse_questionnaire'] = unittest.mock.MagicMock()
 sys.modules['pdfplumber'] = unittest.mock.MagicMock()
 


### PR DESCRIPTION
## Summary
This PR adds support for parsing and displaying Notice of Competition Concerns (NOCC) summary documents from Phase 2 merger reviews. NOCCs are now extracted from PDF files, structured into JSON, and made available for lazy-loading in the frontend.

## Key Changes

- **New NOCC parser** (`scripts/parse_nocc.py`): Extracts structured content from NOCC summary PDFs, including:
  - Cover page metadata (title, matter ID, date, document type)
  - Numbered sections with hierarchical headings
  - Paragraphs with reference numbers (e.g., "1.1", "2.4")
  - Bullet lists and lettered lists
  - Font-based heading detection to distinguish section levels

- **NOCC data extraction** (`scripts/extract_mergers.py`): New `extract_nocc_data()` function that:
  - Processes all NOCC PDFs from the raw data directory
  - Generates a consolidated `nocc_data.json` manifest
  - Integrates with the existing merger enrichment pipeline

- **Frontend output generation** (`scripts/static_data/outputs/noccs.py`): Generates individual lazy-loaded JSON files for each merger with an NOCC (`noccs/{merger_id}.json`)

- **Data enrichment**: Updated merger records to include `has_nocc` flag indicating whether a merger has a parsed NOCC summary

- **Test coverage** (`scripts/tests/test_pipeline.py`): Comprehensive tests for:
  - NOCC filename detection (distinguishing from other PDFs)
  - Heading detection logic (top-level vs. sub-headings)
  - Block parsing (paragraphs, lists, continuations)
  - Section grouping

## Implementation Details

- NOCC parsing reuses line-grouping utilities from the existing determination parser for consistency
- Font size thresholds distinguish document structure: top-level headings (≥15pt), sub-headings (12.5-15pt), body text (≥10pt)
- Numbered paragraphs and list items are preserved with their reference numbers for document navigation
- The parser handles common PDF rendering quirks (missing spaces after numbers, wrapped headings, etc.)
- Two example NOCCs (MN-01019 Ampol-EG, MN-01068 Coles-Kalgoorlie) are included as test data

https://claude.ai/code/session_013oCM4ShJudPeRRmPmwfUxn