### PR TITLE
Enable feedback popup and launch new campaign v3

### DIFF
--- a/merger-tracker/frontend/src/components/FeedbackPopup.jsx
+++ b/merger-tracker/frontend/src/components/FeedbackPopup.jsx
@@ -3,13 +3,13 @@ import { FaTimes } from 'react-icons/fa';
 import { Link } from 'react-router-dom';
 
 // Set to false to hide the popup entirely (e.g. between feedback campaigns).
-const ENABLED = false;
+const ENABLED = true;
 
 // Set to false to suppress the popup on mobile screens (< 768px).
 const SHOW_ON_MOBILE = false;
 
 // Bump this string to resurface the popup for everyone who dismissed a previous campaign.
-const CAMPAIGN = 'v2';
+const CAMPAIGN = 'v3';
 const STORAGE_KEY = `feedback_dismissed_${CAMPAIGN}`;
 const SHOW_DELAY_MS = 10_000;
 


### PR DESCRIPTION
## Summary
This PR re-enables the feedback popup component and launches a new feedback campaign to resurface the popup for all users.

## Key Changes
- Enabled the feedback popup by setting `ENABLED` to `true` (was previously disabled)
- Bumped the campaign version from `v2` to `v3` to reset dismissal state and resurface the popup for all users who previously dismissed earlier campaign versions

## Implementation Details
The feedback popup uses a campaign versioning system to manage user dismissals. By incrementing the `CAMPAIGN` constant, the `STORAGE_KEY` changes, which effectively clears the dismissal state for all users. This allows the popup to be shown again to users who had previously dismissed it under the `v2` campaign.

https://claude.ai/code/session_01PrUCmq3k9ERiyxk1GBrKcA