### PR TITLE
fix: remove trailing comma from frozen_events_mergers.json

### DIFF
--- a/data/frozen_events_mergers.json
+++ b/data/frozen_events_mergers.json
@@ -1,3 +1,3 @@
 {
-  "_comment": "Override data for specific mergers. An entry with an empty dict or 'freeze_events: true' preserves the existing events array rather than overwriting from the scraped page (use this when the ACCC events table is incorrect). Any other keys are treated as field overrides — the scraper will use these values instead of whatever it finds on the page.",
+  "_comment": "Override data for specific mergers. An entry with an empty dict or 'freeze_events: true' preserves the existing events array rather than overwriting from the scraped page (use this when the ACCC events table is incorrect). Any other keys are treated as field overrides — the scraper will use these values instead of whatever it finds on the page."
 }


### PR DESCRIPTION
The file had a trailing comma after the _comment property value, which
is invalid JSON and caused the enrich pipeline to crash when loading the file.

https://claude.ai/code/session_01Ssy359q8mWE9p6PUhoRYn5