### PR TITLE
Add Open Graph meta tags for social media bot crawlers

### DIFF
--- a/functions/mergers/[matter]/[[path]].js
+++ b/functions/mergers/[matter]/[[path]].js
@@ -17,7 +17,7 @@ function buildOgHtml(merger, canonicalUrl) {
     ? `ACCC decision: ${escapeHtml(merger.accc_determination)}`
     : escapeHtml(merger.status ?? '');
   const stage = merger.stage ? ` - ${escapeHtml(merger.stage)}` : '';
-  const description = `${merger.merger_id}: ${statusLabel}${stage}. Track ACCC merger reviews on mergers.fyi`;
+  const description = `Status: ${statusLabel}${stage}.&#10;Find merger analysis, commentary, decisions and more. Track ACCC merger reviews on mergers.fyi`;
   const publishDate = merger.effective_notification_datetime ?? merger.original_notification_datetime ?? '';
 
   return `<!doctype html>
@@ -27,6 +27,7 @@ function buildOgHtml(merger, canonicalUrl) {
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>${title}</title>
 <meta name="description" content="${description}" />
+<meta name="author" content="Nick Twort" />
 <meta property="og:type" content="article" />
 <meta property="og:title" content="${title}" />
 <meta property="og:description" content="${description}" />
@@ -36,6 +37,7 @@ function buildOgHtml(merger, canonicalUrl) {
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
 ${publishDate ? `<meta property="article:published_time" content="${escapeHtml(publishDate)}" />` : ''}
+<meta property="article:author" content="Nick Twort" />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="${title}" />
 <meta name="twitter:description" content="${description}" />

--- a/functions/mergers/[matter]/[[path]].js
+++ b/functions/mergers/[matter]/[[path]].js
@@ -1,9 +1,90 @@
 import { renderViewer } from '../../_lib/pdf-viewer.js';
 
+const BOT_UA_RE = /LinkedInBot|facebookexternalhit|Twitterbot|Slackbot|Discordbot|TelegramBot|WhatsApp|Googlebot|bingbot|Pinterestbot|Applebot|Iframely|rogerbot|embedly|outbrain|quora link preview|Slack|vkShare|W3C_Validator|redditbot|flipboard|tumblr|bitlybot|SkypeUriPreview|nuzzel|Disqus|Google Page Speed|Qwantify|pinterestbot|Baiduspider/i;
+
+function isBotRequest(request) {
+  const ua = request.headers.get('User-Agent') || '';
+  return BOT_UA_RE.test(ua);
+}
+
+function escapeHtml(str) {
+  return String(str ?? '').replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function buildOgHtml(merger, canonicalUrl) {
+  const title = `${escapeHtml(merger.merger_name)} | Australian Merger Tracker`;
+  const statusLabel = merger.accc_determination
+    ? `ACCC decision: ${escapeHtml(merger.accc_determination)}`
+    : escapeHtml(merger.status ?? '');
+  const stage = merger.stage ? ` - ${escapeHtml(merger.stage)}` : '';
+  const description = `${merger.merger_id}: ${statusLabel}${stage}. Track ACCC merger reviews on mergers.fyi`;
+  const publishDate = merger.effective_notification_datetime ?? merger.original_notification_datetime ?? '';
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>${title}</title>
+<meta name="description" content="${description}" />
+<meta property="og:type" content="article" />
+<meta property="og:title" content="${title}" />
+<meta property="og:description" content="${description}" />
+<meta property="og:url" content="${escapeHtml(canonicalUrl)}" />
+<meta property="og:site_name" content="Australian Merger Tracker" />
+<meta property="og:image" content="https://mergers.fyi/og-image.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+${publishDate ? `<meta property="article:published_time" content="${escapeHtml(publishDate)}" />` : ''}
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="${title}" />
+<meta name="twitter:description" content="${description}" />
+<meta name="twitter:image" content="https://mergers.fyi/og-image.png" />
+<link rel="canonical" href="${escapeHtml(canonicalUrl)}" />
+</head>
+<body>
+<script>window.location.replace(${JSON.stringify(canonicalUrl)});</script>
+</body>
+</html>`;
+}
+
+async function serveOgPage(matterId, canonicalUrl, env) {
+  const dataUrl = new URL(`/data/mergers/${matterId}.json`, canonicalUrl);
+  let merger;
+  try {
+    const resp = await env.ASSETS.fetch(new Request(dataUrl.toString()));
+    if (!resp.ok) return null;
+    merger = await resp.json();
+  } catch {
+    return null;
+  }
+  return new Response(buildOgHtml(merger, canonicalUrl), {
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+      'X-Content-Type-Options': 'nosniff',
+      'Referrer-Policy': 'strict-origin-when-cross-origin',
+    },
+  });
+}
+
 export async function onRequest(context) {
   const { request, env } = context;
   const url = new URL(request.url);
   const path = url.pathname;
+
+  // For social/crawler bots hitting a top-level merger page, serve a minimal
+  // HTML response with specific OG meta tags — bots don't run JS so they would
+  // otherwise see only the generic tags in the SPA's index.html.
+  const isTopLevel = /^\/mergers\/((MN|WA)-\d+)\/?$/i.test(path);
+  if (isTopLevel && isBotRequest(request)) {
+    const match = path.match(/^\/mergers\/((MN|WA)-\d+)/i);
+    const matterId = match[1].toUpperCase();
+    const canonicalUrl = `${url.origin}/mergers/${matterId}`;
+    const ogResponse = await serveOgPage(matterId, canonicalUrl, env);
+    if (ogResponse) return ogResponse;
+    // Fall through if the merger data couldn't be fetched
+  }
 
   // Only intercept .pdf requests — let everything else (SPA routes, etc.) pass through
   if (!path.toLowerCase().endsWith('.pdf')) {

--- a/functions/mergers/[matter]/[[path]].js
+++ b/functions/mergers/[matter]/[[path]].js
@@ -1,6 +1,6 @@
 import { renderViewer } from '../../_lib/pdf-viewer.js';
 
-const BOT_UA_RE = /LinkedInBot|facebookexternalhit|Twitterbot|Slackbot|Discordbot|TelegramBot|WhatsApp|Googlebot|bingbot|Pinterestbot|Applebot|Iframely|rogerbot|embedly|outbrain|quora link preview|Slack|vkShare|W3C_Validator|redditbot|flipboard|tumblr|bitlybot|SkypeUriPreview|nuzzel|Disqus|Google Page Speed|Qwantify|pinterestbot|Baiduspider/i;
+const BOT_UA_RE = /LinkedInBot|facebookexternalhit|Twitterbot|Slackbot|Discordbot|TelegramBot|WhatsApp|bingbot|Pinterestbot|Applebot|Iframely|rogerbot|embedly|outbrain|quora link preview|Slack|vkShare|W3C_Validator|redditbot|flipboard|tumblr|bitlybot|SkypeUriPreview|nuzzel|Disqus|Qwantify|pinterestbot|Baiduspider/i;
 
 function isBotRequest(request) {
   const ua = request.headers.get('User-Agent') || '';


### PR DESCRIPTION
## Summary
This change adds support for serving dynamically generated Open Graph meta tags to social media crawlers and bots when they request individual merger pages. This enables proper link previews on platforms like LinkedIn, Facebook, Twitter, Discord, and others.

## Key Changes
- **Bot detection**: Added `isBotRequest()` function that identifies common social media crawlers and bots via User-Agent header matching
- **OG meta tag generation**: Implemented `buildOgHtml()` function that generates a minimal HTML document with Open Graph meta tags containing merger-specific information (name, status, stage, ACCC determination, notification date)
- **Dynamic OG page serving**: Added `serveOgPage()` function that fetches merger data from the assets store and returns an HTML response with appropriate cache headers
- **Request routing**: Modified the main `onRequest()` handler to intercept top-level merger page requests from bots and serve the dynamically generated OG page instead of the SPA's generic index.html
- **HTML escaping**: Added `escapeHtml()` utility function to safely escape special characters in merger data before inserting into HTML

## Implementation Details
- Bot detection uses a comprehensive regex pattern covering 20+ major social media crawlers and bots
- The OG page includes a JavaScript redirect to the canonical URL for non-bot browsers that might access it directly
- Responses are cached for 1 hour with appropriate security headers (`X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`)
- Only applies to top-level merger routes matching the pattern `/mergers/(MN|WA)-\d+`
- Gracefully falls through to normal SPA routing if merger data cannot be fetched

https://claude.ai/code/session_015pW1mKokc69CL6bETmxQiC