### PR TITLE
Replace span elements with div elements in email header

### DIFF
--- a/scripts/send_weekly_email.py
+++ b/scripts/send_weekly_email.py
@@ -537,20 +537,19 @@ def build_html_email(digest: dict) -> str:
         <!-- HEADER -->
         <tr>
           <td style="background:#ffffff;border:1px solid #e5e7eb;border-bottom:none;border-radius:12px 12px 0 0;padding:26px 28px 22px;">
-            <span style="font-size:18px;letter-spacing:-0.3px;">
+            <div style="font-size:18px;letter-spacing:-0.3px;">
               <span style="font-weight:700;color:#335145;">australian merger tracker</span><span style="font-weight:400;color:#335145;"> weekly digest</span>
-            </span>
-            <br>
-            <span style="font-size:13px;color:#6b7280;margin-top:6px;display:block;">
+            </div>
+            <div style="font-size:13px;color:#6b7280;margin-top:6px;">
               Week of {esc(date_range)}
               &nbsp;&middot;&nbsp;
               <a href="{SITE_BASE}/digest" style="color:#335145;text-decoration:underline;">
                 View online
               </a>
-            </span>
-            <span style="font-size:13px;color:#6b7280;margin-top:4px;display:block;font-style:italic;">
+            </div>
+            <div style="font-size:13px;color:#6b7280;margin-top:4px;font-style:italic;">
               {header_cta}
-            </span>
+            </div>
           </td>
         </tr>
 


### PR DESCRIPTION
## Summary
Updated the HTML email header structure to use semantic `<div>` elements instead of `<span>` elements for better markup semantics and maintainability.

## Key Changes
- Replaced three `<span>` elements with `<div>` elements in the email header section
- Removed unnecessary `<br>` tag between header title and subtitle
- Removed redundant `display:block;` CSS properties from spans (divs are block-level by default)
- Maintained all existing styling and functionality through CSS properties

## Implementation Details
- The change improves semantic HTML by using block-level elements (`<div>`) for content that is logically grouped and displayed as blocks
- All inline styles remain unchanged to preserve the visual appearance
- The `margin-top` properties on the subtitle and CTA sections now work more predictably with block-level elements
- No functional changes to the email output, only structural improvements to the underlying HTML

https://claude.ai/code/session_017ij1vQ4pgVHNp6GVHoMze6