### PR TITLE
Add --autostash flag to git pull --rebase in pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -239,7 +239,7 @@ jobs:
               echo "Only acquisitions-register.html staged — skipping commit"
             else
               git commit -m "Update merger data: ${timestamp}"
-              git pull --rebase || { git rebase --abort; exit 1; }
+              git pull --rebase --autostash || { git rebase --abort; exit 1; }
 
               # After rebase, re-clean any HTML files that changed. A 3-way merge
               # during rebase can reintroduce raw dynamic tokens if both the local


### PR DESCRIPTION
## Summary
Updated the git pull command in the CI pipeline to include the `--autostash` flag, which automatically stashes and reapplies uncommitted changes during rebase operations.

## Key Changes
- Modified the `git pull --rebase` command to `git pull --rebase --autostash` in the merger data update workflow step
- This prevents rebase failures when there are uncommitted changes in the working directory

## Implementation Details
The `--autostash` flag ensures that any uncommitted changes are temporarily stashed before the rebase begins and automatically reapplied afterward. This makes the pipeline more resilient to edge cases where the working directory might have unstaged modifications, reducing the likelihood of rebase failures and improving the overall reliability of the automated merger data update process.

https://claude.ai/code/session_01SL1vNdPPvvEtcr5AYcsihY