### PR TITLE
Reorder Analysis page sections: move Monthly Volume chart earlier

### DIFF
--- a/merger-tracker/frontend/src/pages/Analysis.jsx
+++ b/merger-tracker/frontend/src/pages/Analysis.jsx
@@ -317,6 +317,23 @@ function Analysis() {
           ))}
         </div>
 
+        {/* Monthly Volume */}
+        <div className="grid grid-cols-1 gap-6 mb-8">
+          <div className="bg-white rounded-2xl border border-gray-100 shadow-card overflow-hidden">
+            <div className="px-6 py-5 border-b border-gray-100">
+              <h2 className="text-base font-semibold text-gray-900">Monthly notification volume</h2>
+              <p className="text-sm text-gray-500 mt-0.5">
+                Number of merger notifications and waiver applications per month
+              </p>
+            </div>
+            <div className="p-6">
+              <div className="h-72">
+                <Bar data={monthlyVolumeData} options={monthlyVolumeOptions} />
+              </div>
+            </div>
+          </div>
+        </div>
+
         {/* Phase 1 Duration Analysis */}
         <section className="mb-8">
           <div className="bg-white rounded-2xl border border-gray-100 shadow-card overflow-hidden">
@@ -350,23 +367,6 @@ function Analysis() {
             </div>
           </div>
         </section>
-
-        {/* Monthly Volume */}
-        <div className="grid grid-cols-1 gap-6 mb-8">
-          <div className="bg-white rounded-2xl border border-gray-100 shadow-card overflow-hidden">
-            <div className="px-6 py-5 border-b border-gray-100">
-              <h2 className="text-base font-semibold text-gray-900">Monthly notification volume</h2>
-              <p className="text-sm text-gray-500 mt-0.5">
-                Number of merger notifications and waiver applications per month
-              </p>
-            </div>
-            <div className="p-6">
-              <div className="h-72">
-                <Bar data={monthlyVolumeData} options={monthlyVolumeOptions} />
-              </div>
-            </div>
-          </div>
-        </div>
 
       </div>
     </>


### PR DESCRIPTION
## Summary
Reordered the sections in the Analysis page to improve the logical flow of data visualization. The Monthly Volume chart now appears before the Phase 1 Duration Analysis section.

## Changes
- Moved the "Monthly notification volume" chart section to appear earlier in the page layout (after the initial charts and before Phase 1 Duration Analysis)
- No functional changes to the chart itself or its data/options
- Pure reorganization of component order for better UX flow

## Details
This change improves the narrative flow of the analysis dashboard by presenting the monthly volume trends before diving into phase-specific duration analysis. The Monthly Volume chart provides important context about notification frequency that logically precedes the detailed phase duration breakdown.

https://claude.ai/code/session_01LreAJXWnbBzCF7zhgkJ7gc