### PR TITLE
Add glossary and ACCC process explainer pages

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -43,6 +43,8 @@ merger-tracker/frontend/src/
 │   ├── Commentary.jsx    # /commentary
 │   ├── Digest.jsx        # /digest
 │   ├── Analysis.jsx      # /analysis
+│   ├── MergerProcess.jsx # /merger-process — explainer of the ACCC review process
+│   ├── Glossary.jsx      # /glossary — term definitions (source: constants/glossary.js)
 │   ├── NickTwort.jsx     # /nick-twort
 │   ├── PrivacyPolicy.jsx # /privacy
 │   └── NotFound.jsx      # * (404)

--- a/merger-tracker/frontend/src/App.jsx
+++ b/merger-tracker/frontend/src/App.jsx
@@ -18,6 +18,8 @@ import Commentary from './pages/Commentary';
 import Digest from './pages/Digest';
 import NickTwort from './pages/NickTwort';
 import Analysis from './pages/Analysis';
+import MergerProcess from './pages/MergerProcess';
+import Glossary from './pages/Glossary';
 import PrivacyPolicy from './pages/PrivacyPolicy';
 import Feedback from './pages/Feedback';
 import NotFound from './pages/NotFound';
@@ -43,6 +45,8 @@ function AppContent() {
             <Route path="/commentary" element={<Commentary />} />
             <Route path="/digest" element={<Digest />} />
             <Route path="/analysis" element={<Analysis />} />
+            <Route path="/merger-process" element={<MergerProcess />} />
+            <Route path="/glossary" element={<Glossary />} />
             <Route path="/nick-twort" element={<NickTwort />} />
             <Route path="/privacy" element={<PrivacyPolicy />} />
             <Route path="/feedback" element={<Feedback />} />

--- a/merger-tracker/frontend/src/components/GlossaryTerm.jsx
+++ b/merger-tracker/frontend/src/components/GlossaryTerm.jsx
@@ -1,0 +1,149 @@
+import { useState, useRef, useId, useCallback, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { Link } from 'react-router-dom';
+import { GLOSSARY_BY_ID } from '../constants/glossary';
+
+const TOOLTIP_WIDTH = 288; // px — matches w-72
+const VIEWPORT_MARGIN = 8; // px gap from the viewport edge
+const GAP = 8; // px gap between the trigger and the popover
+const CLOSE_DELAY_MS = 120; // grace period so the pointer can travel into the popover
+
+/**
+ * Inline term that reveals its glossary definition on hover, focus or tap.
+ *
+ * The definition shown is exactly the one stored in constants/glossary.js, so
+ * it always matches the corresponding entry on the Glossary page. The popover
+ * also links through to /glossary#<id> for the full context.
+ *
+ * Usage: <GlossaryTerm id="phase-1">Phase 1</GlossaryTerm>
+ * Children are optional — when omitted the canonical term name is shown.
+ */
+export default function GlossaryTerm({ id, children, className = '' }) {
+  const entry = GLOSSARY_BY_ID[id];
+  const triggerRef = useRef(null);
+  const closeTimer = useRef(null);
+  const [open, setOpen] = useState(false);
+  const [coords, setCoords] = useState(null); // { top, left, placement }
+  const tooltipId = useId();
+
+  const computePosition = useCallback(() => {
+    const el = triggerRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const width = Math.min(TOOLTIP_WIDTH, window.innerWidth - VIEWPORT_MARGIN * 2);
+
+    // Prefer below; flip above when there isn't room and there's more space up top.
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const placement = spaceBelow < 160 && rect.top > spaceBelow ? 'top' : 'bottom';
+
+    let left = rect.left + rect.width / 2 - width / 2;
+    left = Math.max(VIEWPORT_MARGIN, Math.min(left, window.innerWidth - width - VIEWPORT_MARGIN));
+
+    const top = placement === 'bottom' ? rect.bottom + GAP : rect.top - GAP;
+    setCoords({ top, left, width, placement });
+  }, []);
+
+  const cancelClose = useCallback(() => {
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+  }, []);
+
+  const show = useCallback(() => {
+    cancelClose();
+    computePosition();
+    setOpen(true);
+  }, [cancelClose, computePosition]);
+
+  const hide = useCallback(() => setOpen(false), []);
+
+  const scheduleClose = useCallback(() => {
+    cancelClose();
+    closeTimer.current = setTimeout(() => setOpen(false), CLOSE_DELAY_MS);
+  }, [cancelClose]);
+
+  // While open, dismiss on Escape and recompute/close when the layout shifts.
+  useEffect(() => {
+    if (!open) return undefined;
+    const onKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+    const onReflow = () => setOpen(false);
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('scroll', onReflow, true);
+    window.addEventListener('resize', onReflow);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('scroll', onReflow, true);
+      window.removeEventListener('resize', onReflow);
+    };
+  }, [open]);
+
+  useEffect(() => cancelClose, [cancelClose]);
+
+  // Unknown id: fail gracefully by rendering plain text (and warn in dev).
+  if (!entry) {
+    if (import.meta.env?.DEV) {
+      console.warn(`GlossaryTerm: no glossary entry for id "${id}"`);
+    }
+    return <>{children}</>;
+  }
+
+  const label = children ?? entry.term;
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-describedby={open ? tooltipId : undefined}
+        onMouseEnter={show}
+        onMouseLeave={scheduleClose}
+        onFocus={show}
+        onBlur={hide}
+        onClick={() => (open ? hide() : show())}
+        className={`inline cursor-help border-b border-dotted border-primary/50 text-inherit underline-offset-2 transition-colors hover:border-primary hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:rounded ${className}`}
+      >
+        {label}
+      </button>
+
+      {open && coords && createPortal(
+        <div
+          id={tooltipId}
+          role="tooltip"
+          onMouseEnter={cancelClose}
+          onMouseLeave={scheduleClose}
+          style={{
+            position: 'fixed',
+            top: coords.placement === 'bottom' ? coords.top : undefined,
+            bottom: coords.placement === 'top' ? window.innerHeight - coords.top : undefined,
+            left: coords.left,
+            width: coords.width,
+          }}
+          className="z-[60] animate-fade-in rounded-xl border border-gray-200/80 bg-white p-3.5 text-left shadow-elevated"
+        >
+          <p className="text-sm font-semibold text-gray-900">
+            {entry.term}
+            {entry.abbr && entry.abbr !== entry.term && (
+              <span className="ml-1.5 font-normal text-gray-400">({entry.abbr})</span>
+            )}
+          </p>
+          <p className="mt-1 text-[13px] leading-relaxed text-gray-600">{entry.definition}</p>
+          <Link
+            to={`/glossary#${entry.id}`}
+            onClick={hide}
+            className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-primary transition-colors hover:text-primary-dark"
+          >
+            More in the glossary
+            <span aria-hidden="true">&rarr;</span>
+          </Link>
+        </div>,
+        document.body
+      )}
+    </>
+  );
+}

--- a/merger-tracker/frontend/src/components/Navbar.jsx
+++ b/merger-tracker/frontend/src/components/Navbar.jsx
@@ -14,6 +14,8 @@ const navLinks = [
   { path: '/industries', label: 'Industries', shortcut: 'i' },
   { path: '/commentary', label: 'Commentary', shortcut: 'c' },
   { path: '/analysis', label: 'Analysis', shortcut: 'a' },
+  { path: '/merger-process', label: 'How it works' },
+  { path: '/glossary', label: 'Glossary' },
   { path: '/digest', label: 'Catch me up' },
 ];
 

--- a/merger-tracker/frontend/src/constants/__tests__/glossary.test.js
+++ b/merger-tracker/frontend/src/constants/__tests__/glossary.test.js
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { GLOSSARY, GLOSSARY_BY_ID, GLOSSARY_CATEGORIES } from '../glossary';
+
+const categoryIds = new Set(GLOSSARY_CATEGORIES.map((c) => c.id));
+
+describe('glossary data integrity', () => {
+  it('has unique entry ids', () => {
+    const ids = GLOSSARY.map((e) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('exposes every entry via GLOSSARY_BY_ID', () => {
+    expect(Object.keys(GLOSSARY_BY_ID)).toHaveLength(GLOSSARY.length);
+    for (const entry of GLOSSARY) {
+      expect(GLOSSARY_BY_ID[entry.id]).toBe(entry);
+    }
+  });
+
+  it('gives every entry a term, a definition and a known category', () => {
+    for (const entry of GLOSSARY) {
+      expect(entry.term, `term for ${entry.id}`).toBeTruthy();
+      expect(entry.definition, `definition for ${entry.id}`).toBeTruthy();
+      expect(categoryIds.has(entry.category), `category for ${entry.id}`).toBe(true);
+    }
+  });
+
+  it('only references related ids that exist', () => {
+    for (const entry of GLOSSARY) {
+      for (const relId of entry.related || []) {
+        expect(GLOSSARY_BY_ID[relId], `${entry.id} -> ${relId}`).toBeDefined();
+      }
+    }
+  });
+
+  it('keeps definitions short enough to read inside a tooltip', () => {
+    for (const entry of GLOSSARY) {
+      expect(entry.definition.length, `definition for ${entry.id}`).toBeLessThanOrEqual(360);
+    }
+  });
+});

--- a/merger-tracker/frontend/src/constants/glossary.js
+++ b/merger-tracker/frontend/src/constants/glossary.js
@@ -1,0 +1,323 @@
+/**
+ * Single source of truth for merger-review terminology.
+ *
+ * Every definition here is reused in two places:
+ *   1. The Glossary page (/glossary), which lists every term, grouped by
+ *      category, with an anchor at #<id>.
+ *   2. The <GlossaryTerm id="..."> component, which shows the *same*
+ *      `definition` text in a hover/focus popover and links back to
+ *      /glossary#<id>.
+ *
+ * Because the tooltip and the glossary entry share one `definition` field,
+ * keep each definition concise (roughly one to three sentences) so it reads
+ * well inside a small popover as well as on the page.
+ *
+ * Accuracy note: definitions describe Australia's mandatory and suspensory
+ * merger control regime, administered by the ACCC, which applies from
+ * 1 January 2026 (with voluntary notification available from 1 July 2025).
+ * Statutory timeframes are expressed in business days, which for this regime
+ * exclude weekends, ACT public holidays, and 23 December to 10 January.
+ *
+ * Sources: ACCC merger control guidance and the Competition and Consumer Act
+ * 2010 (Cth). See https://www.accc.gov.au/business/mergers-and-acquisitions
+ */
+
+// Category metadata controls grouping and ordering on the Glossary page.
+export const GLOSSARY_CATEGORIES = [
+  { id: 'regime', label: 'The regime', blurb: 'How merger control works in Australia.' },
+  { id: 'process', label: 'The review process', blurb: 'The stages a notified acquisition moves through.' },
+  { id: 'documents', label: 'Key documents', blurb: 'The main documents the ACCC publishes.' },
+  { id: 'outcomes', label: 'Statuses and outcomes', blurb: 'The labels you see on merger and determination badges.' },
+  { id: 'mechanisms', label: 'Other mechanisms', blurb: 'Alternative paths, remedies and review rights.' },
+  { id: 'site', label: 'On this site', blurb: 'Terms used to organise the data shown here.' },
+];
+
+/**
+ * @typedef {Object} GlossaryEntry
+ * @property {string}   id          Kebab-case slug; used as the anchor and lookup key.
+ * @property {string}   term        Canonical display name.
+ * @property {string}   [abbr]      Short form, if the term is commonly abbreviated.
+ * @property {string}   category    One of GLOSSARY_CATEGORIES[].id.
+ * @property {string}   definition  Concise definition reused in the tooltip and on the page.
+ * @property {string[]} [aliases]   Alternate spellings/labels, used for search matching.
+ * @property {string[]} [related]   ids of related entries to cross-link.
+ * @property {string}   [acccUrl]   Authoritative ACCC link for further reading.
+ */
+
+/** @type {GlossaryEntry[]} */
+export const GLOSSARY = [
+  // ---- The regime ----------------------------------------------------------
+  {
+    id: 'merger-control-regime',
+    term: 'Mandatory and suspensory regime',
+    category: 'regime',
+    definition:
+      'Australia’s merger control system from 1 January 2026. Acquisitions that meet the notification thresholds must be notified to the ACCC, and "suspensory" means the deal cannot complete until the ACCC approves it. Voluntary notification was available from 1 July 2025.',
+    aliases: ['mandatory regime', 'suspensory', 'merger control'],
+    related: ['notifiable-acquisition', 'notification', 'cca'],
+    acccUrl: 'https://www.accc.gov.au/business/mergers-and-acquisitions/merger-control-regime',
+  },
+  {
+    id: 'cca',
+    term: 'Competition and Consumer Act',
+    abbr: 'CCA',
+    category: 'regime',
+    definition:
+      'The Competition and Consumer Act 2010 (Cth) — the legislation that contains Australia’s merger control rules and the substantial lessening of competition test, administered by the ACCC.',
+    aliases: ['Competition and Consumer Act 2010', 'the Act'],
+    related: ['accc', 'slc'],
+  },
+  {
+    id: 'accc',
+    term: 'ACCC',
+    abbr: 'ACCC',
+    category: 'regime',
+    definition:
+      'The Australian Competition and Consumer Commission — the national regulator that reviews and decides merger notifications under the Competition and Consumer Act.',
+    aliases: ['Australian Competition and Consumer Commission'],
+    related: ['cca', 'tribunal'],
+    acccUrl: 'https://www.accc.gov.au/business/mergers-and-acquisitions',
+  },
+  {
+    id: 'notifiable-acquisition',
+    term: 'Notifiable acquisition',
+    category: 'regime',
+    definition:
+      'An acquisition that meets the notification thresholds and so must be notified to, and approved by, the ACCC before it can complete.',
+    aliases: ['notifiable'],
+    related: ['notification-thresholds', 'notification', 'merger-control-regime'],
+  },
+  {
+    id: 'notification-thresholds',
+    term: 'Notification thresholds',
+    category: 'regime',
+    definition:
+      'The size tests that decide whether an acquisition must be notified. They include a combined Australian turnover of the merger parties of at least $200 million, together with further target-based and market-concentration limbs set by the Treasurer.',
+    aliases: ['thresholds', 'monetary threshold'],
+    related: ['notifiable-acquisition', 'notification-waiver'],
+    acccUrl: 'https://www.accc.gov.au/business/mergers-and-acquisitions/thresholds-for-notifying-acquisitions',
+  },
+  {
+    id: 'slc',
+    term: 'Substantial lessening of competition',
+    abbr: 'SLC',
+    category: 'regime',
+    definition:
+      'The legal test for clearance. The ACCC must approve an acquisition unless it is satisfied the acquisition would have the effect, or be likely to have the effect, of substantially lessening competition in any market.',
+    aliases: ['substantially lessening competition', 'SLC test', 'competition test'],
+    related: ['phase-2', 'public-benefit'],
+  },
+  {
+    id: 'acquisitions-register',
+    term: 'Acquisitions Register',
+    category: 'regime',
+    definition:
+      'The public register on the ACCC website where notified acquisitions, waiver applications, key documents and determinations are published. This site mirrors and reorganises that data.',
+    aliases: ['register', 'public register'],
+    related: ['notification', 'determination'],
+    acccUrl: 'https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register',
+  },
+
+  // ---- The review process --------------------------------------------------
+  {
+    id: 'pre-notification',
+    term: 'Pre-notification engagement',
+    category: 'process',
+    definition:
+      'Optional discussions with the ACCC before lodging, to settle the scope of the notification and the information required. The statutory review clock only starts once a valid notification is accepted.',
+    aliases: ['pre-notification', 'pre-lodgement'],
+    related: ['notification'],
+  },
+  {
+    id: 'notification',
+    term: 'Notification',
+    category: 'process',
+    definition:
+      'The formal filing that starts an ACCC review. Once it is accepted the statutory clock begins, and the acquisition cannot complete until the ACCC approves it.',
+    aliases: ['notify', 'merger notification'],
+    related: ['phase-1', 'acquisitions-register', 'notifiable-acquisition'],
+  },
+  {
+    id: 'phase-1',
+    term: 'Phase 1 review',
+    category: 'process',
+    definition:
+      'The initial review, lasting up to 30 business days. The ACCC can approve the acquisition (with or without commitments) from business day 15, or decide it needs an in-depth Phase 2 review.',
+    aliases: ['phase 1', 'phase one'],
+    related: ['phase-2', 'commitments', 'referred-to-phase-2'],
+    acccUrl: 'https://www.accc.gov.au/business/mergers-and-acquisitions/assessment-process-and-review-timelines',
+  },
+  {
+    id: 'phase-2',
+    term: 'Phase 2 review',
+    category: 'process',
+    definition:
+      'An in-depth review of up to 90 business days, used when the ACCC considers an acquisition could substantially lessen competition. It ends in an approval (with or without commitments) or a refusal.',
+    aliases: ['phase 2', 'phase two', 'in-depth review'],
+    related: ['phase-1', 'nocc', 'slc', 'commitments'],
+    acccUrl: 'https://www.accc.gov.au/business/mergers-and-acquisitions/assessment-process-and-review-timelines',
+  },
+  {
+    id: 'public-benefit',
+    term: 'Public benefit application',
+    category: 'process',
+    definition:
+      'An optional final stage where parties can ask the ACCC to approve an acquisition that lessens competition on the basis that it delivers a net public benefit. It is only available after the ACCC has decided the deal cannot otherwise proceed.',
+    aliases: ['public benefits', 'net public benefit', 'public benefit phase'],
+    related: ['slc', 'determination'],
+  },
+  {
+    id: 'business-day',
+    term: 'Business day',
+    category: 'process',
+    definition:
+      'The unit the statutory clocks are measured in. For the merger regime a business day excludes weekends, ACT public holidays, and the period from 23 December to 10 January, so the clock pauses over the holidays.',
+    aliases: ['business days'],
+    related: ['phase-1', 'phase-2'],
+  },
+
+  // ---- Key documents -------------------------------------------------------
+  {
+    id: 'nocc',
+    term: 'Notice of Competition Concerns',
+    abbr: 'NOCC',
+    category: 'documents',
+    definition:
+      'A document the ACCC issues by no later than business day 25 of a Phase 2 review, setting out its preliminary competition concerns. Merger parties then have 25 business days to respond.',
+    aliases: ['notice of competition concerns'],
+    related: ['phase-2', 'slc'],
+  },
+  {
+    id: 'determination',
+    term: 'Determination',
+    category: 'documents',
+    definition:
+      'The ACCC’s formal, published decision on a notified acquisition or a waiver application, including its reasons.',
+    aliases: ['determinations', 'decision'],
+    related: ['approved', 'refused', 'acquisitions-register'],
+  },
+
+  // ---- Statuses and outcomes (match the badges shown across the site) ------
+  {
+    id: 'under-assessment',
+    term: 'Under assessment',
+    category: 'outcomes',
+    definition:
+      'A status meaning the ACCC is currently reviewing the notification and has not yet made a determination.',
+    aliases: ['under assessment'],
+    related: ['assessment-suspended', 'assessment-completed'],
+  },
+  {
+    id: 'assessment-suspended',
+    term: 'Assessment suspended',
+    category: 'outcomes',
+    definition:
+      'A status meaning the statutory clock has been paused — for example while the ACCC waits for further information from the merger parties.',
+    aliases: ['assessment suspended', 'suspended'],
+    related: ['under-assessment', 'business-day'],
+  },
+  {
+    id: 'assessment-completed',
+    term: 'Assessment completed',
+    category: 'outcomes',
+    definition:
+      'A status meaning the ACCC has finished its review and made a determination.',
+    aliases: ['assessment completed', 'completed'],
+    related: ['determination'],
+  },
+  {
+    id: 'approved',
+    term: 'Approved',
+    category: 'outcomes',
+    definition:
+      'A determination that the ACCC has approved the acquisition, allowing it to proceed — sometimes subject to commitments offered by the parties.',
+    aliases: ['approved', 'cleared', 'clearance'],
+    related: ['commitments', 'refused', 'determination'],
+  },
+  {
+    id: 'referred-to-phase-2',
+    term: 'Referred to Phase 2',
+    category: 'outcomes',
+    definition:
+      'The outcome at the end of Phase 1 where the ACCC decides the acquisition needs an in-depth Phase 2 review before it can be decided.',
+    aliases: ['referred to phase 2', 'phase 2 referral'],
+    related: ['phase-1', 'phase-2'],
+  },
+  {
+    id: 'refused',
+    term: 'Not approved',
+    category: 'outcomes',
+    definition:
+      'A determination that the acquisition cannot proceed because the ACCC is satisfied it would substantially lessen competition and no net public benefit justifies it.',
+    aliases: ['not approved', 'refused', 'blocked', 'opposed'],
+    related: ['slc', 'public-benefit', 'tribunal'],
+  },
+  {
+    id: 'declined',
+    term: 'Declined',
+    category: 'outcomes',
+    definition:
+      'A register label used where the ACCC has declined an application — for example declining to grant a notification waiver, or declining to approve an acquisition.',
+    aliases: ['declined'],
+    related: ['notification-waiver', 'refused'],
+  },
+  {
+    id: 'not-opposed',
+    term: 'Not opposed',
+    category: 'outcomes',
+    definition:
+      'A legacy outcome from the former voluntary informal review, where the ACCC indicated it would not oppose an acquisition. It is retained here for historical matters reviewed before the 2026 regime.',
+    aliases: ['not opposed', 'informal clearance'],
+    related: ['approved'],
+  },
+
+  // ---- Other mechanisms ----------------------------------------------------
+  {
+    id: 'notification-waiver',
+    term: 'Notification waiver',
+    category: 'mechanisms',
+    definition:
+      'An ACCC decision that a specific acquisition does not need to be notified, even though it meets the thresholds. It offers a faster path for deals that clearly do not raise material competition concerns.',
+    aliases: ['waiver', 'notification waivers'],
+    related: ['notification-thresholds', 'notifiable-acquisition'],
+    acccUrl: 'https://www.accc.gov.au/business/mergers-and-acquisitions/notification-waivers',
+  },
+  {
+    id: 'commitments',
+    term: 'Commitments',
+    category: 'mechanisms',
+    definition:
+      'Court-enforceable undertakings parties offer to resolve the ACCC’s concerns — such as divesting a business (structural) or behavioural promises. They can be proposed in Phase 1 (by day 20), Phase 2 (by day 60) or the public benefit phase.',
+    aliases: ['remedies', 'undertakings', 'commitment'],
+    related: ['phase-1', 'phase-2', 'approved'],
+  },
+  {
+    id: 'tribunal',
+    term: 'Australian Competition Tribunal',
+    category: 'mechanisms',
+    definition:
+      'The body to which a dissatisfied notifying party or third party can apply for a limited merits review of an ACCC merger determination.',
+    aliases: ['tribunal', 'ACT'],
+    related: ['determination', 'refused'],
+  },
+
+  // ---- On this site --------------------------------------------------------
+  {
+    id: 'anzsic',
+    term: 'ANZSIC industry classification',
+    abbr: 'ANZSIC',
+    category: 'site',
+    definition:
+      'The Australian and New Zealand Standard Industrial Classification — the industry coding system this site uses to group mergers by sector.',
+    aliases: ['ANZSIC', 'industry classification'],
+    related: [],
+  },
+];
+
+/** Fast lookup by id, e.g. GLOSSARY_BY_ID['phase-1']. */
+export const GLOSSARY_BY_ID = Object.freeze(
+  GLOSSARY.reduce((acc, entry) => {
+    acc[entry.id] = entry;
+    return acc;
+  }, {})
+);

--- a/merger-tracker/frontend/src/pages/Glossary.jsx
+++ b/merger-tracker/frontend/src/pages/Glossary.jsx
@@ -1,0 +1,204 @@
+import { useState, useMemo, useEffect, useRef } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { FaSearch } from 'react-icons/fa';
+import SEO from '../components/SEO';
+import ExternalLinkIcon from '../components/ExternalLinkIcon';
+import { GLOSSARY, GLOSSARY_CATEGORIES, GLOSSARY_BY_ID } from '../constants/glossary';
+
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'DefinedTermSet',
+  name: 'ACCC merger review glossary',
+  description:
+    'Plain-language definitions of the terms used in Australian merger reviews under the ACCC mandatory and suspensory merger control regime.',
+  url: 'https://mergers.fyi/glossary',
+  hasDefinedTerm: GLOSSARY.map((entry) => ({
+    '@type': 'DefinedTerm',
+    '@id': `https://mergers.fyi/glossary#${entry.id}`,
+    name: entry.term,
+    description: entry.definition,
+  })),
+};
+
+function matchesQuery(entry, q) {
+  if (!q) return true;
+  const haystack = [entry.term, entry.abbr, entry.definition, ...(entry.aliases || [])]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+  return haystack.includes(q);
+}
+
+export default function Glossary() {
+  const [query, setQuery] = useState('');
+  const location = useLocation();
+  const [highlightedId, setHighlightedId] = useState(null);
+  const hasScrolled = useRef(false);
+
+  const normalisedQuery = query.trim().toLowerCase();
+
+  const grouped = useMemo(() => {
+    return GLOSSARY_CATEGORIES.map((category) => ({
+      ...category,
+      entries: GLOSSARY
+        .filter((entry) => entry.category === category.id && matchesQuery(entry, normalisedQuery))
+        .sort((a, b) => a.term.localeCompare(b.term)),
+    })).filter((category) => category.entries.length > 0);
+  }, [normalisedQuery]);
+
+  const totalMatches = grouped.reduce((sum, c) => sum + c.entries.length, 0);
+
+  // Scroll to and briefly highlight a term when arriving via /glossary#<id>.
+  useEffect(() => {
+    const id = location.hash.replace('#', '');
+    if (!id || hasScrolled.current) return;
+    const el = document.getElementById(id);
+    if (!el) return;
+    hasScrolled.current = true;
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    // Defer the highlight out of the effect body to avoid a cascading render.
+    const raf = requestAnimationFrame(() => setHighlightedId(id));
+    const timer = setTimeout(() => setHighlightedId(null), 2200);
+    return () => {
+      cancelAnimationFrame(raf);
+      clearTimeout(timer);
+    };
+  }, [location.hash]);
+
+  return (
+    <>
+      <SEO
+        title="Glossary of ACCC merger terms"
+        description="Plain-language definitions of the key terms used in Australian merger reviews — notification, Phase 1 and Phase 2, NOCC, waivers, commitments and more."
+        url="/glossary"
+        structuredData={structuredData}
+      />
+
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12 animate-fade-in">
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">Glossary</h1>
+          <p className="text-gray-600 leading-relaxed">
+            Plain-language definitions of the terms used across this site and in ACCC merger reviews.
+            New to how it all fits together?{' '}
+            <Link
+              to="/merger-process"
+              className="text-primary hover:text-primary-dark font-medium hover:underline transition-colors"
+            >
+              Read how ACCC merger review works
+            </Link>
+            .
+          </p>
+        </div>
+
+        {/* Search */}
+        <div className="sticky top-16 z-10 -mx-4 px-4 py-3 bg-gradient-to-b from-white via-white to-white/0 sm:mx-0 sm:px-0">
+          <label htmlFor="glossary-search" className="sr-only">Search terms</label>
+          <div className="relative">
+            <FaSearch className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" aria-hidden="true" />
+            <input
+              id="glossary-search"
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search terms, e.g. waiver, Phase 2, NOCC…"
+              className="w-full pl-10 pr-4 py-2.5 text-sm bg-white border border-gray-200 rounded-xl text-gray-900 placeholder-gray-400 shadow-card focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary/40"
+            />
+          </div>
+          {normalisedQuery && (
+            <p className="mt-2 text-xs text-gray-500">
+              {totalMatches} {totalMatches === 1 ? 'term' : 'terms'} matching &ldquo;{query.trim()}&rdquo;
+            </p>
+          )}
+        </div>
+
+        {/* Category jump links */}
+        {!normalisedQuery && (
+          <nav aria-label="Glossary categories" className="mt-4 mb-8 flex flex-wrap gap-2">
+            {grouped.map((category) => (
+              <a
+                key={category.id}
+                href={`#cat-${category.id}`}
+                className="px-3 py-1.5 text-xs font-medium rounded-full bg-gray-100 text-gray-600 hover:bg-primary/10 hover:text-primary transition-colors"
+              >
+                {category.label}
+              </a>
+            ))}
+          </nav>
+        )}
+
+        {/* Groups */}
+        {totalMatches === 0 ? (
+          <p className="text-gray-500 py-12 text-center">
+            No terms match your search. Try a different word.
+          </p>
+        ) : (
+          <div className="space-y-10 mt-6">
+            {grouped.map((category) => (
+              <section key={category.id} id={`cat-${category.id}`} aria-labelledby={`cat-${category.id}-heading`}>
+                <div className="mb-4">
+                  <h2 id={`cat-${category.id}-heading`} className="text-xl font-semibold text-gray-900">
+                    {category.label}
+                  </h2>
+                  <p className="text-sm text-gray-500">{category.blurb}</p>
+                </div>
+
+                <dl className="space-y-3">
+                  {category.entries.map((entry) => (
+                    <div
+                      key={entry.id}
+                      id={entry.id}
+                      className={`scroll-mt-28 bg-white rounded-2xl border p-5 shadow-card transition-all duration-300 ${
+                        highlightedId === entry.id
+                          ? 'border-primary/50 ring-2 ring-primary/30'
+                          : 'border-gray-100'
+                      }`}
+                    >
+                      <dt className="flex items-baseline flex-wrap gap-x-2">
+                        <span className="text-base font-semibold text-gray-900">{entry.term}</span>
+                        {entry.abbr && entry.abbr !== entry.term && (
+                          <span className="text-sm font-medium text-gray-400">({entry.abbr})</span>
+                        )}
+                      </dt>
+                      <dd className="mt-1.5 text-sm text-gray-600 leading-relaxed">{entry.definition}</dd>
+
+                      {(entry.related?.length > 0 || entry.acccUrl) && (
+                        <dd className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1.5">
+                          {entry.related?.map((relId) => {
+                            const rel = GLOSSARY_BY_ID[relId];
+                            if (!rel) return null;
+                            return (
+                              <a
+                                key={relId}
+                                href={`#${relId}`}
+                                className="text-xs font-medium text-primary hover:text-primary-dark hover:underline transition-colors"
+                              >
+                                {rel.term}
+                              </a>
+                            );
+                          })}
+                          {entry.acccUrl && (
+                            <a
+                              href={entry.acccUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="inline-flex items-center gap-1 text-xs font-medium text-gray-400 hover:text-gray-600 transition-colors"
+                            >
+                              ACCC guidance
+                              <ExternalLinkIcon className="h-3 w-3" />
+                              <span className="sr-only">(opens in new tab)</span>
+                            </a>
+                          )}
+                        </dd>
+                      )}
+                    </div>
+                  ))}
+                </dl>
+              </section>
+            ))}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/merger-tracker/frontend/src/pages/MergerProcess.jsx
+++ b/merger-tracker/frontend/src/pages/MergerProcess.jsx
@@ -1,0 +1,283 @@
+import { Link } from 'react-router-dom';
+import { FaArrowRight } from 'react-icons/fa';
+import SEO from '../components/SEO';
+import GlossaryTerm from '../components/GlossaryTerm';
+
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: 'How ACCC merger review works',
+  description:
+    'A plain-language walkthrough of how the ACCC reviews mergers under Australia’s mandatory and suspensory merger control regime — from notification through Phase 1, Phase 2 and beyond.',
+  about: 'Australian merger control regime',
+  url: 'https://mergers.fyi/merger-process',
+  publisher: {
+    '@type': 'Organization',
+    name: 'Australian Merger Tracker',
+    url: 'https://mergers.fyi',
+  },
+};
+
+// The headline stages, used for the "at a glance" stepper.
+const STAGES = [
+  {
+    n: 1,
+    termId: 'notification',
+    title: 'Notification',
+    timing: 'Clock starts',
+    body: 'The parties lodge a notification. The deal is now suspensory — it cannot complete until the ACCC approves it.',
+  },
+  {
+    n: 2,
+    termId: 'phase-1',
+    title: 'Phase 1 review',
+    timing: 'Up to 30 business days',
+    body: 'A first-pass review. Most deals are approved here; the ACCC can also accept commitments or send the deal to Phase 2.',
+  },
+  {
+    n: 3,
+    termId: 'phase-2',
+    title: 'Phase 2 review',
+    timing: 'Up to 90 business days',
+    body: 'An in-depth review for deals that may substantially lessen competition, including a Notice of Competition Concerns.',
+  },
+  {
+    n: 4,
+    termId: 'public-benefit',
+    title: 'Public benefit',
+    timing: 'Optional',
+    body: 'If a deal is refused, parties may still seek approval on the basis that it delivers a net public benefit.',
+  },
+];
+
+function Stage({ stage, isLast }) {
+  return (
+    <li className="relative flex gap-4 pb-6 last:pb-0">
+      {!isLast && (
+        <span className="absolute left-4 top-9 -ml-px h-full w-0.5 bg-gray-200" aria-hidden="true" />
+      )}
+      <span className="relative z-10 flex h-8 w-8 flex-none items-center justify-center rounded-full bg-primary text-sm font-semibold text-white">
+        {stage.n}
+      </span>
+      <div className="pt-0.5">
+        <div className="flex flex-wrap items-baseline gap-x-2">
+          <h3 className="text-base font-semibold text-gray-900">
+            <GlossaryTerm id={stage.termId}>{stage.title}</GlossaryTerm>
+          </h3>
+          <span className="text-xs font-medium text-gray-400">{stage.timing}</span>
+        </div>
+        <p className="mt-1 text-sm text-gray-600 leading-relaxed">{stage.body}</p>
+      </div>
+    </li>
+  );
+}
+
+function Section({ title, children }) {
+  return (
+    <section className="bg-white rounded-2xl border border-gray-100 shadow-card p-6 sm:p-8">
+      <h2 className="text-xl font-semibold text-gray-900 mb-4">{title}</h2>
+      <div className="space-y-4 text-gray-700 leading-relaxed">{children}</div>
+    </section>
+  );
+}
+
+export default function MergerProcess() {
+  return (
+    <>
+      <SEO
+        title="How ACCC merger review works"
+        description="A plain-language walkthrough of Australia’s mandatory merger control regime — notification, Phase 1 and Phase 2 reviews, Notices of Competition Concerns, waivers, commitments and the public benefit test."
+        url="/merger-process"
+        structuredData={structuredData}
+      />
+
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12 animate-fade-in">
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900 mb-3">How ACCC merger review works</h1>
+          <p className="text-gray-600 leading-relaxed">
+            Since 1 January 2026, Australia has a{' '}
+            <GlossaryTerm id="merger-control-regime">mandatory and suspensory</GlossaryTerm>{' '}
+            merger control regime. Larger acquisitions must be cleared by the{' '}
+            <GlossaryTerm id="accc">ACCC</GlossaryTerm> before they can complete. This page walks
+            through the journey from start to finish. Hover over any{' '}
+            <span className="border-b border-dotted border-primary/50 text-primary">underlined term</span>{' '}
+            for a quick definition, or browse the{' '}
+            <Link
+              to="/glossary"
+              className="text-primary hover:text-primary-dark font-medium hover:underline transition-colors"
+            >
+              full glossary
+            </Link>
+            .
+          </p>
+        </div>
+
+        {/* At a glance stepper */}
+        <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6 sm:p-8 mb-6">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-400 mb-5">
+            The journey at a glance
+          </h2>
+          <ol className="list-none">
+            {STAGES.map((stage, i) => (
+              <Stage key={stage.n} stage={stage} isLast={i === STAGES.length - 1} />
+            ))}
+          </ol>
+        </div>
+
+        <div className="space-y-6">
+          {/* 1. Does the deal need notifying? */}
+          <Section title="1. Does the deal need to be notified?">
+            <p>
+              The regime only bites once a deal is big enough. An acquisition is a{' '}
+              <GlossaryTerm id="notifiable-acquisition">notifiable acquisition</GlossaryTerm>{' '}
+              when it meets the{' '}
+              <GlossaryTerm id="notification-thresholds">notification thresholds</GlossaryTerm>{' '}
+              — most notably a combined Australian turnover of the merger parties of at least
+              $200 million, plus further target-based and concentration limbs.
+            </p>
+            <p>
+              Where a deal technically meets the thresholds but clearly raises no concerns, parties
+              can ask for a{' '}
+              <GlossaryTerm id="notification-waiver">notification waiver</GlossaryTerm> — a faster
+              path that exempts that specific deal from the obligation to notify. Many matters on
+              this site are waiver decisions rather than full reviews.
+            </p>
+          </Section>
+
+          {/* 2. Lodging the notification */}
+          <Section title="2. Lodging the notification">
+            <p>
+              Parties often start with{' '}
+              <GlossaryTerm id="pre-notification">pre-notification engagement</GlossaryTerm> to
+              agree the scope of information the ACCC needs. The statutory clock only starts once a
+              valid <GlossaryTerm id="notification">notification</GlossaryTerm> is accepted, at
+              which point the deal is suspensory and the matter appears on the{' '}
+              <GlossaryTerm id="acquisitions-register">Acquisitions Register</GlossaryTerm>.
+            </p>
+            <p className="text-sm text-gray-500">
+              Timeframes are counted in{' '}
+              <GlossaryTerm id="business-day">business days</GlossaryTerm>, which exclude weekends,
+              ACT public holidays, and the period from 23 December to 10 January.
+            </p>
+          </Section>
+
+          {/* 3. Phase 1 */}
+          <Section title="3. Phase 1 — the first-pass review">
+            <p>
+              <GlossaryTerm id="phase-1">Phase 1</GlossaryTerm> runs for up to 30 business days. The
+              ACCC applies the{' '}
+              <GlossaryTerm id="slc">substantial lessening of competition</GlossaryTerm> test: it
+              must approve the deal unless it is satisfied the acquisition would, or would be likely
+              to, substantially lessen competition in any market.
+            </p>
+            <p>From day 15, Phase 1 can end in one of three ways:</p>
+            <ul className="space-y-2">
+              <li className="flex gap-2">
+                <FaArrowRight className="mt-1 h-3 w-3 flex-none text-primary" aria-hidden="true" />
+                <span>
+                  <GlossaryTerm id="approved">Approved</GlossaryTerm> — the deal is cleared and can
+                  proceed.
+                </span>
+              </li>
+              <li className="flex gap-2">
+                <FaArrowRight className="mt-1 h-3 w-3 flex-none text-primary" aria-hidden="true" />
+                <span>
+                  Approved subject to{' '}
+                  <GlossaryTerm id="commitments">commitments</GlossaryTerm> — concerns are resolved
+                  by court-enforceable undertakings (offered by day 20).
+                </span>
+              </li>
+              <li className="flex gap-2">
+                <FaArrowRight className="mt-1 h-3 w-3 flex-none text-primary" aria-hidden="true" />
+                <span>
+                  <GlossaryTerm id="referred-to-phase-2">Referred to Phase 2</GlossaryTerm> — the
+                  deal needs a closer look.
+                </span>
+              </li>
+            </ul>
+          </Section>
+
+          {/* 4. Phase 2 */}
+          <Section title="4. Phase 2 — the in-depth review">
+            <p>
+              <GlossaryTerm id="phase-2">Phase 2</GlossaryTerm> is reserved for deals that may
+              substantially lessen competition and runs for up to 90 business days. By day 25 the
+              ACCC issues a{' '}
+              <GlossaryTerm id="nocc">Notice of Competition Concerns</GlossaryTerm> setting out its
+              preliminary concerns, and the parties have 25 business days to respond. The parties can
+              again offer <GlossaryTerm id="commitments">commitments</GlossaryTerm> (by day 60).
+              Phase 2 ends in an approval or a refusal.
+            </p>
+          </Section>
+
+          {/* 5. Public benefit */}
+          <Section title="5. The public benefit safety net">
+            <p>
+              Even if the ACCC decides a deal cannot proceed on competition grounds, the parties can
+              lodge a{' '}
+              <GlossaryTerm id="public-benefit">public benefit application</GlossaryTerm>, asking the
+              ACCC to approve it anyway because the benefits to the public outweigh the harm to
+              competition. This optional stage is only available after a deal has otherwise been
+              refused.
+            </p>
+          </Section>
+
+          {/* 6. The outcome */}
+          <Section title="6. The outcome">
+            <p>
+              The ACCC records its decision in a published{' '}
+              <GlossaryTerm id="determination">determination</GlossaryTerm>, with reasons. A deal is
+              either <GlossaryTerm id="approved">approved</GlossaryTerm> (sometimes with commitments)
+              or <GlossaryTerm id="refused">not approved</GlossaryTerm>. Throughout the review you
+              will see a matter move through the{' '}
+              <GlossaryTerm id="under-assessment">under assessment</GlossaryTerm> and{' '}
+              <GlossaryTerm id="assessment-completed">assessment completed</GlossaryTerm> statuses
+              shown on the badges across this site.
+            </p>
+            <p>
+              A party unhappy with a determination can seek a limited merits review by the{' '}
+              <GlossaryTerm id="tribunal">Australian Competition Tribunal</GlossaryTerm>.
+            </p>
+          </Section>
+        </div>
+
+        {/* CTA */}
+        <div className="mt-8 rounded-2xl border border-primary/15 bg-primary/5 p-6 sm:p-8 text-center">
+          <h2 className="text-lg font-semibold text-gray-900">See it in practice</h2>
+          <p className="mt-1.5 text-sm text-gray-600">
+            Browse real matters moving through these stages, or look up any term.
+          </p>
+          <div className="mt-4 flex flex-wrap justify-center gap-3">
+            <Link
+              to="/mergers"
+              className="inline-flex items-center gap-1.5 rounded-xl bg-primary px-4 py-2 text-sm font-medium text-white shadow-card transition-colors hover:bg-primary-dark"
+            >
+              Browse mergers
+              <FaArrowRight className="h-3 w-3" aria-hidden="true" />
+            </Link>
+            <Link
+              to="/glossary"
+              className="inline-flex items-center gap-1.5 rounded-xl border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-card transition-colors hover:bg-gray-50"
+            >
+              Open the glossary
+            </Link>
+          </div>
+        </div>
+
+        <p className="mt-8 text-xs text-gray-400 leading-relaxed text-center">
+          This page is a general explainer, not legal advice. For official guidance see the{' '}
+          <a
+            href="https://www.accc.gov.au/business/mergers-and-acquisitions/merger-control-regime"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-gray-500 hover:text-gray-700 hover:underline transition-colors"
+          >
+            ACCC merger control regime
+          </a>{' '}
+          pages.
+        </p>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
Introduces two new pages backed by a single source of truth for
merger-review terminology (constants/glossary.js):

- /glossary lists every term grouped by category, with search,
  hash-deep-linking, cross-links and DefinedTermSet structured data.
- /merger-process walks through the mandatory and suspensory regime
  (notification -> Phase 1 -> Phase 2 -> public benefit -> outcome).

A reusable <GlossaryTerm> component shows the same definitions in an
accessible hover/focus/tap popover, so inline terms on the process page
match the glossary entries exactly. Adds both to the navbar and a data
integrity test for the glossary.

https://claude.ai/code/session_01XorZjnP6Q8THrctaFE8mbD