### PR TITLE
Auto-fix missing questionnaire dates and create GitHub issues

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   pipeline:
@@ -143,7 +144,8 @@ jobs:
           git add data/processed/mergers.json data/processed/questionnaire_data.json \
             data/processed/similar_mergers.json \
             data/raw/matters/ merger-tracker/frontend/public/data/ \
-            merger-tracker/frontend/public/feed.xml data/output/
+            merger-tracker/frontend/public/feed.xml data/output/ \
+            data/frozen_events_mergers.json
 
       # --- Convert DOCX to PDF ---
       # Runs whenever there are unconverted files, catching both new downloads and stragglers.
@@ -209,7 +211,8 @@ jobs:
           git add data/processed/mergers.json data/processed/questionnaire_data.json \
             data/processed/similar_mergers.json \
             data/raw/matters/ merger-tracker/frontend/public/data/ \
-            merger-tracker/frontend/public/feed.xml data/output/
+            merger-tracker/frontend/public/feed.xml data/output/ \
+            data/frozen_events_mergers.json
 
       # --- Single commit ---
 
@@ -272,3 +275,56 @@ jobs:
               fi
             fi
           fi
+
+      # --- Open GitHub issues for auto-fixed questionnaire dates ---
+      # The extraction script writes missing_questionnaire_dates.json when it
+      # auto-sets a date.  We create one issue per affected merger so the owner
+      # can confirm the date is correct and close the issue when happy.
+
+      - name: Create issues for auto-fixed questionnaire dates
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ ! -f data/processed/missing_questionnaire_dates.json ]; then
+            echo "No missing questionnaire dates to report"
+            exit 0
+          fi
+
+          COUNT=$(jq '.issues | length' data/processed/missing_questionnaire_dates.json)
+          if [ "$COUNT" -eq 0 ]; then
+            echo "No issues to create"
+            exit 0
+          fi
+
+          echo "Creating $COUNT issue(s) for missing questionnaire dates..."
+
+          gh label create "missing-questionnaire-date" \
+            --description "Questionnaire date was missing; auto-set by pipeline" \
+            --color "e4e669" \
+            --force
+
+          for i in $(seq 0 $((COUNT - 1))); do
+            MERGER_ID=$(jq -r ".issues[$i].merger_id" data/processed/missing_questionnaire_dates.json)
+
+            # Skip if an open issue already exists for this merger (idempotent guard)
+            EXISTING=$(gh issue list \
+              --label "missing-questionnaire-date" \
+              --state open \
+              --json title \
+              --jq '.[].title' | grep "$MERGER_ID" || true)
+            if [ -n "$EXISTING" ]; then
+              echo "Issue already open for $MERGER_ID — skipping"
+              continue
+            fi
+
+            TITLE=$(jq -r ".issues[$i].title" data/processed/missing_questionnaire_dates.json)
+            jq -n \
+              --argjson idx "$i" \
+              --slurpfile data data/processed/missing_questionnaire_dates.json \
+              '{"title": $data[0].issues[$idx].title,
+                "body":  $data[0].issues[$idx].body,
+                "labels": ["missing-questionnaire-date"]}' | \
+            gh api "repos/$GITHUB_REPOSITORY/issues" \
+              --method POST --input -
+            echo "Created issue: $TITLE"
+          done

--- a/scripts/extract_mergers.py
+++ b/scripts/extract_mergers.py
@@ -744,6 +744,124 @@ def enrich_with_questionnaire_data(mergers_data):
     return mergers_data
 
 
+MISSING_QUESTIONNAIRE_DATES_PATH = 'data/processed/missing_questionnaire_dates.json'
+
+
+def auto_fix_missing_questionnaire_dates(all_mergers_data, frozen_events_mergers):
+    """Detect questionnaire events with empty dates, set today as the date, and freeze.
+
+    For each merger not already frozen that has a questionnaire event with no date:
+      1. Sets the event date to today at noon UTC.
+      2. Adds the merger to frozen_events_mergers.json so future scrapes preserve the date.
+      3. Writes issue content to MISSING_QUESTIONNAIRE_DATES_PATH for the pipeline to
+         create GitHub issues asking the user to confirm the auto-set date is correct.
+
+    Returns a set of newly frozen merger IDs (empty set if nothing was fixed).
+    """
+    today = datetime.utcnow()
+    today_iso = today.strftime('%Y-%m-%dT12:00:00Z')
+    day = str(today.day)
+    today_display = f"{day} {today.strftime('%b %Y')}"  # e.g. "6 May 2026"
+
+    newly_frozen = []
+
+    for merger in all_mergers_data:
+        merger_id = merger.get('merger_id')
+        if not merger_id or merger_id in frozen_events_mergers:
+            continue
+
+        for event in merger.get('events', []):
+            if event.get('date') in ('', None) and 'questionnaire' in event.get('title', '').lower():
+                event['date'] = today_iso
+                newly_frozen.append({
+                    'merger_id': merger_id,
+                    'merger_name': merger.get('merger_name', ''),
+                    'event_title': event.get('title', ''),
+                    'date_display': today_display,
+                    'merger_url': merger.get('url', ''),
+                })
+                break  # one fix per merger
+
+    if not newly_frozen:
+        if os.path.exists(MISSING_QUESTIONNAIRE_DATES_PATH):
+            os.remove(MISSING_QUESTIONNAIRE_DATES_PATH)
+        return set()
+
+    # Update frozen_events_mergers.json
+    try:
+        with open(FROZEN_EVENTS_MERGERS_PATH, 'r', encoding='utf-8') as f:
+            frozen_data = json.load(f)
+    except FileNotFoundError:
+        frozen_data = {
+            "_comment": (
+                "Override data for specific mergers. An entry with an empty dict or "
+                "'freeze_events: true' preserves the existing events array rather than "
+                "overwriting from the scraped page."
+            )
+        }
+
+    for item in newly_frozen:
+        mid = item['merger_id']
+        frozen_data[mid] = {
+            "_comment": (
+                f"Questionnaire event date ({item['date_display']}) is missing from the "
+                "ACCC page; freezing events to preserve the automatically set date."
+            ),
+            "freeze_events": True,
+        }
+
+    with open(FROZEN_EVENTS_MERGERS_PATH, 'w', encoding='utf-8') as f:
+        json.dump(frozen_data, f, indent=2)
+
+    # Build GitHub issue content
+    _repo = "nwbort/accc-mergers"
+    issues = []
+    for item in newly_frozen:
+        mid = item['merger_id']
+        name = item['merger_name']
+        url = item['merger_url']
+        event_title = item['event_title']
+        date_display = item['date_display']
+        mergers_fyi_url = f"https://mergers.fyi/mergers/{mid}"
+        frozen_json_url = f"https://github.com/{_repo}/blob/main/data/frozen_events_mergers.json"
+
+        body = (
+            f"The questionnaire event for **{name}** had no date on the ACCC page.\n\n"
+            f"The pipeline automatically set the date to **{date_display}** and froze "
+            f"the merger's events to prevent future scrapes from clearing it.\n\n"
+            f"### Details\n\n"
+            f"| Field | Value |\n"
+            f"|-------|-------|\n"
+            f"| Merger | [{name}]({url}) |\n"
+            f"| Merger ID | `{mid}` |\n"
+            f"| Event | {event_title} |\n"
+            f"| Date set | {date_display} |\n\n"
+            f"### Action required\n\n"
+            f"Please verify that **{date_display}** is the correct questionnaire date.\n\n"
+            f"- If it is correct, close this issue.\n"
+            f"- If it is wrong, update the date in "
+            f"[`data/frozen_events_mergers.json`]({frozen_json_url}) and "
+            f"`data/processed/mergers.json` with the correct value.\n\n"
+            f"[View on mergers.fyi]({mergers_fyi_url})"
+        )
+        issues.append({
+            'merger_id': mid,
+            'merger_name': name,
+            'title': f"Auto-fix: missing questionnaire date for {name} ({mid})",
+            'body': body,
+        })
+
+    with open(MISSING_QUESTIONNAIRE_DATES_PATH, 'w', encoding='utf-8') as f:
+        json.dump({'issues': issues}, f, indent=2)
+
+    newly_frozen_ids = {item['merger_id'] for item in newly_frozen}
+    print(
+        f"Auto-fixed missing questionnaire date(s) for: {', '.join(sorted(newly_frozen_ids))}",
+        file=sys.stderr,
+    )
+    return newly_frozen_ids
+
+
 def extract_nocc_data():
     """Parse all NOCC summary PDFs and write the standalone JSON manifest.
 
@@ -892,6 +1010,11 @@ def main():
     # back into per-merger fields (their date is already on the event), but
     # downstream pipelines load the manifest separately.
     extract_nocc_data()
+
+    # 8c. Auto-fix questionnaire events whose date is missing on the ACCC page.
+    #     Sets today as the date, freezes the merger to preserve it, and writes
+    #     issue content for the pipeline to open a GitHub issue for confirmation.
+    auto_fix_missing_questionnaire_dates(all_mergers_data, frozen_events_mergers)
 
     # 9. Add is_waiver field to each merger
     for merger in all_mergers_data:


### PR DESCRIPTION
## Summary
This PR adds automatic detection and fixing of questionnaire events with missing dates on the ACCC page. When a questionnaire event has no date, the pipeline now sets it to today at noon UTC, freezes the merger to preserve the date, and creates a GitHub issue asking the user to confirm the auto-set date is correct.

## Key Changes

- **New function `auto_fix_missing_questionnaire_dates()`** in `scripts/extract_mergers.py`:
  - Detects questionnaire events with empty or null dates
  - Sets the event date to today at noon UTC
  - Adds affected mergers to `frozen_events_mergers.json` to prevent future scrapes from clearing the date
  - Generates GitHub issue content with merger details and instructions for manual verification
  - Writes issue data to `data/processed/missing_questionnaire_dates.json` for the pipeline to consume

- **Updated `main()` function** to call the new auto-fix function after enriching with questionnaire data

- **GitHub Actions workflow updates** (`.github/workflows/pipeline.yml`):
  - Added `issues: write` permission to allow creating GitHub issues
  - Updated git add commands to include `data/frozen_events_mergers.json`
  - Added new job step "Create issues for auto-fixed questionnaire dates" that:
    - Reads the missing questionnaire dates JSON file
    - Creates a "missing-questionnaire-date" label
    - Creates one GitHub issue per affected merger with detailed information
    - Includes idempotent guard to skip if an issue already exists for a merger

## Implementation Details

- The auto-fix function processes one questionnaire event per merger (breaks after first match)
- Newly frozen merger IDs are returned as a set for potential downstream use
- If no fixes are needed, the `missing_questionnaire_dates.json` file is cleaned up
- GitHub issues include a formatted table with merger details and clear action items for the user
- The pipeline uses `gh` CLI for idempotent issue creation with proper error handling

https://claude.ai/code/session_01Cf7Uu62BGXXsxLTXFY1zdJ