### PR TITLE
Remove frozen events entry for MN-75018

### DIFF
--- a/data/frozen_events_mergers.json
+++ b/data/frozen_events_mergers.json
@@ -1,7 +1,3 @@
 {
   "_comment": "Override data for specific mergers. An entry with an empty dict or 'freeze_events: true' preserves the existing events array rather than overwriting from the scraped page (use this when the ACCC events table is incorrect). Any other keys are treated as field overrides — the scraper will use these values instead of whatever it finds on the page.",
-  "MN-75018": {
-    "_comment": "Questionnaire event date (6 May 2026) is missing from the ACCC page; freezing events to preserve the manually set date.",
-    "freeze_events": true
-  }
 }


### PR DESCRIPTION
Removed the entry for MN-75018 that froze events to preserve a manually set date.