### PR TITLE
Replace duplicate-events issues workflow with auto-fixing PR

### DIFF
--- a/.github/workflows/detect-duplicates.yml
+++ b/.github/workflows/detect-duplicates.yml
@@ -7,8 +7,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write   # needed to push the fix branch
-  issues: write
+  contents: write        # needed to push the fix branch
+  pull-requests: write   # needed to create / update the fix PR
 
 jobs:
   detect:
@@ -42,110 +42,75 @@ jobs:
         run: |
           python3 scripts/detect_duplicates.py >> "$GITHUB_STEP_SUMMARY" || true
 
-      - name: Ensure label exists
-        if: steps.detect.outputs.found == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh label create "duplicate-events" \
-            --description "Duplicate events detected in merger data" \
-            --color "e4e669" \
-            --force
-
-      # Push (or reset) a single well-known fix branch so there is always
-      # exactly one place to make edits.  The branch points to the current
-      # HEAD of the default branch, giving reviewers a clean diff baseline.
+      # Switch to (or create/reset) the well-known fix branch so the commit
+      # lands on top of the current default-branch HEAD.
       - name: Create or reset fix branch
         id: branch
         if: steps.detect.outputs.found == 'true'
         run: |
           BRANCH="fix/duplicate-events"
-          git push origin "HEAD:refs/heads/$BRANCH" --force
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git switch -C "$BRANCH"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 
-      - name: Generate issue content
+      - name: Apply duplicate fixes
         if: steps.detect.outputs.found == 'true'
         run: |
           python3 scripts/detect_duplicates.py \
-            --issues-json issue_content.json \
-            --branch "${{ steps.branch.outputs.branch }}" || true
+            --apply-fixes \
+            --pr-markdown pr_body.md || true
 
-      # Close any open issues from a previous run before creating fresh ones.
-      # This keeps the issue list clean and ensures sub-issue bodies reflect
-      # the current state of the data.
-      - name: Close stale duplicate-events issues
+      - name: Commit and push fix branch
+        id: commit
         if: steps.detect.outputs.found == 'true'
+        run: |
+          BRANCH="${{ steps.branch.outputs.branch }}"
+          if git diff --quiet data/processed/mergers.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            git add data/processed/mergers.json
+            git commit -m "fix: remove duplicate events detected on $(date -u +%Y-%m-%d)"
+            git push origin "$BRANCH" --force
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create or update pull request
+        if: steps.detect.outputs.found == 'true' && steps.commit.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh issue list \
-            --label "duplicate-events" \
+          BRANCH="${{ steps.branch.outputs.branch }}"
+          TITLE="fix: remove duplicate events ($(date -u +%Y-%m-%d))"
+
+          EXISTING=$(gh pr list \
+            --head "$BRANCH" \
             --state open \
             --json number \
-            --jq '.[].number' | \
-          while read -r num; do
-            gh issue close "$num" \
-              --comment "Superseded by a new detection run — closing to recreate with updated details." \
-              || true
-          done
+            --jq '.[0].number' 2>/dev/null || echo "")
 
-      # Create one sub-issue per affected merger, then a parent issue that
-      # links them all.  Sub-issues are attached via the GitHub REST API.
-      - name: Create sub-issues and main issue
-        if: steps.detect.outputs.found == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          SUB_IDS=""
-          COUNT=$(jq '.sub_issues | length' issue_content.json)
+          if [ -n "$EXISTING" ]; then
+            gh pr edit "$EXISTING" --title "$TITLE" --body-file pr_body.md
+            echo "Updated PR #$EXISTING"
+          else
+            gh pr create \
+              --head "$BRANCH" \
+              --title "$TITLE" \
+              --body-file pr_body.md
+          fi
 
-          for i in $(seq 0 $((COUNT - 1))); do
-            TITLE=$(jq -r ".sub_issues[$i].title" issue_content.json)
-            # Use gh api directly so the response is JSON with both .id and
-            # .number in one call — no URL-parsing and no second lookup.
-            RESULT=$(jq -n \
-              --argjson idx "$i" \
-              --slurpfile data issue_content.json \
-              '{"title": $data[0].sub_issues[$idx].title,
-                "body":  $data[0].sub_issues[$idx].body,
-                "labels": ["duplicate-events"]}' | \
-              gh api "repos/$GITHUB_REPOSITORY/issues" \
-                --method POST --input -)
-            NUM=$(echo "$RESULT" | jq -r '.number')
-            ID=$(echo "$RESULT" | jq -r '.id')
-            SUB_IDS="$SUB_IDS $ID"
-            echo "Created sub-issue #$NUM (id=$ID): $TITLE"
-          done
-
-          MAIN_RESULT=$(jq -n \
-            --slurpfile data issue_content.json \
-            '{"title": $data[0].main_issue.title,
-              "body":  $data[0].main_issue.body,
-              "labels": ["duplicate-events"]}' | \
-            gh api "repos/$GITHUB_REPOSITORY/issues" \
-              --method POST --input -)
-          MAIN_NUM=$(echo "$MAIN_RESULT" | jq -r '.number')
-          echo "Created main issue #$MAIN_NUM"
-
-          for SUB_ID in $SUB_IDS; do
-            gh api "repos/$GITHUB_REPOSITORY/issues/$MAIN_NUM/sub_issues" \
-              --method POST \
-              -F sub_issue_id="$SUB_ID" \
-              || echo "Warning: could not attach sub-issue id=$SUB_ID (feature may not be enabled on this repo)"
-          done
-
-      - name: Close all duplicate-events issues when resolved
+      - name: Close fix PR when no duplicates remain
         if: steps.detect.outputs.found == 'false'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh issue list \
-            --label "duplicate-events" \
+          gh pr list \
+            --head "fix/duplicate-events" \
             --state open \
             --json number \
             --jq '.[].number' | \
           while read -r num; do
-            gh issue close "$num" \
+            gh pr close "$num" \
               --comment "All duplicate events resolved as of $(date -u +%Y-%m-%d). Closing automatically." \
               || true
           done

--- a/scripts/detect_duplicates.py
+++ b/scripts/detect_duplicates.py
@@ -360,6 +360,89 @@ def _build_main_issue_body(report: dict, branch: str, date: str) -> str:
     return "\n".join(out)
 
 
+def apply_fixes(mergers: list[dict], report: dict) -> list[dict]:
+    """Remove the suggested-deletion event from each duplicate group in-place.
+
+    Deletes the highest-index event first within each merger so that earlier
+    indices remain valid after each pop.  Returns a list of change records.
+    """
+    merger_map = {m.get("merger_id"): m for m in mergers}
+    changes: list[dict] = []
+
+    for entry in report["findings"]:
+        merger_id = entry["merger_id"]
+        merger = merger_map.get(merger_id)
+        if merger is None:
+            continue
+        events = merger.get("events", [])
+
+        targets: list[tuple[int, str, str, str]] = []
+        for g in entry["duplicate_groups"]:
+            del_idx, reason = suggest_deletion(g)
+            targets.append((del_idx, reason, g["kind"], g["date"]))
+
+        targets.sort(key=lambda x: x[0], reverse=True)
+
+        for del_idx, reason, kind, date in targets:
+            if del_idx >= len(events):
+                continue
+            deleted = events.pop(del_idx)
+            changes.append({
+                "merger_id": merger_id,
+                "merger_name": entry["merger_name"],
+                "deleted_index": del_idx,
+                "kind": kind,
+                "date": date,
+                "title": deleted.get("title", ""),
+                "reason": reason,
+            })
+
+    return changes
+
+
+def build_pr_body(changes: list[dict], report: dict, date: str) -> str:
+    """Build a markdown PR body summarising the auto-applied fixes."""
+    s = report["summary"]
+    lines = [
+        f"Duplicate events were automatically detected and removed on **{date}**.",
+        "",
+        f"**{s['mergers_with_duplicates']} merger(s) affected · "
+        f"{s['certain_duplicate_groups']} certain · "
+        f"{s['likely_duplicate_groups']} likely duplicate group(s)**",
+        "",
+        "---",
+        "",
+        "## Changes",
+        "",
+    ]
+
+    for entry in report["findings"]:
+        mid = entry["merger_id"]
+        name = entry["merger_name"]
+        merger_changes = [c for c in changes if c["merger_id"] == mid]
+        if not merger_changes:
+            continue
+        fyi_url = mergers_fyi_url(mid)
+        lines.append(f"### [{mid}]({fyi_url}) — {name}")
+        lines.append("")
+        for c in merger_changes:
+            kind_tag = "CERTAIN" if c["kind"] == "certain" else "LIKELY"
+            lines.append(
+                f"- Removed `event[{c['deleted_index']}]` ({kind_tag} duplicate on {c['date']}): "
+                f"**{c['title']}** — _{c['reason']}_"
+            )
+        lines.append("")
+
+    lines.extend([
+        "---",
+        "",
+        f"*Generated automatically by the [Detect Duplicate Events]"
+        f"(https://github.com/{_REPO}/actions/workflows/detect-duplicates.yml) workflow.*",
+    ])
+
+    return "\n".join(lines)
+
+
 def build_issues_data(report: dict, input_path: Path, branch: str, date: str) -> dict:
     """
     Build structured data for GitHub issue creation:
@@ -423,6 +506,20 @@ def main() -> None:
         dest="issues_json",
         help="Write structured issue data (main issue + per-merger sub-issues) to this JSON file",
     )
+    parser.add_argument(
+        "--apply-fixes",
+        action="store_true",
+        dest="apply_fixes",
+        help="Apply suggested deletions to the input file in-place",
+    )
+    parser.add_argument(
+        "--pr-markdown",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        dest="pr_markdown",
+        help="Write a PR body (markdown) summarising the applied fixes to this file",
+    )
     args = parser.parse_args()
 
     if not args.input.exists():
@@ -455,6 +552,21 @@ def main() -> None:
         with args.issues_json.open("w") as fh:
             json.dump(issues_data, fh, indent=2)
         print(f"Issue data written to {args.issues_json}", file=sys.stderr)
+
+    if args.apply_fixes or args.pr_markdown:
+        changes = apply_fixes(mergers, report)
+        if args.apply_fixes:
+            with args.input.open("w") as fh:
+                json.dump(raw, fh, indent=2)
+                fh.write("\n")
+            print(f"Applied {len(changes)} deletion(s) to {args.input}", file=sys.stderr)
+        if args.pr_markdown:
+            today = datetime.utcnow().strftime("%Y-%m-%d")
+            pr_body = build_pr_body(changes, report, today)
+            args.pr_markdown.parent.mkdir(parents=True, exist_ok=True)
+            with args.pr_markdown.open("w") as fh:
+                fh.write(pr_body)
+            print(f"PR body written to {args.pr_markdown}", file=sys.stderr)
 
     # Exit with a non-zero code if any duplicates were found (useful in CI)
     total = (


### PR DESCRIPTION
## Summary
Refactored the duplicate events detection workflow to automatically apply fixes via pull requests instead of creating GitHub issues. This provides a more direct path to resolution while maintaining visibility and review capability.

## Key Changes

**Workflow Changes (`detect-duplicates.yml`)**
- Updated permissions: replaced `issues: write` with `pull-requests: write` to enable PR creation/updates
- Removed issue-based workflow steps:
  - Label creation and management
  - Issue creation (main and sub-issues)
  - Issue closing logic
- Implemented PR-based workflow:
  - Create or reset a well-known `fix/duplicate-events` branch locally
  - Apply fixes directly to `data/processed/mergers.json`
  - Commit and push changes to the fix branch
  - Create or update a single PR with the changes
  - Close the PR when no duplicates remain

**Script Changes (`detect_duplicates.py`)**
- Added `apply_fixes()` function: removes suggested-deletion events from duplicate groups in-place, processing highest indices first to maintain valid indices
- Added `build_pr_body()` function: generates markdown PR description summarizing applied fixes with merger details and change records
- Added CLI arguments:
  - `--apply-fixes`: enables in-place modification of the input JSON file
  - `--pr-markdown`: outputs PR body to a markdown file
- Updated `main()` to handle the new fix-application workflow

## Notable Implementation Details

- The fix branch is created/reset locally and pushed with `--force` to ensure a clean baseline for reviewers
- Changes are only committed if the data file actually changed (checked via `git diff`)
- The PR is created or updated based on whether one already exists for the branch, avoiding duplicate PRs
- Deletion targets are sorted in reverse index order before removal to prevent index shifting issues
- PR body includes summary statistics and detailed per-merger change records with deletion reasons

https://claude.ai/code/session_01T3k31pYmAta6Ce8YG1WPge