### PR TITLE
Add LinkedIn and GitHub links to Nick Twort page

### DIFF
--- a/merger-tracker/frontend/package-lock.json
+++ b/merger-tracker/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "react-chartjs-2": "^5.3.1",
         "react-dom": "^19.2.0",
         "react-helmet-async": "^2.0.5",
+        "react-icons": "^5.6.0",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.9.5"
       },
@@ -5272,6 +5273,15 @@
       },
       "peerDependencies": {
         "react": "^16.6.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
+      "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/merger-tracker/frontend/package.json
+++ b/merger-tracker/frontend/package.json
@@ -18,6 +18,7 @@
     "react-chartjs-2": "^5.3.1",
     "react-dom": "^19.2.0",
     "react-helmet-async": "^2.0.5",
+    "react-icons": "^5.6.0",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.9.5"
   },

--- a/merger-tracker/frontend/src/components/Footer.jsx
+++ b/merger-tracker/frontend/src/components/Footer.jsx
@@ -6,14 +6,12 @@ function Footer() {
       <div className="mx-auto px-4 sm:px-6 lg:px-8 py-4">
         <div className="text-center text-xs text-gray-500 leading-relaxed">
           <span className="font-semibold text-gray-600">Disclaimer:</span> This is an unofficial website created by{' '}
-          <a
-            href="http://nick.twort.co.nz/"
-            target="_blank"
-            rel="noopener noreferrer"
+          <Link
+            to="/nick-twort"
             className="text-primary hover:text-primary-dark font-medium hover:underline transition-colors"
           >
             Nick Twort
-          </a>
+          </Link>
           . The information on this site is provided for informational purposes only and should not be relied upon for legal or business decisions. No responsibility is accepted for any errors, omissions, or reliance on the information presented. <span className="whitespace-nowrap">For official merger information, please visit the</span>{' '}
           <a
             href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register"

--- a/merger-tracker/frontend/src/components/Footer.jsx
+++ b/merger-tracker/frontend/src/components/Footer.jsx
@@ -8,6 +8,7 @@ function Footer() {
           <span className="font-semibold text-gray-600">Disclaimer:</span> This is an unofficial website created by{' '}
           <Link
             to="/nick-twort"
+            onClick={() => window.scrollTo(0, 0)}
             className="text-primary hover:text-primary-dark font-medium hover:underline transition-colors"
           >
             Nick Twort

--- a/merger-tracker/frontend/src/pages/NickTwort.jsx
+++ b/merger-tracker/frontend/src/pages/NickTwort.jsx
@@ -1,3 +1,4 @@
+import { FaLinkedin, FaGithub } from 'react-icons/fa';
 import SEO from '../components/SEO';
 
 const structuredData = {
@@ -53,7 +54,27 @@ export default function NickTwort() {
 
         {/* Header */}
         <div className="mb-10">
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">Nick Twort</h1>
+          <div className="flex items-center gap-3 mb-2">
+            <h1 className="text-3xl font-bold text-gray-900">Nick Twort</h1>
+            <a
+              href="https://www.linkedin.com/in/nick-twort"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="LinkedIn profile"
+              className="text-[#0A66C2] hover:opacity-75 transition-opacity"
+            >
+              <FaLinkedin size={28} />
+            </a>
+            <a
+              href="https://github.com/nwbort"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="GitHub profile"
+              className="text-gray-800 hover:opacity-75 transition-opacity"
+            >
+              <FaGithub size={28} />
+            </a>
+          </div>
           <p className="text-lg text-emerald-700 font-medium">Competition Economist – Australia &amp; New Zealand</p>
         </div>
 

--- a/merger-tracker/frontend/src/pages/NickTwort.jsx
+++ b/merger-tracker/frontend/src/pages/NickTwort.jsx
@@ -61,7 +61,7 @@ export default function NickTwort() {
               target="_blank"
               rel="noopener noreferrer"
               aria-label="LinkedIn profile"
-              className="text-[#0A66C2] hover:opacity-75 transition-opacity"
+              className="text-primary hover:opacity-75 transition-opacity"
             >
               <FaLinkedin size={28} />
             </a>
@@ -70,7 +70,7 @@ export default function NickTwort() {
               target="_blank"
               rel="noopener noreferrer"
               aria-label="GitHub profile"
-              className="text-gray-800 hover:opacity-75 transition-opacity"
+              className="text-primary hover:opacity-75 transition-opacity"
             >
               <FaGithub size={28} />
             </a>


### PR DESCRIPTION
## Summary

- Adds LinkedIn and GitHub icon links next to the name heading on the Nick Twort page, using `react-icons` (`FaLinkedin`, `FaGithub`)
- Updates the footer "Nick Twort" link to use an internal route (`/nick-twort`) instead of the external `nick.twort.co.nz`

## Test plan

- [ ] Visit `/nick-twort` and confirm LinkedIn and GitHub icons appear beside the heading, link to the correct profiles, and open in a new tab
- [ ] Confirm icons render at an appropriate size and with correct brand colours (LinkedIn blue, GitHub dark)
- [ ] Check the footer — "Nick Twort" should now navigate to `/nick-twort` within the app