### PR TITLE
Replace emoji icons with Font Awesome icons in Dashboard

### DIFF
--- a/merger-tracker/frontend/src/components/StatCard.jsx
+++ b/merger-tracker/frontend/src/components/StatCard.jsx
@@ -12,7 +12,7 @@ function StatCard({ title, value, subtitle, icon, href }) {
       <div className="p-6">
         <div className="flex items-start gap-4">
           {icon && (
-            <div className="flex-shrink-0 w-11 h-11 rounded-xl bg-primary/10 flex items-center justify-center text-xl group-hover:scale-105 transition-transform duration-200">
+            <div className="flex-shrink-0 w-11 h-11 rounded-xl bg-primary/10 flex items-center justify-center text-xl text-primary group-hover:scale-105 transition-transform duration-200">
               {icon}
             </div>
           )}

--- a/merger-tracker/frontend/src/pages/Dashboard.jsx
+++ b/merger-tracker/frontend/src/pages/Dashboard.jsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
+import { FaMagnifyingGlass, FaStopwatch, FaChartLine } from 'react-icons/fa6';
 import { Doughnut } from 'react-chartjs-2';
 import StatusBadge from '../components/StatusBadge';
 import NewBadge from '../components/NewBadge';
@@ -135,7 +136,7 @@ function Dashboard() {
           title="Mergers"
           value={`${stats.by_status['Under assessment'] || 0} under assessment`}
           subtitle={`${stats.total_mergers} notified${stats.total_waivers ? ` and ${stats.total_waivers} waiver${stats.total_waivers !== 1 ? 's' : ''}` : ''}`}
-          icon="🔍"
+          icon={<FaMagnifyingGlass />}
           href="/mergers?status=Under assessment"
         />
         <StatCard
@@ -150,7 +151,7 @@ function Dashboard() {
               ? `${Math.round(stats.phase_duration.average_days)} calendar days`
               : null
           }
-          icon="⏱️"
+          icon={<FaStopwatch />}
         />
         <StatCard
           title="Median phase 1 duration"
@@ -164,7 +165,7 @@ function Dashboard() {
               ? `${stats.phase_duration.median_days} calendar days`
               : null
           }
-          icon="📈"
+          icon={<FaChartLine />}
         />
       </div>
 


### PR DESCRIPTION
## Summary
Replaced emoji icons with Font Awesome React icons (fa6) in the Dashboard component for a more consistent and professional appearance.

## Key Changes
- Imported `FaMagnifyingGlass`, `FaStopwatch`, and `FaChartLine` from `react-icons/fa6`
- Updated three StatCard instances to use Font Awesome icons instead of emoji:
  - "Mergers" card: `🔍` → `<FaMagnifyingGlass />`
  - "Average phase 1 duration" card: `⏱️` → `<FaStopwatch />`
  - "Median phase 1 duration" card: `📈` → `<FaChartLine />`
- Added `text-primary` class to the icon container in StatCard to ensure proper color styling for the new SVG icons

## Implementation Details
The emoji icons were replaced with their Font Awesome equivalents to maintain visual consistency with the design system. The `text-primary` class was added to the icon wrapper to ensure the SVG icons inherit the correct color styling, matching the appearance of the previous emoji implementation.

https://claude.ai/code/session_01HG4nY8FMZTXpUHYsNYjQiB