### PR TITLE
Extend auto-fix to handle remedy offer events with missing dates

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -342,39 +342,39 @@ jobs:
             sleep $((2 ** attempt))
           done
 
-      # --- Open GitHub issues for auto-fixed questionnaire dates ---
-      # The extraction script writes missing_questionnaire_dates.json when it
-      # auto-sets a date.  We create one issue per affected merger so the owner
-      # can confirm the date is correct and close the issue when happy.
+      # --- Open GitHub issues for auto-fixed event dates ---
+      # The extraction script writes missing_event_dates.json when it auto-sets
+      # a date on a catchable event (questionnaire, remedy offer, etc.).
+      # We create one issue per affected merger so the owner can confirm the date.
 
-      - name: Create issues for auto-fixed questionnaire dates
+      - name: Create issues for auto-fixed event dates
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if [ ! -f data/processed/missing_questionnaire_dates.json ]; then
-            echo "No missing questionnaire dates to report"
+          if [ ! -f data/processed/missing_event_dates.json ]; then
+            echo "No missing event dates to report"
             exit 0
           fi
 
-          COUNT=$(jq '.issues | length' data/processed/missing_questionnaire_dates.json)
+          COUNT=$(jq '.issues | length' data/processed/missing_event_dates.json)
           if [ "$COUNT" -eq 0 ]; then
             echo "No issues to create"
             exit 0
           fi
 
-          echo "Creating $COUNT issue(s) for missing questionnaire dates..."
+          echo "Creating $COUNT issue(s) for missing event dates..."
 
-          gh label create "missing-questionnaire-date" \
-            --description "Questionnaire date was missing; auto-set by pipeline" \
+          gh label create "missing-event-date" \
+            --description "Event date was missing; auto-set by pipeline" \
             --color "e4e669" \
             --force
 
           for i in $(seq 0 $((COUNT - 1))); do
-            MERGER_ID=$(jq -r ".issues[$i].merger_id" data/processed/missing_questionnaire_dates.json)
+            MERGER_ID=$(jq -r ".issues[$i].merger_id" data/processed/missing_event_dates.json)
 
             # Skip if an open issue already exists for this merger (idempotent guard)
             EXISTING=$(gh issue list \
-              --label "missing-questionnaire-date" \
+              --label "missing-event-date" \
               --state open \
               --json title \
               --jq '.[].title' | grep "$MERGER_ID" || true)
@@ -383,13 +383,13 @@ jobs:
               continue
             fi
 
-            TITLE=$(jq -r ".issues[$i].title" data/processed/missing_questionnaire_dates.json)
+            TITLE=$(jq -r ".issues[$i].title" data/processed/missing_event_dates.json)
             jq -n \
               --argjson idx "$i" \
-              --slurpfile data data/processed/missing_questionnaire_dates.json \
+              --slurpfile data data/processed/missing_event_dates.json \
               '{"title": $data[0].issues[$idx].title,
                 "body":  $data[0].issues[$idx].body,
-                "labels": ["missing-questionnaire-date"]}' | \
+                "labels": ["missing-event-date"]}' | \
             gh api "repos/$GITHUB_REPOSITORY/issues" \
               --method POST --input -
             echo "Created issue: $TITLE"

--- a/data/frozen_events_mergers.json
+++ b/data/frozen_events_mergers.json
@@ -7,5 +7,9 @@
   "MN-05014": {
     "_comment": "Questionnaire event date (27 May 2026) is missing from the ACCC page; freezing events to preserve the automatically set date.",
     "freeze_events": true
+  },
+  "MN-50009": {
+    "_comment": "Remedy offer event date (28 May 2026) was missing from ACCC page; freezing events to preserve the automatically set date.",
+    "freeze_events": true
   }
 }

--- a/data/processed/mergers.json
+++ b/data/processed/mergers.json
@@ -7679,7 +7679,7 @@
         "status": "live"
       },
       {
-        "date": "",
+        "date": "2026-05-28T12:00:00Z",
         "title": "Remedy offer - Heidelberg Materials Australia \u2013 construction materials business of MAAS - 28 May 2026",
         "display_title": "Remedy offer - Heidelberg Materials Australia \u2013 construction materials business of MAAS - 28 May 2026",
         "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/Heidelberg%20Materials%20Australia%20%E2%80%93%20construction%20materials%20business%20of%20MAAS%20-%20remedy%20offer%20-%2028%20May%202026_0.pdf",

--- a/scripts/enrich_pdfs.py
+++ b/scripts/enrich_pdfs.py
@@ -25,7 +25,7 @@ from cutoff import is_waiver_merger
 from extract_mergers import (
     MATTERS_DIR,
     _load_frozen_events_mergers,
-    auto_fix_missing_questionnaire_dates,
+    auto_fix_missing_event_dates,
     enrich_with_questionnaire_data,
     extract_nocc_data,
 )
@@ -63,8 +63,8 @@ def main():
     # 2. NOCC manifest.
     extract_nocc_data()
 
-    # 3. Auto-fix questionnaire events whose date is missing on the ACCC page.
-    auto_fix_missing_questionnaire_dates(all_mergers_data, frozen_events_mergers)
+    # 3. Auto-fix catchable events (questionnaire, remedy offer) whose date is missing.
+    auto_fix_missing_event_dates(all_mergers_data, frozen_events_mergers)
 
     # is_waiver may shift if enrichment changed a date that affects classification.
     for merger in all_mergers_data:

--- a/scripts/extract_mergers.py
+++ b/scripts/extract_mergers.py
@@ -768,7 +768,7 @@ def enrich_with_questionnaire_data(mergers_data):
 MISSING_EVENT_DATES_PATH = 'data/processed/missing_event_dates.json'
 
 # Event title keywords that trigger the missing-date catch.
-_CATCHABLE_EVENT_KEYWORDS = ('questionnaire', 'remedy offer')
+_CATCHABLE_EVENT_KEYWORDS = ('questionnaire', 'remedy')
 
 
 def _is_catchable_event(title):

--- a/scripts/extract_mergers.py
+++ b/scripts/extract_mergers.py
@@ -765,17 +765,27 @@ def enrich_with_questionnaire_data(mergers_data):
     return mergers_data
 
 
-MISSING_QUESTIONNAIRE_DATES_PATH = 'data/processed/missing_questionnaire_dates.json'
+MISSING_EVENT_DATES_PATH = 'data/processed/missing_event_dates.json'
+
+# Event title keywords that trigger the missing-date catch.
+_CATCHABLE_EVENT_KEYWORDS = ('questionnaire', 'remedy offer')
 
 
-def auto_fix_missing_questionnaire_dates(all_mergers_data, frozen_events_mergers):
-    """Detect questionnaire events with empty dates, set today as the date, and freeze.
+def _is_catchable_event(title):
+    lower = title.lower()
+    return any(kw in lower for kw in _CATCHABLE_EVENT_KEYWORDS)
 
-    For each merger not already frozen that has a questionnaire event with no date:
-      1. Sets the event date to today at noon UTC.
+
+def auto_fix_missing_event_dates(all_mergers_data, frozen_events_mergers):
+    """Detect catchable events with empty dates, set a date, and freeze the merger.
+
+    Catchable event types: questionnaire, remedy offer (see _CATCHABLE_EVENT_KEYWORDS).
+
+    For each merger not already frozen that has a catchable event with no date:
+      1. Tries to extract the date from the event title; falls back to today at noon UTC.
       2. Adds the merger to frozen_events_mergers.json so future scrapes preserve the date.
-      3. Writes issue content to MISSING_QUESTIONNAIRE_DATES_PATH for the pipeline to
-         create GitHub issues asking the user to confirm the auto-set date is correct.
+      3. Writes issue content to MISSING_EVENT_DATES_PATH for the pipeline to create
+         GitHub issues asking the user to confirm the auto-set date is correct.
 
     Returns a set of newly frozen merger IDs (empty set if nothing was fixed).
     """
@@ -791,21 +801,35 @@ def auto_fix_missing_questionnaire_dates(all_mergers_data, frozen_events_mergers
         if not merger_id or merger_id in frozen_events_mergers:
             continue
 
+        fixed_events = []
         for event in merger.get('events', []):
-            if event.get('date') in ('', None) and 'questionnaire' in event.get('title', '').lower():
+            if event.get('date') not in ('', None) or not _is_catchable_event(event.get('title', '')):
+                continue
+            extracted_iso = parse_text_to_iso(event.get('title', ''), include_time=True)
+            if extracted_iso:
+                event['date'] = extracted_iso
+                dt = datetime.strptime(extracted_iso, '%Y-%m-%dT%H:%M:%SZ')
+                date_display = f"{dt.day} {dt.strftime('%b %Y')}"
+            else:
                 event['date'] = today_iso
-                newly_frozen.append({
-                    'merger_id': merger_id,
-                    'merger_name': merger.get('merger_name', ''),
-                    'event_title': event.get('title', ''),
-                    'date_display': today_display,
-                    'merger_url': merger.get('url', ''),
-                })
-                break  # one fix per merger
+                date_display = today_display
+            fixed_events.append({
+                'event_title': event.get('title', ''),
+                'date_display': date_display,
+                'extracted_from_title': extracted_iso is not None,
+            })
+
+        if fixed_events:
+            newly_frozen.append({
+                'merger_id': merger_id,
+                'merger_name': merger.get('merger_name', ''),
+                'fixed_events': fixed_events,
+                'merger_url': merger.get('url', ''),
+            })
 
     if not newly_frozen:
-        if os.path.exists(MISSING_QUESTIONNAIRE_DATES_PATH):
-            os.remove(MISSING_QUESTIONNAIRE_DATES_PATH)
+        if os.path.exists(MISSING_EVENT_DATES_PATH):
+            os.remove(MISSING_EVENT_DATES_PATH)
         return set()
 
     # Update frozen_events_mergers.json
@@ -823,10 +847,14 @@ def auto_fix_missing_questionnaire_dates(all_mergers_data, frozen_events_mergers
 
     for item in newly_frozen:
         mid = item['merger_id']
+        event_summaries = ', '.join(
+            f"{fe['event_title']} ({fe['date_display']})"
+            for fe in item['fixed_events']
+        )
         frozen_data[mid] = {
             "_comment": (
-                f"Questionnaire event date ({item['date_display']}) is missing from the "
-                "ACCC page; freezing events to preserve the automatically set date."
+                f"Event date(s) missing from ACCC page ({event_summaries}); "
+                "freezing events to preserve the automatically set date(s)."
             ),
             "freeze_events": True,
         }
@@ -841,26 +869,31 @@ def auto_fix_missing_questionnaire_dates(all_mergers_data, frozen_events_mergers
         mid = item['merger_id']
         name = item['merger_name']
         url = item['merger_url']
-        event_title = item['event_title']
-        date_display = item['date_display']
+        fixed_events = item['fixed_events']
         mergers_fyi_url = f"https://mergers.fyi/mergers/{mid}"
         frozen_json_url = f"https://github.com/{_repo}/blob/main/data/frozen_events_mergers.json"
 
+        event_rows = ''.join(
+            f"| {fe['event_title']} | {fe['date_display']} | "
+            f"{'from title' if fe['extracted_from_title'] else 'today (fallback)'} |\n"
+            for fe in fixed_events
+        )
         body = (
-            f"The questionnaire event for **{name}** had no date on the ACCC page.\n\n"
-            f"The pipeline automatically set the date to **{date_display}** and froze "
-            f"the merger's events to prevent future scrapes from clearing it.\n\n"
+            f"One or more events for **{name}** had no date on the ACCC page.\n\n"
+            f"The pipeline automatically set the date(s) and froze "
+            f"the merger's events to prevent future scrapes from clearing them.\n\n"
             f"### Details\n\n"
-            f"| Field | Value |\n"
-            f"|-------|-------|\n"
             f"| Merger | [{name}]({url}) |\n"
-            f"| Merger ID | `{mid}` |\n"
-            f"| Event | {event_title} |\n"
-            f"| Date set | {date_display} |\n\n"
+            f"|--------|---------------|\n"
+            f"| Merger ID | `{mid}` |\n\n"
+            f"### Fixed events\n\n"
+            f"| Event | Date set | Source |\n"
+            f"|-------|----------|--------|\n"
+            f"{event_rows}\n"
             f"### Action required\n\n"
-            f"Please verify that **{date_display}** is the correct questionnaire date.\n\n"
-            f"- If it is correct, close this issue.\n"
-            f"- If it is wrong, update the date in "
+            f"Please verify the date(s) above are correct.\n\n"
+            f"- If they are correct, close this issue.\n"
+            f"- If any are wrong, update the date in "
             f"[`data/frozen_events_mergers.json`]({frozen_json_url}) and "
             f"`data/processed/mergers.json` with the correct value.\n\n"
             f"[View on mergers.fyi]({mergers_fyi_url})"
@@ -868,16 +901,16 @@ def auto_fix_missing_questionnaire_dates(all_mergers_data, frozen_events_mergers
         issues.append({
             'merger_id': mid,
             'merger_name': name,
-            'title': f"Auto-fix: missing questionnaire date for {name} ({mid})",
+            'title': f"Auto-fix: missing event date(s) for {name} ({mid})",
             'body': body,
         })
 
-    with open(MISSING_QUESTIONNAIRE_DATES_PATH, 'w', encoding='utf-8') as f:
+    with open(MISSING_EVENT_DATES_PATH, 'w', encoding='utf-8') as f:
         json.dump({'issues': issues}, f, indent=2)
 
     newly_frozen_ids = {item['merger_id'] for item in newly_frozen}
     print(
-        f"Auto-fixed missing questionnaire date(s) for: {', '.join(sorted(newly_frozen_ids))}",
+        f"Auto-fixed missing event date(s) for: {', '.join(sorted(newly_frozen_ids))}",
         file=sys.stderr,
     )
     return newly_frozen_ids
@@ -1050,10 +1083,10 @@ def main():
         # downstream pipelines load the manifest separately.
         extract_nocc_data()
 
-        # 8c. Auto-fix questionnaire events whose date is missing on the ACCC page.
-        #     Sets today as the date, freezes the merger to preserve it, and writes
-        #     issue content for the pipeline to open a GitHub issue for confirmation.
-        auto_fix_missing_questionnaire_dates(all_mergers_data, frozen_events_mergers)
+        # 8c. Auto-fix catchable events whose date is missing on the ACCC page.
+        #     Tries to extract the date from the event title; falls back to today.
+        #     Freezes the merger and writes issue content for GitHub issue creation.
+        auto_fix_missing_event_dates(all_mergers_data, frozen_events_mergers)
 
     # 9. Add is_waiver field to each merger
     for merger in all_mergers_data:


### PR DESCRIPTION
## Summary
Generalize the missing event date auto-fix functionality to handle multiple event types beyond just questionnaires. The pipeline now detects and auto-fixes missing dates for both "questionnaire" and "remedy offer" events, with improved date extraction from event titles and better GitHub issue reporting.

## Key Changes

- **Renamed function and constants** for clarity:
  - `auto_fix_missing_questionnaire_dates()` → `auto_fix_missing_event_dates()`
  - `MISSING_QUESTIONNAIRE_DATES_PATH` → `MISSING_EVENT_DATES_PATH`
  - `missing-questionnaire-date` label → `missing-event-date`

- **Added catchable event type system**:
  - New `_CATCHABLE_EVENT_KEYWORDS` tuple defining event types to auto-fix: `('questionnaire', 'remedy offer')`
  - New `_is_catchable_event()` helper function for flexible event type matching

- **Enhanced date extraction logic**:
  - Attempts to extract dates from event titles using `parse_text_to_iso()` before falling back to today's date
  - Tracks whether date was extracted from title or set as fallback for transparency in GitHub issues

- **Improved issue reporting**:
  - Changed from single event per merger to support multiple fixed events per merger
  - GitHub issues now display a table of all fixed events with their dates and extraction source
  - Updated issue templates and comments to reflect generic "event date(s)" instead of questionnaire-specific language

- **Updated workflow and scripts**:
  - Updated GitHub Actions workflow to use new file paths and labels
  - Updated `enrich_pdfs.py` to call renamed function with updated comments

## Implementation Details

The auto-fix now:
1. Iterates through all events in unfrozen mergers
2. For each catchable event with a missing date, attempts to parse the date from the event title
3. Falls back to today's date at noon UTC if extraction fails
4. Collects all fixed events per merger and writes comprehensive issue content
5. Freezes the merger to preserve the auto-set date(s)

This change enables the pipeline to handle remedy offer events (like the new MN-50009 example) in addition to questionnaires, improving coverage of missing event dates across different merger event types.

https://claude.ai/code/session_01J7ZTHxSJfMkNcTaQXdWPYZ