### PR TITLE
Add NOCC (Notice of Competition Concerns) data support

### DIFF
--- a/data/output/cli/cli-bundle.json
+++ b/data/output/cli/cli-bundle.json
@@ -42455,6 +42455,942 @@
       "questions_count": 3
     }
   },
+  "noccs": {
+    "MN-01019": {
+      "date": "2 March 2026",
+      "date_iso": "2026-03-02",
+      "document_type": "Notice of Competition Concerns – Summary",
+      "file_name": "Ampol_EG - NOCC summary - AR version - 2 March 2026.pdf",
+      "file_path": "matters/MN-01019/Ampol_EG - NOCC summary - AR version - 2 March 2026.pdf",
+      "matter_id": "MN-01019",
+      "sections": [
+        {
+          "blocks": [
+            {
+              "number": "1.1",
+              "text": "On 10 October 2025, Ampol Limited lodged a notification in respect of Ampol Retail Holding Pty Ltd’s proposed acquisition of 100% of the share capital in EG Group Australia Pty Ltd and EG AsiaPac Holdings Limited (the Acquisition) with the Australian Competition and Consumer Commission (ACCC).",
+              "type": "paragraph"
+            },
+            {
+              "number": "1.2",
+              "text": "On 20 January 2026, the ACCC decided that the Acquisition is to be subject to Phase 2 review.",
+              "type": "paragraph"
+            },
+            {
+              "number": "1.3",
+              "text": "On 27 February 2026, the ACCC issued a Notice of Competition Concerns (NOCC) to Ampol.",
+              "type": "paragraph"
+            },
+            {
+              "number": "1.4",
+              "text": "The NOCC sets out the ACCC’s preliminary assessment of whether the acquisition, if put into effect, would have the effect, or be likely to have the effect, of substantially lessening competition in any market, and the grounds on which the ACCC makes its assessment, referring to the evidence or other material on which those grounds are based.",
+              "type": "paragraph"
+            },
+            {
+              "number": "1.5",
+              "text": "This is a summary of the NOCC as required to be published on the Acquisitions Register.",
+              "type": "paragraph"
+            }
+          ],
+          "number": "1",
+          "title": "Introduction"
+        },
+        {
+          "blocks": [
+            {
+              "text": "The acquirer – Ampol",
+              "type": "heading"
+            },
+            {
+              "number": "2.1",
+              "text": "Ampol Retail Holding Pty Ltd is a wholly-owned subsidiary of Ampol Limited (Ampol), which is listed on the ASX. Ampol is a vertically integrated fuel company with upstream fuel production and importing assets, wholesale supply and distribution facilities and a network of fuel and retail convenience sites across Australia.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.2",
+              "text": "Ampol owns the Lytton refinery in Brisbane, Queensland, where it refines imported crude oil, and a number of terminals nationwide through which it imports finished petrol products from overseas refineries and trading houses.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.3",
+              "text": "Ampol operates retail sites under both the Ampol brand and the U-GO brand. Ampol branded sites are full-service sites with fuel and convenience offerings. Launched in 2023, the U-GO branded sites are low cost, unstaffed self-service sites selling only fuel and with no convenience offering. Ampol owns and operates 576 sites under the Ampol brand and 46 under the U-GO brand.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.4",
+              "text": "Ampol also has 50% interests in the following two fuel distributors and retailers:",
+              "type": "paragraph"
+            },
+            {
+              "items": [
+                "Bonney Energy Group Pty Ltd (Bonney Energy) is a distributor of Ampol fuel. Bonney Energy operates 45 retail fuel sites across regional Victoria and Tasmania under the Ampol brand.",
+                "Geraldton Fuel Company Pty Ltd (trading as Refuel Australia) is a fuel distributor operating in Western Australia and the Northern Territory. Twenty-eight of Refuel Australia’s 38 locations operate under the Ampol brand."
+              ],
+              "type": "bullet_list"
+            },
+            {
+              "text": "The target – EG Australia",
+              "type": "heading"
+            },
+            {
+              "number": "2.5",
+              "text": "EG Group Australia and EG AsiaPac Holdings are the entities that carry on EG Group’s business in Australia (together, EG Australia), which includes the retail supply of fuel, food to go and convenience products. EG Australia is owned by EG Group, a UK-based independent fuel and convenience retailer with sites across Europe and North America.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.6",
+              "text": "EG Australia commenced operations in Australia in April 2019 when EG Group acquired Woolworths’ retail fuel and convenience sites. EG Australia owns and operates 512 retail fuel sites.",
+              "type": "paragraph"
+            },
+            {
+              "text": "Relationship between the Parties",
+              "type": "heading"
+            },
+            {
+              "number": "2.7",
+              "text": "Ampol and EG Australia (together, the Parties) have a fuel supply agreement (FSA) whereby Ampol is EG Australia’s exclusive wholesale supplier of fuel until 2033. Pursuant to the FSA and other agreements which were novated from Woolworths to EG Group in 2019, EG Australia’s retail fuel sites must carry the ‘Ampol’ brand, while its convenience stores carry the ‘EG’ brand.",
+              "type": "paragraph"
+            },
+            {
+              "text": "The Acquisition",
+              "type": "heading"
+            },
+            {
+              "number": "2.8",
+              "text": "Ampol proposes to acquire 100% of the share capital in EG Australia for $1.1 billion.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.9",
+              "text": "In public statements about the Acquisition, Ampol states that the Acquisition will enable it to expand its national footprint (to 1,134 sites) and accelerate Ampol’s retail growth strategy through segmented offers.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.10",
+              "text": "As part of this, a key stated rationale for the Acquisition is to accelerate the rollout of U-GO sites. In particular, Ampol states that it would progressively convert 125 EG Australia sites to U-GO sites over a two year period (with the remainder to be rebranded as Ampol Foodary sites). Ampol currently has 46 U-GO sites and plans to convert 14 additional Ampol sites by the end of 2026. Taken together, Ampol would have close to 200 U-GO sites in 2 to 3 years’ time.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.11",
+              "text": "EG Group has stated that it is seeking to exit the Australian market with the proceeds from the sale to be used to reduce the Group’s debt and focus on global markets where it sees growth opportunities.",
+              "type": "paragraph"
+            },
+            {
+              "text": "Industry background",
+              "type": "heading"
+            },
+            {
+              "number": "2.12",
+              "text": "In assessing the competitive effects of the Acquisition, it is relevant to understand that Australia’s fuel industry consists of three broad levels – the import of refined fuel and the domestic refining of crude oil (suppliers), the sale or resale and distribution of wholesale fuel (primary and secondary wholesalers), and retail supply. This structure is depicted at Figure 1 below. Figure 1. Fuel industry structure",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.13",
+              "text": "Further industry background relevant to the ACCC’s competition assessment is set out below.",
+              "type": "paragraph"
+            },
+            {
+              "text": "Refining and wholesale supply",
+              "type": "heading"
+            },
+            {
+              "number": "2.14",
+              "text": "A number of Australian fuel suppliers, including Ampol, are vertically integrated, refining and/or importing fuel and supplying fuel to downstream retail sites.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.15",
+              "text": "Refineries process and transform crude oil into refined petroleum products (including petrol, diesel, jet fuel, fuel oil and other fuel products). Currently, there are 2 refineries operating in Australia – Viva Energy’s Geelong refinery in Victoria and Ampol’s Lytton refinery in Queensland. However, other market participants such as Chevron have refinery operations in the Asia-Pacific region. Chevron has interests in refineries in South Korea, Thailand and Singapore, which are sources of refined product for some retailers in Australia.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.16",
+              "text": "Import terminals receive refined petroleum products by ship, store them and distribute them to retailers. A number of parties import finished products into Australia from overseas including Ampol, BP, Chevron, ExxonMobil, United, Viva Energy, IOR, PetroChina and Freedom Fuels.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.17",
+              "text": "Refiners and many importers supply fuel to secondary wholesalers or directly to retailers on a wholesale basis. Currently, the four major wholesalers in Australia are Ampol, BP, ExxonMobil and Viva Energy.",
+              "type": "paragraph"
+            },
+            {
+              "text": "Retail supply and competition in fuel retailing",
+              "type": "heading"
+            },
+            {
+              "number": "2.18",
+              "text": "The ACCC has a monitoring role in fuel markets and reports on fuel prices and industry issues as a part of that role. In various reports, the ACCC has identified certain trends in relation to competition in fuel retailing. These trends are relevant to the assessment of the competitive impact of the Acquisition and are set out below.",
+              "type": "paragraph"
+            },
+            {
+              "text": "Composition of retail fuel markets",
+              "type": "heading"
+            },
+            {
+              "number": "2.19",
+              "text": "Australia’s downstream retail supply has evolved over the past decade with market consolidation through acquisitions, expansion by several retailers and other retail brands opening in Australia. The net result of these changes is that the number of retail sites increased from around 7,500 in 2018 to over 8,000 in 2026.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.20",
+              "text": "Fuel retailers in Australia have varied business models and structures. They can be broadly categorised as follows:",
+              "type": "paragraph"
+            },
+            {
+              "items": [
+                "Larger, national, vertically integrated retailers: Ampol, Viva Energy (including the Reddy Express and On The Run retail networks), BP and Chevron (operating under the Caltex and Puma Energy retail brands) (major fuel retailers).",
+                "Larger, national independent retailers with or without branded fuel supplier: EG Australia, United Petroleum, and 7 Eleven (major independent fuel retailers).",
+                "Smaller independent retailers, such as Speedway, Metro Petroleum, Freedom Fuels, Budget, Vibe, and Pearl Energy (small independent fuel retailers).",
+                "Dealers under the national branded retailers (independently priced sites branded BP, Shell, Ampol etc)."
+              ],
+              "type": "bullet_list"
+            },
+            {
+              "number": "2.21",
+              "text": "The brand of the retail site will often, but not always, reflect the owner or fuel price setter of the retail site. Some independent chains use a fuel supplier brand but set their own retail fuel prices, as do some single site retail operations.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.22",
+              "text": "While these different groups of retailers generally offer the same fuel types, they differ in non-fuel offerings, scale of presence across Australia and in each state or territory, and pricing strategy. Major fuel retailers and major independent fuel retailers have a national presence and are likely to compete more on non-fuel offerings, such as convenience products and services. In contrast, smaller independent fuel retailers may have fewer sites across a city and/or are not present in all states/territories and tend to compete primarily on fuel price to attract consumers.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.23",
+              "text": "The aggregated share of national petrol sales volumes of the small independent fuel retailers has gradually increased over time, from 18% in 2017–18 to around 26% in 2023-24. The ACCC estimates that, as a group, small independent fuel retailers have the strongest presence in Sydney, Melbourne and Adelaide, and a small presence in Brisbane and Canberra. However, the ACCC has noted that the presence of these independents differs from city to city. For example, Freedom Fuels only has sites in and around Brisbane while Speedway is present mainly in Sydney and Melbourne.",
+              "type": "paragraph"
+            },
+            {
+              "text": "Petrol price movements",
+              "type": "heading"
+            },
+            {
+              "number": "2.24",
+              "text": "As the ACCC’s ongoing monitoring of fuel markets has found, Australian fuel prices are typically influenced by international benchmark crude oil and refined fuel prices and the value of the Australian dollar, as well as the levels of competition in different locations.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.25",
+              "text": "In addition, in the major cities such as Sydney, Melbourne, Brisbane, Adelaide and Perth, petrol prices move up and down in regular patterns. These patterns are known as petrol price cycles. Petrol price cycles are not driven by movements in wholesale prices or underlying costs and not all retailers participate in price cycles. Price cycles do not occur for retail diesel and automotive LPG prices.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.26",
+              "text": "Typically in a price cycle, prices at individual retail sites increase sharply, then decrease more gradually over a longer period before the process repeats. Not all retail sites change prices at the same time, meaning average metropolitan-wide prices can take time to increase (and decrease).",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.27",
+              "text": "Average prices move up and down across two phases. The ACCC has made the following observations regarding these phases:",
+              "type": "paragraph"
+            },
+            {
+              "items": [
+                "In the increase phase, various retailers generally increase prices substantially to the same or a similar price point across different locations within a city. The ACCC has observed some retailers increasing prices to varying levels, including levels below the highest priced retailer.",
+                "In the decrease phase, retailers tend to more gradually match and undercut their rivals’ pricing until prices begin to approach terminal gate prices (indicative wholesale prices), such that they may be making slim margins or not recovering their purchase costs on petrol. At this point, one or more retailers will tend to increase their prices substantially such that the cycle repeats."
+              ],
+              "type": "bullet_list"
+            },
+            {
+              "number": "2.28",
+              "text": "The ACCC has also observed differences in petrol price cycle patterns in Australia’s largest cities over time. For example, in the year to September 2025, cycles in Sydney were around 5 and a half weeks in duration while in Melbourne they were around 6 and a half weeks and in Brisbane around 7 weeks. Previously, in 2018, the ACCC observed that cycles in the same three cities were about a month long.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.29",
+              "text": "Smaller cities such as Canberra, Hobart and Darwin and most regional areas do not have petrol price cycles.",
+              "type": "paragraph"
+            }
+          ],
+          "number": "2",
+          "title": "Background"
+        },
+        {
+          "blocks": [
+            {
+              "number": "3.1",
+              "text": "The Parties are both retail suppliers of fuel and convenience products in all Australian states and territories. Currently:",
+              "type": "paragraph"
+            },
+            {
+              "items": [
+                "Ampol owns and operates 576 sites under the Ampol brand, and 46 under the U-GO brand.",
+                "EG Australia owns and operates 512 retail fuel sites."
+              ],
+              "type": "bullet_list"
+            },
+            {
+              "number": "3.2",
+              "text": "Acquiring EG Australia’s sites would make Ampol the largest fuel retailer in Australia in terms of number of sites.",
+              "type": "paragraph"
+            },
+            {
+              "number": "3.3",
+              "text": "The Parties also overlap in convenience grocery retailing co-located at fuel sites across Australia. However, as the ACCC does not consider that the Acquisition is likely to result in a substantial lessening of competition in the retail supply of groceries given the remaining constraints on Ampol post-acquisition, no further consideration is given to this overlap in this Notice.",
+              "type": "paragraph"
+            },
+            {
+              "text": "Approach to market definition",
+              "type": "heading"
+            },
+            {
+              "number": "3.4",
+              "text": "Adopting the ACCC’s past approach to market definition in the fuel industry, Ampol has submitted that the relevant markets for considering the competitive effects of the Acquisition are:",
+              "type": "paragraph"
+            },
+            {
+              "items": [
+                "Local markets for the supply of fuel through retail outlets in the vicinity of each EG Australia site, applying up to a 5km radius around each site in metropolitan areas and a 10km radius around each site in regional areas.",
+                "Metropolitan-wide markets for the retail supply of fuel in metropolitan areas such as Sydney, Melbourne, Brisbane, Perth and Adelaide."
+              ],
+              "type": "bullet_list"
+            },
+            {
+              "number": "3.5",
+              "text": "The ACCC broadly accepts Ampol’s submission that the competitive effects of the Acquisition are to be assessed at a local level and a metropolitan level. However, as set out further below, the ACCC has considered the relevant geographic dimension in each local area individually. In each local area, the ACCC has applied a broader or narrower radius, having regard to the presence of traffic routes, natural barriers, and/or due to other information provided by the Parties.",
+              "type": "paragraph"
+            },
+            {
+              "number": "3.6",
+              "text": "In addition, the ACCC considers that:",
+              "type": "paragraph"
+            },
+            {
+              "items": [
+                "In terms of the product dimension of the relevant markets, petrol and diesel should be considered separately. From a demand-side perspective, consumers cannot substitute between petrol and diesel without switching vehicles. Additionally, some sites offer only diesel as they aim to cater for trucks and other fleet vehicles that are fuelled only by diesel. Such sites are unlikely to be an alternative option to a petrol site for consumers who have petrol vehicles.",
+                "While within each of the various grades of petrol and diesel, fuel retailers supply a homogeneous product, there is product differentiation in respect of fuel retailers’ non-fuel offerings. Fuel retailers differentiate themselves across various dimensions, including fuel-adjacent offerings (e.g., branding and loyalty schemes, such as reward cards or discount dockets), the other products they supply (e.g., convenience groceries, take away food, dine-in restaurants, car washes, gas bottles and EV charging) and the quality of their sites (including site location, access number and type of pumps, presence and level of staffing)."
+              ],
+              "type": "bullet_list"
+            },
+            {
+              "text": "Geographic dimension of fuel markets",
+              "type": "heading"
+            },
+            {
+              "number": "3.7",
+              "text": "In considering the appropriate radius to apply in defining a local market around an EG Australia site, the ACCC has considered industry surveys regarding how consumers shop for fuel.",
+              "type": "paragraph"
+            },
+            {
+              "number": "3.8",
+              "text": "According to a 2024 industry survey, for many consumers, price remains the top driver of fuel purchasing decisions, with 56% of respondents indicating that price is their primary consideration when choosing a fuel retailer, followed by 12% making a decision to purchase fuel based on service station fuel location and 10% by fuel quality or type. This focus on price has also driven the increased use of fuel price apps, with 40% of consumers using these apps to shop around for fuel.",
+              "type": "paragraph"
+            },
+            {
+              "number": "3.9",
+              "text": "A 2022 industry survey indicated that:",
+              "type": "paragraph"
+            },
+            {
+              "items": [
+                "Around 34% of consumers were willing to travel more than 5 minutes out of their way for cheaper fuel.",
+                "Around 43% of consumers were willing to travel up to 5 minutes out of their way to purchase cheaper fuel.",
+                "Around 20% of consumers would never travel up to 5 minutes out of their way for fuel."
+              ],
+              "type": "bullet_list"
+            },
+            {
+              "number": "3.10",
+              "text": "As this survey indicates, it may still be the case that, for many consumers, the closest substitutes for a given retail fuel site are other retail fuel sites in close geographic proximity. This is because the distance that consumers may be willing to travel to obtain lower prices is likely to be limited by the time and cost of travelling to alternative sites.",
+              "type": "paragraph"
+            },
+            {
+              "number": "3.11",
+              "text": "The emergence of fuel price apps and the increase in their use may have changed these considerations at some level – for example, it may allow consumers to better plan their fuel purchases. In particular, the ACCC found that consumers are increasingly using apps, such that they can plan both ‘when’ and ‘where’ they fill up. Further, the question of where to fill up may also be influenced by work, school and home travel routes such that consumers, depending on the nature of those routes, may have a more geographically dispersed set of fuel sites that they consider are substitutable.",
+              "type": "paragraph"
+            },
+            {
+              "number": "3.12",
+              "text": "As with previous considerations of fuel mergers, and having regard to the above industry surveys, the Parties’ submissions and internal documents, the ACCC considers it appropriate to assess the competitive effects of the Acquisition in both metropolitan-wide and local markets.",
+              "type": "paragraph"
+            },
+            {
+              "number": "3.13",
+              "text": "For each local market, the ACCC has assessed the competitive effects of the Acquisition within a particular radius surrounding the EG Australia target site. The appropriate radius considered for each local market varies, having regard to specific local conditions.",
+              "type": "paragraph"
+            },
+            {
+              "number": "3.14",
+              "text": "The ACCC has considered the following information to determine the appropriate radius for its preliminary competition assessment in each local market:",
+              "type": "paragraph"
+            },
+            {
+              "items": [
+                "The location of competitors.",
+                "Topographical features that may impact demand-side substitution. For example, in some local markets, there may be traffic routes and/or natural barriers that affect the distance consumers are willing to travel to purchase fuel."
+              ],
+              "type": "bullet_list"
+            },
+            {
+              "number": "3.15",
+              "text": "In addition to local market competition, evidence before the ACCC indicates that it is also appropriate to consider the competitive effect of the Acquisition on metropolitan areas in which Ampol and EG Australia are among the largest fuel retail networks. In cities with petrol price cycles, the existence of those price cycles appears to be evidence of, or at least consistent with, retailers monitoring and responding to the pricing behaviour of competitors across a metropolitan area and not just locally.",
+              "type": "paragraph"
+            },
+            {
+              "number": "3.16",
+              "text": "The density of Ampol and EG Australia sites in Brisbane, Melbourne and Sydney also suggests that multiple areas of local competition between the Parties are likely to overlap with each other and are therefore interconnected. This can be observed in Figure 2, which plots the Ampol (blue) and EG Australia (green) sites on the maps of each city along with competitor sites (grey).",
+              "type": "paragraph"
+            },
+            {
+              "number": "3.17",
+              "text": "In considering a metropolitan-wide market, the ACCC is also concerned with the competitive effects of the Acquisition arising outside of, or extending beyond, local market boundaries. An analysis confined to local effects potentially misses those competitive effects in circumstances where the documentary and data evidence suggests that there are competitive dynamics occurring beyond local market boundaries. Figure 2. Maps of Ampol, EG Australia and competitor sites in Brisbane, Melbourne and Sydney (left to right)",
+              "type": "paragraph"
+            }
+          ],
+          "number": "3",
+          "title": "Overlap and relevant areas of competition"
+        },
+        {
+          "blocks": [
+            {
+              "number": "4.1",
+              "text": "The ACCC is considering the effects of the Acquisition by comparing the likely future state of competition if the Acquisition proceeds against the likely future state of competition if the Acquisition does not proceed.",
+              "type": "paragraph"
+            },
+            {
+              "number": "4.2",
+              "text": "The ACCC’s preliminary view is that the future state of competition without the Acquisition is the status quo, which takes into account that EG Australia may continue to close selected sites that it considers are underperforming and that Ampol is likely to continue rolling out U-GO sites organically.",
+              "type": "paragraph"
+            }
+          ],
+          "number": "4",
+          "title": "The future with and without the Acquisition"
+        },
+        {
+          "blocks": [
+            {
+              "text": "Competitive effects in the retail supply of fuel in local markets in Australia",
+              "type": "heading"
+            },
+            {
+              "number": "5.1",
+              "text": "The ACCC initially identified 274 EG Australia sites that overlap with one or more Ampol sites. Following closer analysis of the overlaps, the ACCC identified in the Phase 2 notice published on 20 January 2026 that the Acquisition could have the effect or likely effect of substantially lessening competition in respect of 115 of those EG Australia site overlaps. Since publishing the notice, the ACCC has continued to analyse these overlaps.",
+              "type": "paragraph"
+            },
+            {
+              "number": "5.2",
+              "text": "The ACCC’s preliminary assessment is that the Acquisition would have the effect or be likely to have the effect of substantially lessening competition in 51 local markets where 54 EG Australia sites overlap with Ampol sites.",
+              "type": "paragraph"
+            },
+            {
+              "number": "5.3",
+              "text": "In addition, the ACCC is continuing to consider whether the Acquisition would have the effect, or likely effect, of substantially lessening competition in relation to an additional 20 local markets where 20 EG Australia sites overlap with Ampol sites.",
+              "type": "paragraph"
+            },
+            {
+              "number": "5.4",
+              "text": "The following factors were relevant to the ACCC’s preliminary assessment of competitive effects:",
+              "type": "paragraph"
+            },
+            {
+              "items": [
+                "The increase and the post-acquisition level of concentration by site numbers in a local area. In some areas, the post-acquisition site share is as high as 75% and the increment is as high as 50%.",
+                "The distance between the Ampol and EG Australia sites. In particular, there are 5 EG Australia sites which are located within 200m of an Ampol site and a further 24 which are within 1km of an Ampol.",
+                "The number, identity and location of remaining competitors. The ACCC’s preliminary view is that some competitors may not impose as strong a constraint on Ampol post-acquisition as EG Australia currently does. This is either because they are not proximate to the Ampol and EG Australia sites, do not have equivalent offerings (for example, do not supply all fuel types, or only offer a small number of pumps) and/or Ampol’s current pricing rule or strategy suggests they would not be a strong competitive constraint."
+              ],
+              "type": "bullet_list"
+            },
+            {
+              "number": "5.5",
+              "text": "The table below shows the locations of the relevant local markets.",
+              "type": "paragraph"
+            },
+            {
+              "number": "5.6",
+              "text": "The ACCC will continue to investigate these matters in Phase 2.",
+              "type": "paragraph"
+            },
+            {
+              "text": "Competitive effects in the retail supply of fuel in metropolitan markets",
+              "type": "heading"
+            },
+            {
+              "number": "5.7",
+              "text": "The ACCC’s preliminary assessment is that the Acquisition would have the effect, or likely effect, of substantially lessening competition in the retail supply of fuel in the metropolitan markets of Brisbane, Melbourne, Sydney, and Canberra.",
+              "type": "paragraph"
+            },
+            {
+              "number": "5.8",
+              "text": "In Brisbane, Melbourne and Sydney, 3 cities with petrol price cycles, the ACCC’s preliminary view is that the removal of EG Australia would likely lead to a substantial lessening of competition through unilateral effects, as:",
+              "type": "paragraph"
+            },
+            {
+              "items": [
+                "The Acquisition removes a direct and significant competitor to Ampol and other major fuel retailers. It will lessen the competitive constraints on the fuel retailers that track and respond to price at Ampol and EG Australia sites in these three metropolitan markets.",
+                "The Acquisition increases Ampol’s share of sites in each of these three metropolitan markets, making it the largest fuel retailer in Sydney and Melbourne and second largest retailer in Brisbane.",
+                "The removal of EG Australia as an independent pricing constraint on Ampol may result in higher prices for consumers as Ampol would implement its own pricing strategies to the EG Australia network. In particular, the Acquisition will remove a competitor in these three markets that:",
+                "prices, on average, lower than Ampol across both phases of the price cycle;",
+                "is often the first mover of the major fuel retailers in the decrease phase of price cycles and has, at times, moved a larger proportion of sites more quickly down in the decrease phase than other major retailers; and",
+                "tends to have, on average, lower prices than Ampol when prices across a metropolitan area are increasing."
+              ],
+              "type": "bullet_list"
+            },
+            {
+              "number": "5.9",
+              "text": "In Canberra, which does not have petrol price cycles, the Acquisition would remove a direct competitor to Ampol and lead to Ampol becoming the largest fuel retailer in that metropolitan market. The ACCC’s preliminary assessment is that the Acquisition would have the effect, or likely effect, of substantially lessening competition in the retail supply of fuel in Canberra from coordinated effects becoming more likely, more complete and/or more sustainable across the remaining retailers. The ACCC is continuing to consider the potential for the Acquisition to give rise to unilateral effects in Canberra.",
+              "type": "paragraph"
+            },
+            {
+              "number": "5.10",
+              "text": "The ACCC has also considered whether the Acquisition is likely to give rise to coordinated effects in Brisbane, Melbourne and Sydney where price cycles are a feature of price competition between fuel retailers. This is separate to the (unilateral) mechanism by which competition could be lessened and prices increased. In considering the evidence before it, the ACCC’s preliminary view is that coordinated effects are not sufficiently likely to arise from the Acquisition in these metropolitan areas that have price cycles to consider them further (as distinct from the potential for unilateral effects). It is therefore no longer investigating whether the Acquisition is likely to give rise to coordinated effects in Brisbane, Melbourne and Sydney.",
+              "type": "paragraph"
+            }
+          ],
+          "number": "5",
+          "title": "Summary of preliminary competition concerns"
+        },
+        {
+          "blocks": [
+            {
+              "number": "6.1",
+              "text": "The ACCC’s preliminary assessment is that the Acquisition is not likely to substantially lessen competition in the Adelaide or Perth metropolitan markets as a result of either unilateral effects or coordinated effects.",
+              "type": "paragraph"
+            },
+            {
+              "number": "6.2",
+              "text": "In Perth, ACCC average pricing analysis indicates EG Australia has higher metropolitan-wide average prices compared to Ampol, meaning EG Australia’s pricing strategy is producing higher pricing outcomes than Ampol’s.Consequently, there is unlikely to be a substantial lessening of competition in the Perth metropolitan market.",
+              "type": "paragraph"
+            },
+            {
+              "number": "6.3",
+              "text": "In relation to Adelaide, the average pricing differential between Ampol and EG Australia is relatively small. The ACCC also notes that Viva Energy is the largest retailer in the metropolitan area, with a share of supply of almost 40% by number of sites. While the Acquisition will increase concentration in Adelaide, with Ampol’s share of sites increasing to approximately 18%, the ACCC notes the incremental increase as a result of the Acquisition would be a 5.3% share of sites. Together, these factors (among others) indicate there is unlikely to be a substantial lessening of competition in the Adelaide metropolitan market.",
+              "type": "paragraph"
+            },
+            {
+              "number": "6.4",
+              "text": "As noted above, the ACCC has is also no longer investigating whether the Acquisition is likely to give rise to coordinated effects in the metropolitan markets of Brisbane, Melbourne and Sydney.",
+              "type": "paragraph"
+            }
+          ],
+          "number": "6",
+          "title": "Areas no longer under active investigation"
+        },
+        {
+          "blocks": [
+            {
+              "number": "7.1",
+              "text": "On 10 October 2025, Ampol made a remedy offer to the ACCC with respect to the Acquisition. The remedy offer was in the form of a draft undertaking pursuant to section 87B of the Act. The undertaking was to divest 19 Ampol and EG Australia fuel retail sites to a purchaser approved by the ACCC (the Remedy Offer).",
+              "type": "paragraph"
+            },
+            {
+              "number": "7.2",
+              "text": "The ACCC’s decision that the Acquisition is to be subject to Phase 2 review set out the ACCC’s consideration of the Remedy Offer.",
+              "type": "paragraph"
+            },
+            {
+              "number": "7.3",
+              "text": "Ampol may make further remedy offers within permitted timeframes. Any such further offer will be assessed and the ACCC may provide feedback.",
+              "type": "paragraph"
+            },
+            {
+              "number": "7.4",
+              "text": "The ACCC’s assessment of a remedy offer will include, but is not limited to, whether the offer could address the relevant competition concerns. For divestitures, the ACCC’s consideration will generally also include matters related to the composition of the proposed divestiture, the availability and identification of an appropriate purchaser, management of risk of business or asset degradation and implementation of the remedy.",
+              "type": "paragraph"
+            },
+            {
+              "number": "7.5",
+              "text": "The ACCC has a broad power to determine the nature, form and scope of any conditions included in a determination and is not confined to either accepting or rejecting a remedy offer. There may be differences between a remedy offer and any remedy that the ACCC includes in a determination as one or more conditions.",
+              "type": "paragraph"
+            }
+          ],
+          "number": "7",
+          "title": "Remedy offer"
+        },
+        {
+          "blocks": [
+            {
+              "number": "8.1",
+              "text": "Following the release of the NOCC, and consistent with s 50ABZL of the Act, the Parties have an opportunity to respond to the preliminary issues identified in the NOCC by 8 April 2026.",
+              "type": "paragraph"
+            },
+            {
+              "number": "8.2",
+              "text": "Under the current statutory timeframe, the ACCC must issue a determination in respect of the Acquisition by 5 June 2026.",
+              "type": "paragraph"
+            }
+          ],
+          "number": "8",
+          "title": "Next steps"
+        }
+      ],
+      "title": "Ampol – EG Australia"
+    },
+    "MN-01068": {
+      "date": "5 March 2026",
+      "date_iso": "2026-03-05",
+      "document_type": "Notice of Competition Concerns – Summary",
+      "file_name": "Coles_Kalgoorlie - Final - Summary of Notice of Competition Concerns - March 2026.pdf",
+      "file_path": "matters/MN-01068/Coles_Kalgoorlie - Final - Summary of Notice of Competition Concerns - March 2026.pdf",
+      "matter_id": "MN-01068",
+      "sections": [
+        {
+          "blocks": [
+            {
+              "number": "1.1",
+              "text": "On 27 November 2025, Coles Supermarkets Australia Pty Ltd (Coles Supermarkets) lodged a notification with the Australian Competition and Consumer Commission (ACCC) in respect of its proposed acquisition of a leasehold interest for a supermarket and liquor site in Kalgoorlie, WA (the Acquisition). Coles Supermarkets is a subsidiary of Coles Group Limited (Coles).",
+              "type": "paragraph"
+            },
+            {
+              "number": "1.2",
+              "text": "On 29 January 2026, the ACCC decided that the Acquisition is to be subject to Phase 2 review.",
+              "type": "paragraph"
+            },
+            {
+              "number": "1.3",
+              "text": "On 5 March 2026, the ACCC issued a Notice of Competition Concerns (NOCC) to Coles Supermarkets.",
+              "type": "paragraph"
+            },
+            {
+              "number": "1.4",
+              "text": "The NOCC sets out the ACCC’s preliminary assessment of whether the Acquisition, if put into effect, would have the effect, or be likely to have the effect, of substantially lessening competition in any market, and the grounds on which the ACCC makes its assessment, referring to the evidence or other material on which those grounds are based.",
+              "type": "paragraph"
+            },
+            {
+              "number": "1.5",
+              "text": "This is a summary of the NOCC as required to be published on the Acquisitions Register.",
+              "type": "paragraph"
+            }
+          ],
+          "number": "1",
+          "title": "Introduction"
+        },
+        {
+          "blocks": [
+            {
+              "text": "The Acquisition",
+              "type": "heading"
+            },
+            {
+              "number": "2.1",
+              "text": "Coles Supermarkets proposes to acquire a leasehold interest (the Lease) at Lots 95- 106 Great Eastern Highway, in Somerville, WA (the Property) for the purpose of opening a supermarket and liquor store. Somerville is a suburb of Kalgoorlie-Boulder (Kalgoorlie).",
+              "type": "paragraph"
+            },
+            {
+              "text": "The acquirer – Coles",
+              "type": "heading"
+            },
+            {
+              "number": "2.2",
+              "text": "Coles is an Australian ASX-listed company. Its subsidiary, Coles Supermarkets, operates more than 800 supermarkets nationwide.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.3",
+              "text": "Coles’ standard offering entails large-format supermarkets that are either freestanding or located in shopping centres. Coles’ large-format stores typically offer standard grocery items, as well as a full-service bakery and deli service. Coles also operates smaller format ‘Coles Local’ supermarkets with a smaller range of grocery items.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.4",
+              "text": "Coles operates an online grocery shopping and delivery platform named ‘Coles Online’, which allows consumers to shop for groceries with either home delivery or pick up from ‘Click&Collect’ locations at existing Coles stores.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.5",
+              "text": "Coles also operates three different chains of liquor stores nationally, under the brand names Liquorland, First Choice Liquor Market (soon to be re-branded as Liquorland Warehouse) and Vintage Cellars (soon to be rebranded as Liquorland Cellars).",
+              "type": "paragraph"
+            },
+            {
+              "text": "Leasehold interest in Kalgoorlie",
+              "type": "heading"
+            },
+            {
+              "number": "2.6",
+              "text": "M Holdings 4 Pty Ltd is proposing to develop a neighbourhood centre on the Property, which is currently vacant. A Coles supermarket and Liquorland store will form part of the neighbourhood centre as a result of the Lease.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.7",
+              "text": "Coles proposes to develop a large format supermarket, with a selling floor area of 2,800 square metres (the Proposed Supermarket).",
+              "type": "paragraph"
+            },
+            {
+              "text": "Industry background – grocery retailing",
+              "type": "heading"
+            },
+            {
+              "text": "Grocery retailing in Australia",
+              "type": "heading"
+            },
+            {
+              "number": "2.8",
+              "text": "Grocery retailing is characterised by a mix of national supermarket chains and independently owned supermarkets with various business models. These different business models result in variation in pricing, product ranges, store format and competitive behaviour in the supply of groceries in Australia.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.9",
+              "text": "Coles and Woolworths Limited (Woolworths) are Australia’s two largest supermarket operators. They are vertically integrated, meaning they procure groceries directly from suppliers, manage their own distribution and logistics networks and operate retail stores under their respective banners.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.10",
+              "text": "In contrast, many independent supermarkets (including those trading under the IGA banner) are supplied by the wholesale distributor, Metcash Limited (Metcash). Metcash owns and operates some supermarkets, but predominantly supplies groceries and provides marketing and support services to independent supermarkets. Under this business model, independent supermarkets retain control over pricing, range and store operation.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.11",
+              "text": "Independent supermarkets differentiate themselves from Coles and Woolworths in a variety of ways including by sourcing some of their products from local suppliers, including local bakeries, restaurants, and producers.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.12",
+              "text": "There are also independent supermarket operators that are partially vertically integrated. Spudshed, for example, sources a proportion of its fresh produce directly from farms it owns.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.13",
+              "text": "These different business models result in variation in pricing, product ranges, store format and competitive behaviour in the supply of groceries.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.14",
+              "text": "In 2025, the ACCC published its Supermarkets Inquiry (the Inquiry) final report, which reviewed grocery retailing markets in Australia. The ACCC found the Australian supermarket industry is generally highly concentrated and that Coles and Woolworths have limited incentive to compete vigorously on price. The Inquiry found that generally, while independent supermarkets also have a limited ability to compete on price, they offer alternative product ranges to major chains that meet local needs, and compete on other non-price aspects of their offer.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.15",
+              "text": "The Inquiry considered competition in Australian grocery retailing markets generally. In considering the Acquisition, the ACCC is considering competition in Kalgoorlie specifically.",
+              "type": "paragraph"
+            },
+            {
+              "text": "Grocery retailing in Kalgoorlie",
+              "type": "heading"
+            },
+            {
+              "number": "2.16",
+              "text": "There are 6 supermarkets in Kalgoorlie, as set out in Table 1 below, of which 4 supply a larger range of groceries in a larger format store: Woolworths, Coles, Spudshed and O’Connor Fresh IGA. These larger supermarkets offer a comprehensive range of groceries—including fresh produce, meat, dairy, bakery, frozen and general merchandise items—and a ‘one-stop-shop’ experience for consumers.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.17",
+              "text": "Coles and Woolworths are Australia’s largest grocery chain supermarkets and are the two largest supermarkets in Kalgoorlie.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.18",
+              "text": "O’Connor Fresh IGA is an independent supermarket. It has smaller floor space than Coles and Woolworths and it offers a reasonably large range of groceries for customers.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.19",
+              "text": "Spudshed is an independent supermarket that entered Kalgoorlie in November 2025, taking over the space formerly occupied by IGA Hannans Fresh, which was occupied by Coles before that. Spudshed offers a large range of fresh produce, a proportion of which is sourced from its owners’ farms. Spudshed also offers a range of meat, dairy and grocery items.",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.20",
+              "text": "Compared to other supermarkets in Kalgoorlie, the Hannans Marketplace by Foodworks and Lionel St IGA supermarkets have smaller floor space and a smaller product range. Table 1Supermarkets in Kalgoorlie",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.21",
+              "text": "The locations of existing supermarkets and the Proposed Supermarket are illustrated in the figure below. O’Connor Fresh IGA will be the closest store geographically to the Proposed Supermarket (approximately 1.8km driving distance). Figure 1 Map of supermarkets in Kalgoorlie",
+              "type": "paragraph"
+            },
+            {
+              "number": "2.22",
+              "text": "Supermarkets in Kalgoorlie offer different trading hours to each other. Large supermarkets, such as Coles and Woolworths in Kalgoorlie, are subject to trading hour regulations. Other supermarkets, such as Spudshed, O’Connor Fresh IGA, Lionel St IGA and Hannans Marketplace by Foodworks, are not. Table 2 sets out the trading times for the 6 supermarkets in Kalgoorlie. Table 2Opening hours of supermarkets in Kalgoorlie",
+              "type": "paragraph"
+            },
+            {
+              "text": "Overlap and relationship between the parties",
+              "type": "heading"
+            },
+            {
+              "number": "2.23",
+              "text": "The Lease will be an input to Coles’ supermarket retailing operations.",
+              "type": "paragraph"
+            }
+          ],
+          "number": "2",
+          "title": "Background"
+        },
+        {
+          "blocks": [
+            {
+              "number": "3.1",
+              "text": "The area of competition the ACCC is considering for the purpose of assessing the Acquisition is the retail supply of groceries by supermarkets in Kalgoorlie.",
+              "type": "paragraph"
+            },
+            {
+              "number": "3.2",
+              "text": "Market definition is a purposive tool used to help assess whether an acquisition might have anti-competitive effects. At this stage of the review, the ACCC is taking a simple approach to defining the relevant market, by focussing on the most important competitive constraints on Coles.",
+              "type": "paragraph"
+            },
+            {
+              "number": "3.3",
+              "text": "For any given supermarket in Kalgoorlie, the extent of competitive rivalry they face from other participants will depend on a range of factors, including how similar or differentiated their product offerings are and their geographic proximity to each other.",
+              "type": "paragraph"
+            },
+            {
+              "text": "Product market",
+              "type": "heading"
+            },
+            {
+              "number": "3.4",
+              "text": "The ACCC’s preliminary view is the relevant product dimension is the retail supply of groceries by supermarkets. Supermarkets offer consumers the convenience of a one- stop-shop service for their grocery needs and a broad range of products.",
+              "type": "paragraph"
+            },
+            {
+              "number": "3.5",
+              "text": "This product dimension likely includes each of the supermarkets identified in Table 1 above. However, as discussed further in the Preliminary Competition Assessment below, the ACCC is still considering the extent of the competitive rivalry each supermarket in Kalgoorlie imposes on the others.",
+              "type": "paragraph"
+            },
+            {
+              "number": "3.6",
+              "text": "The ACCC’s view is that while the following types of retailers overlap in some product offerings with supermarkets, they are unlikely to be close substitutes for supermarkets for consumers:",
+              "type": "paragraph"
+            },
+            {
+              "items": [
+                "convenience stores—are not likely to be sufficiently close substitutes to supermarkets as they target consumers seeking few items on a convenient basis, and",
+                "speciality and general merchandise stores—retailers such as Chemist Warehouse, Bunnings, butchers, bakeries, green grocers and other specialty or general merchandise stores may stock a limited subset of grocery or household items, but they do not provide a sufficiently broad or substitutable range of grocery products to be close substitutes for supermarkets."
+              ],
+              "type": "bullet_list"
+            },
+            {
+              "number": "3.7",
+              "text": "Coles, Woolworths and other supermarkets supplement their bricks-and-mortar supermarket offerings with online delivery and online order services. The ACCC’s view is that for the purposes of assessing the Acquisition, these services should be included when assessing competition between supermarkets.",
+              "type": "paragraph"
+            },
+            {
+              "number": "3.8",
+              "text": "Kalgoorlie has a substantial population of fly-in-fly-out (FIFO) workers. However, the ACCC’s preliminary view is this customer group does not alter the product market or form a separate market.",
+              "type": "paragraph"
+            },
+            {
+              "text": "Geographic market",
+              "type": "heading"
+            },
+            {
+              "number": "3.9",
+              "text": "The ACCC considers that the geographic market is likely to be Kalgoorlie, though supermarkets in close geographic proximity are likely to compete more closely with each other.",
+              "type": "paragraph"
+            },
+            {
+              "number": "3.10",
+              "text": "Consumers are unlikely to travel beyond Kalgoorlie to shop for grocery products as it is geographically remote. For this reason, supermarkets outside the town are unlikely to be adequate substitutes for consumers.",
+              "type": "paragraph"
+            },
+            {
+              "number": "3.11",
+              "text": "The Inquiry found consumers generally prefer to travel shorter distances to do their grocery shopping. Additionally, feedback from a market participant suggests while it draws consumers from all over Kalgoorlie, the majority of its customers are coming from surrounding suburbs.",
+              "type": "paragraph"
+            }
+          ],
+          "number": "3",
+          "title": "Relevant areas of competition"
+        },
+        {
+          "blocks": [
+            {
+              "number": "4.1",
+              "text": "The ACCC is closely examining the effects of the Acquisition on competition between supermarkets in Kalgoorlie, by comparing the likely future state of competition if the Acquisition proceeds against the likely future state of competition if the Acquisition does not proceed. The ACCC considers the latter would be the status quo, or continuation of the current state of competition.",
+              "type": "paragraph"
+            },
+            {
+              "number": "4.2",
+              "text": "In the status quo and in the future without the Acquisition, the ACCC considers Coles and Woolworths likely have market power in Kalgoorlie. This is the case even though Coles and Woolworths face a degree of rivalry from independent supermarkets via their competitive differentiated offering compared to Coles and Woolworths. Coles and Woolworths each and combined account for a significant proportion of the market and the ACCC has previously found Coles and Woolworths have limited incentive to compete vigorously with each other on price. The ACCC is still considering whether Coles and Woolworths may have substantial market power in Kalgoorlie.",
+              "type": "paragraph"
+            },
+            {
+              "number": "4.3",
+              "text": "Information from market participants shows independent supermarkets in Kalgoorlie compete on the basis of price, range and quality of products, store quality and customer service. Market participants have also provided information to show supermarkets monitor and respond to each other, including with independents matching or beating Coles and Woolworths on key value items.",
+              "type": "paragraph"
+            },
+            {
+              "number": "4.4",
+              "text": "In the future with the Acquisition, the ACCC considers the Acquisition will likely create an over-supply of supermarket capacity and thereby lead to the exit of an effective independent competitor. This will reduce the level of competition faced by remaining rivals, in circumstances where the likelihood of new entry is low. Coles would increase its market power and likely have a substantial degree of market power. This is because:",
+              "type": "paragraph"
+            },
+            {
+              "items": [
+                "Coles’ market share in Kalgoorlie will increase to a high level",
+                "while some supermarkets will continue to compete, their ability to constrain Coles’ market power would be limited, and",
+                "it is likely that Coles would earn high economic profits in Kalgoorlie."
+              ],
+              "type": "bullet_list"
+            },
+            {
+              "number": "4.5",
+              "text": "The ACCC is considering whether Coles’ investment in the Proposed Supermarket is likely to only be profitable if it leads to the exit of an effective competitor.",
+              "type": "paragraph"
+            },
+            {
+              "number": "4.6",
+              "text": "Having regard to the likely future with the Acquisition and the likely future without the Acquisition, the ACCC’s preliminary assessment is that the Acquisition would have the effect or likely effect of substantially lessening competition in Kalgoorlie as it leads to the exit of an effective independent competitor and increases Coles’ market power. This would be likely to, in all the circumstances, create, strengthen or entrench a substantial degree of market power for Coles.",
+              "type": "paragraph"
+            },
+            {
+              "number": "4.7",
+              "text": "The ACCC considers the Kalgoorlie market will likely lose an effective competitor that:",
+              "type": "paragraph"
+            },
+            {
+              "items": [
+                "price matches and price discounts relative to Coles and other supermarkets in Kalgoorlie",
+                "offers a range and quality of products—this includes high-revenue products where an effective competitor competes head-to-head, but also unique and specialised products that provide a differentiated offering valued by customers",
+                "is valued by customers as a high-quality alternative to other competitors— including in terms of the store’s stock levels and shelf replenishment, store cleanliness and condition, maintenance expenditure and capital refurbishment, and",
+                "provides a high level of customer service—this includes ensuring check outs are staffed and queues are minimised, and offering extended opening hours."
+              ],
+              "type": "bullet_list"
+            },
+            {
+              "number": "4.8",
+              "text": "This is likely to lead to Coles competing less strongly in Kalgoorlie, as it will no longer be concerned with the effective competitor’s activity. Coles and other supermarkets may:",
+              "type": "paragraph"
+            },
+            {
+              "items": [
+                "reduce the extent to which they match competitor discounts i.e. reduce the frequency or extent of altering prices on select product lines, such as fresh produce, or deviate from statewide pricing policies",
+                "have higher incentives to raise statewide prices",
+                "reduce customer service by employing fewer staff at its Kalgoorlie stores and reduce other aspects of quality, and",
+                "reduce the range of products available, particularly where they might have matched the speciality products the exiting competitor used to differentiate itself."
+              ],
+              "type": "bullet_list"
+            },
+            {
+              "number": "4.9",
+              "text": "The ACCC expects Coles sets statewide prices having regard to the likelihood of losing customers’ sales to competitors across its stores in Western Australia. The ACCC is further considering whether, if local competition declines in Kalgoorlie, Coles may increase statewide prices, albeit by a small amount.",
+              "type": "paragraph"
+            },
+            {
+              "number": "4.10",
+              "text": "The ACCC is exploring whether competition will also be substantially lessened, albeit to a lesser extent, where an effective competitor is significantly harmed but does not exit. It is not yet clear whether a competitor would respond to significant harm following the Acquisition by undertaking less competitive activity to reduce their costs or by competing more fiercely to defend its position in the market.",
+              "type": "paragraph"
+            },
+            {
+              "number": "4.11",
+              "text": "The ACCC is also considering whether the Acquisition may harm competition by reducing the competitive rivalry existing competitors impose on Coles. Interested parties have submitted that if the Acquisition reduces the scale of existing competitors, it may increase distribution and wholesale costs in a relatively remote location such as Kalgoorlie.",
+              "type": "paragraph"
+            },
+            {
+              "number": "4.12",
+              "text": "The ACCC will continue considering these issues.",
+              "type": "paragraph"
+            }
+          ],
+          "number": "4",
+          "title": "Summary of preliminary competition assessment"
+        },
+        {
+          "blocks": [
+            {
+              "number": "5.1",
+              "text": "Following the release of the NOCC, and consistent with s 51ABZL of the Act, the notifying party (Coles Supermarkets) has an opportunity to respond to the preliminary issues identified in the NOCC by 14 April 2026.",
+              "type": "paragraph"
+            },
+            {
+              "number": "5.2",
+              "text": "Under the current statutory timeframe, the ACCC must issue a determination in response to the Acquisition by 12 June 2026.",
+              "type": "paragraph"
+            }
+          ],
+          "number": "5",
+          "title": "Next steps"
+        }
+      ],
+      "title": "Coles – supermarket and liquor site in Kalgoorlie, WA"
+    }
+  },
   "stats": {
     "total_mergers": 89,
     "total_waivers": 128,

--- a/data/output/cli/cli-manifest.json
+++ b/data/output/cli/cli-manifest.json
@@ -1,7 +1,7 @@
 {
-  "version": 63,
-  "generated_at": "2026-05-04T12:14:21Z",
+  "version": 64,
+  "generated_at": "2026-05-04T23:02:47Z",
   "merger_count": 217,
-  "bundle_sha256": "9f443d6c4b0b8ea2c02ad75c681bb2f8f63693bc2a53c6ec2afbc2b1a048a327",
+  "bundle_sha256": "007a92d20df6afffd781e56aa8d90ad4bfc5a5690e180c2cce9090e68517a432",
   "merger_manifest_sha256": "69a23065dd5c62bf07a2d473c5e537df1fb3457c68b86404f56255d0c2283282"
 }

--- a/scripts/generate-cli-data.sh
+++ b/scripts/generate-cli-data.sh
@@ -9,9 +9,9 @@
 #     committing to a full download.
 #
 #   data/output/cli/cli-bundle.json
-#     Complete dataset (all mergers + questionnaires + stats + industries)
-#     bundled into a single file. Only downloaded when the manifest's
-#     bundle_sha256 differs from the client's cached copy.
+#     Complete dataset (all mergers + questionnaires + noccs + stats +
+#     industries) bundled into a single file. Only downloaded when the
+#     manifest's bundle_sha256 differs from the client's cached copy.
 #
 #   data/output/cli/cli-merger-manifest.json
 #     {merger_id: sha256} map of every individual merger file. Supports a
@@ -42,6 +42,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SRC_DIR="$REPO_ROOT/merger-tracker/frontend/public/data"
 MERGERS_DIR="$SRC_DIR/mergers"
 QUESTIONNAIRES_DIR="$SRC_DIR/questionnaires"
+NOCCS_DIR="$SRC_DIR/noccs"
 STATS_FILE="$SRC_DIR/stats.json"
 INDUSTRIES_FILE="$SRC_DIR/industries.json"
 
@@ -94,6 +95,14 @@ if [[ -d "$QUESTIONNAIRES_DIR" ]]; then
 fi
 echo "Found ${#QUESTIONNAIRE_FILES[@]} questionnaire files"
 
+NOCC_FILES=()
+if [[ -d "$NOCCS_DIR" ]]; then
+    for f in "$NOCCS_DIR"/*.json; do
+        [[ -f "$f" ]] && NOCC_FILES+=("$f")
+    done
+fi
+echo "Found ${#NOCC_FILES[@]} NOCC files"
+
 # ---------------------------------------------------------------------------
 # Build bundle into a temp file
 #
@@ -104,9 +113,10 @@ echo "Found ${#QUESTIONNAIRE_FILES[@]} questionnaire files"
 BUNDLE_TMP="$(mktemp)"
 MERGERS_TMP="$(mktemp)"
 QUESTIONNAIRES_TMP="$(mktemp)"
+NOCCS_TMP="$(mktemp)"
 STATS_TMP="$(mktemp)"
 INDUSTRIES_TMP="$(mktemp)"
-trap 'rm -f "$BUNDLE_TMP" "$MERGERS_TMP" "$QUESTIONNAIRES_TMP" "$STATS_TMP" "$INDUSTRIES_TMP"' EXIT
+trap 'rm -f "$BUNDLE_TMP" "$MERGERS_TMP" "$QUESTIONNAIRES_TMP" "$NOCCS_TMP" "$STATS_TMP" "$INDUSTRIES_TMP"' EXIT
 
 echo "Building bundle..."
 
@@ -126,6 +136,20 @@ else
     echo "{}" > "$QUESTIONNAIRES_TMP"
 fi
 
+if [[ ${#NOCC_FILES[@]} -gt 0 ]]; then
+    python3 - "${NOCC_FILES[@]}" > "$NOCCS_TMP" <<'PYEOF'
+import json, os, sys
+result = {}
+for path in sys.argv[1:]:
+    merger_id = os.path.splitext(os.path.basename(path))[0]
+    with open(path) as f:
+        result[merger_id] = json.load(f)
+print(json.dumps(result, separators=(',', ':'), sort_keys=True))
+PYEOF
+else
+    echo "{}" > "$NOCCS_TMP"
+fi
+
 if [[ -f "$STATS_FILE" ]]; then
     cp "$STATS_FILE" "$STATS_TMP"
 else
@@ -143,9 +167,10 @@ jq -n \
     '{
         mergers:        input,
         questionnaires: input,
+        noccs:          input,
         stats:          input,
         industries:     input
-    }' "$MERGERS_TMP" "$QUESTIONNAIRES_TMP" "$STATS_TMP" "$INDUSTRIES_TMP" \
+    }' "$MERGERS_TMP" "$QUESTIONNAIRES_TMP" "$NOCCS_TMP" "$STATS_TMP" "$INDUSTRIES_TMP" \
     > "$BUNDLE_TMP"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
This PR adds support for Notice of Competition Concerns (NOCC) documents to the merger tracker data pipeline. NOCCs are now included in the CLI bundle alongside existing merger, questionnaire, and statistics data.

## Key Changes
- **Data Structure**: Added `noccs` section to `cli-bundle.json` containing two NOCC documents:
  - MN-01019: Ampol – EG Australia acquisition (2 March 2026)
  - MN-01068: Coles – Kalgoorlie supermarket acquisition (5 March 2026)
  
- **Build Script Updates** (`scripts/generate-cli-data.sh`):
  - Added `NOCCS_DIR` variable to reference the source NOCC files directory
  - Implemented NOCC file discovery logic to scan and collect all NOCC JSON files
  - Updated bundle generation to include NOCC data alongside mergers, questionnaires, stats, and industries
  - Updated documentation comments to reflect that the bundle now includes NOCCs
  - Added temporary file cleanup for NOCC processing

- **Manifest Updates** (`cli-manifest.json`):
  - Incremented version from 63 to 64
  - Updated generated timestamp

## Implementation Details
The NOCC documents follow the same structured format as existing data, with sections containing blocks of content (paragraphs, headings, bullet lists) organized by document type and matter ID. The build script now treats NOCCs as a first-class data type in the bundle generation pipeline, ensuring they are properly included in the complete dataset distribution.

https://claude.ai/code/session_01JWmPfEuYaUrw43cdus1VUX