### PR TITLE
Add clarification note about waiver recording timing

### DIFF
--- a/merger-tracker/frontend/src/pages/Analysis.jsx
+++ b/merger-tracker/frontend/src/pages/Analysis.jsx
@@ -330,6 +330,9 @@ function Analysis() {
               <div className="h-72">
                 <Bar data={monthlyVolumeData} options={monthlyVolumeOptions} />
               </div>
+              <p className="text-xs text-gray-400 mt-3">
+                Waivers are recorded on the ACCC's register when they are decided. This means the number of waiver applications in a month can rise for up to 25 business days after the month ends.
+              </p>
             </div>
           </div>
         </div>
@@ -367,6 +370,7 @@ function Analysis() {
             </div>
           </div>
         </section>
+
 
       </div>
     </>


### PR DESCRIPTION
## Summary
Added an informational note below the monthly volume chart to clarify when waiver applications are recorded in the ACCC's register.

## Key Changes
- Added a disclaimer paragraph explaining that waivers are recorded when decided, not when applied
- Clarifies that waiver application counts can increase for up to 25 business days after a month ends
- Styled with small text and muted gray color to distinguish it as supplementary information

## Implementation Details
- The note is positioned directly below the Bar chart component using `mt-3` margin
- Uses Tailwind classes (`text-xs text-gray-400`) for consistent styling with the rest of the application
- Provides important context to users interpreting the monthly volume data

https://claude.ai/code/session_01STv8321rH6dmoNvWy8yPUq