### PR TITLE
Update workflow timestamps to use Australia/Sydney timezone

### DIFF
--- a/.github/workflows/extract.yml
+++ b/.github/workflows/extract.yml
@@ -47,7 +47,7 @@ jobs:
             data/processed/similar_mergers.json \
             data/raw/matters/ merger-tracker/frontend/public/data/ \
             merger-tracker/frontend/public/feed.xml data/output/
-          timestamp=$(date -u)
+          timestamp=$(TZ='Australia/Sydney' date)
           git diff --staged --quiet || true
           git commit -m "Update scraped data and static files: ${timestamp}" || exit 0
           git pull --rebase || { git rebase --abort; exit 1; }

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -228,7 +228,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          timestamp=$(date -u)
+          timestamp=$(TZ='Australia/Sydney' date)
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -44,7 +44,7 @@ jobs:
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git add -A
-        timestamp=$(date -u)
+        timestamp=$(TZ='Australia/Sydney' date)
         git diff --staged --quiet || true
         git commit -m "Update scraped data: ${timestamp}" || exit 0
         git pull --rebase || { git rebase --abort; exit 1; }


### PR DESCRIPTION
## Summary
Updated all GitHub Actions workflow files to generate commit timestamps in the Australia/Sydney timezone instead of UTC.

## Key Changes
- Modified `.github/workflows/extract.yml`: Changed timestamp generation from `date -u` to `TZ='Australia/Sydney' date`
- Modified `.github/workflows/pipeline.yml`: Changed timestamp generation from `date -u` to `TZ='Australia/Sydney' date`
- Modified `.github/workflows/scrape.yml`: Changed timestamp generation from `date -u` to `TZ='Australia/Sydney' date`

## Implementation Details
All three workflow files that generate automated commit messages now use the `TZ` environment variable to set the timezone to Australia/Sydney before calling the `date` command. This ensures that commit timestamps in the repository reflect the local timezone rather than UTC, making them more aligned with the project's operational timezone.

https://claude.ai/code/session_01HwMRBtz728GDjn6qX2hsii