### PR TITLE
Fix timeline event sorting to handle missing dates

### DIFF
--- a/scripts/static_data/outputs/timeline.py
+++ b/scripts/static_data/outputs/timeline.py
@@ -40,7 +40,7 @@ def generate(mergers: list, output_dir: Path, page_size: int = 100) -> int:
     # Sort by date ascending (oldest first, newest last).
     # New events always append to the last page, so only the last page file
     # changes per scrape run rather than cascading through all pages.
-    events.sort(key=lambda x: x.get('date', ''))
+    events.sort(key=lambda x: x.get('date') or '9999-99-99')
 
     total_events = len(events)
     total_pages = (total_events + page_size - 1) // page_size


### PR DESCRIPTION
## Summary
Updated the timeline event sorting logic to properly handle events with missing or null date values by assigning them a default sort value that places them at the end of the timeline.

## Key Changes
- Modified the sort key function in `generate()` to use `x.get('date') or '9999-99-99'` instead of `x.get('date', '')`
- This ensures events without a date value are sorted to the end of the list (using a far-future date) rather than appearing at the beginning (empty string sorts first)

## Implementation Details
- The change uses Python's `or` operator to provide a fallback value when `get('date')` returns `None`
- Using `'9999-99-99'` as the default ensures missing dates sort after all valid dates in ascending order
- This maintains the existing behavior where new events append to the last page, while preventing undated events from disrupting the chronological order

https://claude.ai/code/session_01NDyHNocQ6fMo9CtJ21134d