### PR TITLE
Add Seismic-Highspot questionnaire data and improve parsing

### DIFF
--- a/data/output/mergers.json
+++ b/data/output/mergers.json
@@ -16070,6 +16070,7 @@
       "phase_2_determination_date": null,
       "public_benefits_determination": null,
       "public_benefits_determination_date": null,
+      "has_questionnaire": true,
       "similar_mergers": [
         {
           "merger_id": "MN-20009",

--- a/data/processed/questionnaire_data.json
+++ b/data/processed/questionnaire_data.json
@@ -2938,8 +2938,41 @@
     "deadline_iso": "2026-05-20",
     "file_name": "Seismic - Highspot - 3rd Party Questionnaire.pdf",
     "file_path": "matters/MN-75014/Seismic - Highspot - 3rd Party Questionnaire.pdf",
-    "questions": [],
-    "questions_count": 0
+    "questions": [
+      {
+        "number": 1,
+        "text": "Provide a brief description of your business or organisation, including any commercial relationships with Seismic and/or Highspot."
+      },
+      {
+        "number": 2,
+        "text": "Outline any concerns regarding the impact of the Acquisition on competition, including if Seismic and Highspot are close competitors (if so, for what products/services?) and whether there are many alternatives (if so, who are the main alternatives?)."
+      },
+      {
+        "number": 3,
+        "text": "If your organisation acquires, or has acquired, any sales enablement software products, provide a brief description of each product and the relevant supplier(s), their use cases (including if a full \u2018sales enablement platform\u2019 solution is or has been acquired), and identify which products are most important to your organisation."
+      },
+      {
+        "number": 4,
+        "text": "If your organisation acquires, or has acquired, sales enablement software products from Seismic or Highspot, list any features of Seismic or Highspot\u2019s products for which you consider there are no effective or limited substitutes available (e.g. due to cost, functionality or performance)."
+      },
+      {
+        "number": 5,
+        "text": "If you are a supplier of sales enablement software, to what extent do you compete with Seismic and/or Highspot, identifying the specific functions, sectors, services or use cases where you compete?"
+      },
+      {
+        "number": 6,
+        "text": "Describe any barriers to entry that exist for global sales enablement software suppliers looking to enter or expand into the supply of sales enablement software in Australia."
+      },
+      {
+        "number": 7,
+        "text": "How easy would it be for customers of sales enablement software to switch to an alternative supplier, in terms of time and cost?"
+      },
+      {
+        "number": 8,
+        "text": "Provide any additional information or comments that you consider relevant to the ACCC\u2019s assessment of the Acquisition."
+      }
+    ],
+    "questions_count": 8
   },
   "MN-75016": {
     "deadline": "6 May 2026",

--- a/merger-tracker/frontend/public/data/mergers/MN-75014.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-75014.json
@@ -75,6 +75,7 @@
   "phase_2_determination_date": null,
   "public_benefits_determination": null,
   "public_benefits_determination_date": null,
+  "has_questionnaire": true,
   "similar_mergers": [
     {
       "merger_id": "MN-20009",

--- a/merger-tracker/frontend/public/data/questionnaires/MN-75014.json
+++ b/merger-tracker/frontend/public/data/questionnaires/MN-75014.json
@@ -1,0 +1,40 @@
+{
+  "deadline": "20 May 2026",
+  "deadline_iso": "2026-05-20",
+  "file_name": "Seismic - Highspot - 3rd Party Questionnaire.pdf",
+  "questions": [
+    {
+      "number": 1,
+      "text": "Provide a brief description of your business or organisation, including any commercial relationships with Seismic and/or Highspot."
+    },
+    {
+      "number": 2,
+      "text": "Outline any concerns regarding the impact of the Acquisition on competition, including if Seismic and Highspot are close competitors (if so, for what products/services?) and whether there are many alternatives (if so, who are the main alternatives?)."
+    },
+    {
+      "number": 3,
+      "text": "If your organisation acquires, or has acquired, any sales enablement software products, provide a brief description of each product and the relevant supplier(s), their use cases (including if a full \u2018sales enablement platform\u2019 solution is or has been acquired), and identify which products are most important to your organisation."
+    },
+    {
+      "number": 4,
+      "text": "If your organisation acquires, or has acquired, sales enablement software products from Seismic or Highspot, list any features of Seismic or Highspot\u2019s products for which you consider there are no effective or limited substitutes available (e.g. due to cost, functionality or performance)."
+    },
+    {
+      "number": 5,
+      "text": "If you are a supplier of sales enablement software, to what extent do you compete with Seismic and/or Highspot, identifying the specific functions, sectors, services or use cases where you compete?"
+    },
+    {
+      "number": 6,
+      "text": "Describe any barriers to entry that exist for global sales enablement software suppliers looking to enter or expand into the supply of sales enablement software in Australia."
+    },
+    {
+      "number": 7,
+      "text": "How easy would it be for customers of sales enablement software to switch to an alternative supplier, in terms of time and cost?"
+    },
+    {
+      "number": 8,
+      "text": "Provide any additional information or comments that you consider relevant to the ACCC\u2019s assessment of the Acquisition."
+    }
+  ],
+  "questions_count": 8
+}

--- a/scripts/parse_questionnaire.py
+++ b/scripts/parse_questionnaire.py
@@ -271,8 +271,13 @@ def extract_questions(lines: List[Dict]) -> List[Dict[str, str]]:
         text = line['text']
         is_bold = line['is_bold']
 
-        # Stop if we hit certain keywords that indicate end of questions section
-        if re.match(r'^(Confidentiality|Note:|Please note)', text, re.IGNORECASE):
+        # Stop if we hit certain keywords that indicate end of questions section.
+        # Only stop once we've seen at least one question so preamble notes
+        # (e.g. a "Note:" paragraph between the "Questions" heading and Q1)
+        # don't abort parsing before any questions are captured.
+        if (questions or current_question_num is not None) and re.match(
+            r'^(Confidentiality|Note:|Please note)', text, re.IGNORECASE
+        ):
             break
 
         # Skip lines that fall inside a detected table region. Save the current


### PR DESCRIPTION
## Summary
This PR adds the questionnaire data for the Seismic-Highspot merger (MN-75014) and improves the questionnaire parsing logic to handle preamble notes that appear before the first question.

## Key Changes
- **Added questionnaire data**: Created `MN-75014.json` with 8 questions from the Seismic-Highspot 3rd Party Questionnaire
- **Updated questionnaire database**: Populated the previously empty questions array in `questionnaire_data.json` for MN-75014
- **Improved parsing logic**: Modified `parse_questionnaire.py` to only stop parsing when encountering end-of-section keywords (like "Note:", "Confidentiality") after at least one question has been captured. This prevents preamble notes between the "Questions" heading and Q1 from prematurely terminating the parsing
- **Updated merger metadata**: Added `has_questionnaire: true` flag to both the main mergers database and the MN-75014 merger record

## Implementation Details
The key improvement in the parsing script ensures that introductory notes or instructions that appear before the first question don't cause the parser to exit early. The condition now checks `(questions or current_question_num is not None)` before applying the end-of-section keyword matching, allowing the parser to skip preamble content while still capturing all actual questions.

https://claude.ai/code/session_01CmKPPjFyj9XQ4DBmmeWY43