### PR TITLE
Add sign-up prompt to weekly email footer

### DIFF
--- a/scripts/send_weekly_email.py
+++ b/scripts/send_weekly_email.py
@@ -519,6 +519,9 @@ def build_html_email(digest: dict) -> str:
                 View online
               </a>
             </span>
+            <span style="font-size:13px;color:#6b7280;margin-top:4px;display:block;font-style:italic;">
+              Were you forwarded this email? Sign up <a href="https://mergers.fyi/digest" style="color:#335145;text-decoration:underline;">here</a>
+            </span>
           </td>
         </tr>
 


### PR DESCRIPTION
## Summary
Added a call-to-action prompt in the weekly email footer to encourage forwarded recipients to sign up for the digest directly.

## Changes
- Added a new footer message in the HTML email template that appears below the "View online" link
- The message includes styled text ("Were you forwarded this email?") with a link to the digest sign-up page
- Styled with gray text (#6b7280), italic font, and matching link color (#335145) to maintain visual consistency with the email design

## Implementation Details
- The new element is positioned as a block-level span with appropriate margins and font styling
- Links to `https://mergers.fyi/digest` for new user sign-ups
- Uses inline CSS styling consistent with the existing email template design

https://claude.ai/code/session_011qBVfN4bKUAzp5ncMmQo42