### PR TITLE
Set schedule for weekly digest email

### DIFF
--- a/.github/workflows/send-weekly-email.yml
+++ b/.github/workflows/send-weekly-email.yml
@@ -5,7 +5,6 @@ on:
     # Monday 9:26 AM Sydney time
     - cron: '26 9 * * 1'
       timezone: 'Australia/Sydney'
-
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/send-weekly-email.yml
+++ b/.github/workflows/send-weekly-email.yml
@@ -1,10 +1,11 @@
 name: Send Weekly Digest Email
 
 on:
-  #schedule:
-  #  # Monday 9 AM AEST (Sunday 11 PM UTC)
-  #  # Runs ~1 hour after the digest.json is generated and pushed by weekly-digest.yml
-  #  - cron: '0 23 * * 0'
+  schedule:
+    # Monday 9:26 AM Sydney time
+    - cron: '26 9 * * 1'
+      timezone: 'Australia/Sydney'
+
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/weekly-digest.yml
+++ b/.github/workflows/weekly-digest.yml
@@ -2,10 +2,10 @@ name: Generate Weekly Digest
 
 on:
   schedule:
-    # Run every Sunday at 8 AM AEST (Saturday 10 PM UTC)
-    # Note: During AEDT (daylight saving), this will be 9 AM
-    - cron: '0 22 * * 6'
-  workflow_dispatch:  # Allow manual trigger
+    # Run every Sunday at 8:36 AM Sydney time
+    - cron: '36 8 * * 0'
+      timezone: 'Australia/Sydney'
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Updated the schedule for the weekly digest email to run at 9:26 AM Sydney time on Mondays.