### PR TITLE
Inline CLI SQLite publishing into pipeline workflow

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -224,6 +224,7 @@ jobs:
       # --- Single commit ---
 
       - name: Commit all changes
+        id: commit
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -279,9 +280,67 @@ jobs:
                 git reset --hard HEAD^
               else
                 git push
+                # Flag downstream cli-sqlite publish if cli-bundle.json is in
+                # the pushed commit. Pushes from GITHUB_TOKEN don't fire other
+                # workflows, so we publish inline rather than relying on a
+                # paths-filtered push trigger on publish-cli-sqlite.yml.
+                if git diff HEAD^..HEAD --name-only \
+                    | grep -qx "data/output/cli/cli-bundle.json"; then
+                  echo "publish_cli=true" >> "$GITHUB_OUTPUT"
+                fi
               fi
             fi
           fi
+
+      # --- Publish cli.sqlite to the cli-dist orphan branch ---
+      # Inlined here (rather than a separate workflow triggered by push to
+      # cli-bundle.json) because pushes from the default GITHUB_TOKEN do not
+      # fire downstream workflow runs.
+
+      - name: Build CLI SQLite
+        if: steps.commit.outputs.publish_cli == 'true'
+        run: |
+          mkdir -p "${RUNNER_TEMP}/cli-dist"
+          python scripts/build_cli_sqlite.py \
+            --bundle data/output/cli/cli-bundle.json \
+            --output-dir "${RUNNER_TEMP}/cli-dist"
+          echo "--- Manifest ---"
+          cat "${RUNNER_TEMP}/cli-dist/cli-manifest.json"
+
+      - name: Force-push cli.sqlite to cli-dist branch
+        if: steps.commit.outputs.publish_cli == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          work="${RUNNER_TEMP}/cli-dist-publish"
+          mkdir -p "$work"
+          cp "${RUNNER_TEMP}/cli-dist/cli.sqlite" "$work/cli.sqlite"
+          cp "${RUNNER_TEMP}/cli-dist/cli-manifest.json" "$work/cli-manifest.json"
+
+          cd "$work"
+          git init -q -b cli-dist
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          version=$(python -c 'import json; print(json.load(open("cli-manifest.json"))["version"])')
+
+          git add cli.sqlite cli-manifest.json
+          git commit -q -m "Publish cli.sqlite (data version ${version})"
+
+          remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          for attempt in 1 2 3 4; do
+            if git push --force "$remote" HEAD:cli-dist; then
+              echo "Push succeeded on attempt ${attempt}"
+              break
+            fi
+            if [ "$attempt" -eq 4 ]; then
+              echo "Push failed after 4 attempts" >&2
+              exit 1
+            fi
+            sleep $((2 ** attempt))
+          done
 
       # --- Open GitHub issues for auto-fixed questionnaire dates ---
       # The extraction script writes missing_questionnaire_dates.json when it

--- a/.github/workflows/publish-cli-sqlite.yml
+++ b/.github/workflows/publish-cli-sqlite.yml
@@ -1,20 +1,21 @@
 name: Publish CLI SQLite
 
-# Builds cli.sqlite + cli-manifest.json from the latest cli-bundle.json on
-# main and force-pushes them to the orphan `cli-dist` branch. The
-# accc-mergers-cli reads those two files directly from raw.githubusercontent.com:
+# Manual republish of cli.sqlite + cli-manifest.json from the latest
+# cli-bundle.json on main, force-pushed to the orphan `cli-dist` branch.
+# The accc-mergers-cli reads those two files directly from
+# raw.githubusercontent.com:
 #
 #   https://raw.githubusercontent.com/nwbort/accc-mergers/cli-dist/cli-manifest.json
 #   https://raw.githubusercontent.com/nwbort/accc-mergers/cli-dist/cli.sqlite
 #
 # The SQLite binary lives only on the orphan branch so it doesn't bloat the
 # main history. Each run replaces the branch with a fresh single commit.
+#
+# Routine publishes happen inline at the end of pipeline.yml whenever a
+# pipeline run pushes a change to cli-bundle.json. This workflow exists for
+# manual republishes (e.g. after a schema change in build_cli_sqlite.py).
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - data/output/cli/cli-bundle.json
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
Moved CLI SQLite publishing logic from a separate triggered workflow into the main pipeline workflow. This change addresses the limitation that pushes from the default `GITHUB_TOKEN` do not trigger downstream workflow runs.

## Key Changes
- Added `id: commit` to the "Commit all changes" step to enable output capture
- Implemented inline detection of `cli-bundle.json` changes in the commit and set `publish_cli` output flag when detected
- Added two new steps to pipeline.yml:
  - "Build CLI SQLite": Runs `build_cli_sqlite.py` to generate `cli.sqlite` and `cli-manifest.json`
  - "Force-push cli.sqlite to cli-dist branch": Publishes the built artifacts to the orphan `cli-dist` branch with retry logic (up to 4 attempts with exponential backoff)
- Converted `publish-cli-sqlite.yml` from an automatic push-triggered workflow to a manual-only workflow (`workflow_dispatch`)
- Updated documentation in `publish-cli-sqlite.yml` to clarify that routine publishes now happen inline during pipeline runs, with this workflow reserved for manual republishes (e.g., after schema changes)

## Implementation Details
- The inline publishing only executes when `cli-bundle.json` is detected in the pushed commit, avoiding unnecessary work on other changes
- Uses `git diff HEAD^..HEAD --name-only` with grep to detect the specific file change
- Implements retry logic with exponential backoff (2^attempt seconds) to handle potential race conditions when force-pushing to the orphan branch
- Extracts version information from the generated `cli-manifest.json` for the commit message

https://claude.ai/code/session_014RGJyzeqULvLct6koRszrx