### PR TITLE
fix: exclude Phase 2 mergers with early determination from upcoming events

### DIFF
--- a/scripts/extract_mergers.py
+++ b/scripts/extract_mergers.py
@@ -561,6 +561,25 @@ def _dates_within_one_day(date1, date2):
     return abs((dt1.date() - dt2.date()).days) <= 1
 
 
+def _infer_determination_date_from_events(merger_data):
+    """Set determination_publication_date from linked determination events when absent.
+
+    The ACCC sometimes publishes the determination outcome and document links
+    before populating the structured date field on the page.  When accc_determination
+    is set but the HTML date field was absent, use the earliest linked determination
+    event's date as the publication date.
+    """
+    if not merger_data.get('accc_determination') or merger_data.get('determination_publication_date'):
+        return
+    det_events = [
+        e for e in merger_data.get('events', [])
+        if 'determination' in e.get('title', '').lower() and e.get('url')
+    ]
+    if det_events:
+        det_events.sort(key=lambda e: e.get('date', ''))
+        merger_data['determination_publication_date'] = det_events[0]['date']
+
+
 def _add_synthetic_events(merger_data):
     """Add notification and determination synthetic events if not already present."""
     events = merger_data['events']
@@ -667,6 +686,8 @@ def parse_merger_file(filepath, existing_merger_data=None, frozen_events_mergers
         merger_data['events'] = _merge_events(
             scraped_events, existing_merger_data, merger_id, frozen_events_mergers
         )
+
+        _infer_determination_date_from_events(merger_data)
         _add_synthetic_events(merger_data)
 
         if field_overrides and merger_id in field_overrides:

--- a/scripts/extract_mergers.py
+++ b/scripts/extract_mergers.py
@@ -566,8 +566,13 @@ def _infer_determination_date_from_events(merger_data):
 
     The ACCC sometimes publishes the determination outcome and document links
     before populating the structured date field on the page.  When accc_determination
-    is set but the HTML date field was absent, use the earliest linked determination
+    is set but the HTML date field was absent, use the latest linked determination
     event's date as the publication date.
+
+    Using the latest (not earliest) date is important for Phase 1 → Phase 2 mergers:
+    both phases can have linked determination documents in the events list, and the
+    Phase 2 determination is always dated after the Phase 1 referral document.
+    Taking the earliest would wrongly pick the Phase 1 date in that scenario.
     """
     if not merger_data.get('accc_determination') or merger_data.get('determination_publication_date'):
         return
@@ -576,8 +581,9 @@ def _infer_determination_date_from_events(merger_data):
         if 'determination' in e.get('title', '').lower() and e.get('url')
     ]
     if det_events:
-        det_events.sort(key=lambda e: e.get('date', ''))
-        merger_data['determination_publication_date'] = det_events[0]['date']
+        merger_data['determination_publication_date'] = max(
+            det_events, key=lambda e: e.get('date', '')
+        )['date']
 
 
 def _add_synthetic_events(merger_data):

--- a/scripts/static_data/outputs/upcoming_events.py
+++ b/scripts/static_data/outputs/upcoming_events.py
@@ -22,10 +22,15 @@ def generate(mergers: list, days_ahead: int = 60) -> dict:
 
     events = []
 
-    # Skip waivers + suspended assessments and already-determined mergers
+    # Skip waivers + suspended assessments and already-determined mergers.
+    # Check both determination_publication_date and accc_determination: the
+    # ACCC sometimes publishes the determination outcome before the date field
+    # is scraped (e.g. an early Phase 2 determination), so relying solely on
+    # determination_publication_date can leave stale "due" events on the board.
     candidate_mergers = [
         m for m in exclude_for_public_output(mergers)
         if not m.get('determination_publication_date')
+        and not m.get('accc_determination')
     ]
 
     for m in candidate_mergers:

--- a/scripts/tests/test_pipeline.py
+++ b/scripts/tests/test_pipeline.py
@@ -21,7 +21,7 @@ from parse_determination import (
 )
 from parse_questionnaire import extract_deadline, extract_questions, extract_questions_from_text, _extract_subpoints, _extract_bullets, _has_questionnaire_header
 from cutoff import is_waiver_merger, get_cutoff_date, should_skip_merger
-from extract_mergers import is_safe_url, get_serve_filename
+from extract_mergers import is_safe_url, get_serve_filename, _infer_determination_date_from_events
 
 
 # ---------------------------------------------------------------------------
@@ -909,6 +909,70 @@ class TestGetServeFilename:
 
     def test_other_extension_unchanged(self):
         assert get_serve_filename("image.png") == "image.png"
+
+
+# ---------------------------------------------------------------------------
+# extract_mergers: _infer_determination_date_from_events
+# ---------------------------------------------------------------------------
+
+class TestInferDeterminationDateFromEvents:
+    def _base(self):
+        return {
+            'accc_determination': 'Approved',
+            'determination_publication_date': None,
+            'events': [],
+        }
+
+    def test_infers_date_from_linked_determination_event(self):
+        m = self._base()
+        m['events'] = [
+            {'title': 'Phase 2 determination', 'date': '2026-06-02T12:00:00Z', 'url': 'https://accc.gov.au/det.pdf'},
+        ]
+        _infer_determination_date_from_events(m)
+        assert m['determination_publication_date'] == '2026-06-02T12:00:00Z'
+
+    def test_uses_earliest_date_when_multiple_events(self):
+        m = self._base()
+        m['events'] = [
+            {'title': 'Phase 2 determination - Summary', 'date': '2026-06-02T12:00:00Z', 'url': 'https://accc.gov.au/a.pdf'},
+            {'title': 'Phase 2 determination - Statement of reasons', 'date': '2026-06-02T12:00:00Z', 'url': 'https://accc.gov.au/b.pdf'},
+        ]
+        _infer_determination_date_from_events(m)
+        assert m['determination_publication_date'] == '2026-06-02T12:00:00Z'
+
+    def test_skips_events_without_url(self):
+        m = self._base()
+        m['events'] = [
+            {'title': 'Phase 2 determination', 'date': '2026-06-02T12:00:00Z'},  # no url
+        ]
+        _infer_determination_date_from_events(m)
+        assert m['determination_publication_date'] is None
+
+    def test_no_op_when_determination_publication_date_already_set(self):
+        m = self._base()
+        m['determination_publication_date'] = '2026-01-01T12:00:00Z'
+        m['events'] = [
+            {'title': 'Phase 2 determination', 'date': '2026-06-02T12:00:00Z', 'url': 'https://accc.gov.au/det.pdf'},
+        ]
+        _infer_determination_date_from_events(m)
+        assert m['determination_publication_date'] == '2026-01-01T12:00:00Z'
+
+    def test_no_op_when_no_accc_determination(self):
+        m = self._base()
+        m['accc_determination'] = None
+        m['events'] = [
+            {'title': 'Phase 2 determination', 'date': '2026-06-02T12:00:00Z', 'url': 'https://accc.gov.au/det.pdf'},
+        ]
+        _infer_determination_date_from_events(m)
+        assert m['determination_publication_date'] is None
+
+    def test_no_op_when_no_determination_events(self):
+        m = self._base()
+        m['events'] = [
+            {'title': 'Merger notified to ACCC', 'date': '2025-10-10T12:00:00Z', 'url': 'https://accc.gov.au/n.pdf'},
+        ]
+        _infer_determination_date_from_events(m)
+        assert m['determination_publication_date'] is None
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_pipeline.py
+++ b/scripts/tests/test_pipeline.py
@@ -931,11 +931,22 @@ class TestInferDeterminationDateFromEvents:
         _infer_determination_date_from_events(m)
         assert m['determination_publication_date'] == '2026-06-02T12:00:00Z'
 
-    def test_uses_earliest_date_when_multiple_events(self):
+    def test_uses_latest_date_when_multiple_events_same_day(self):
         m = self._base()
         m['events'] = [
             {'title': 'Phase 2 determination - Summary', 'date': '2026-06-02T12:00:00Z', 'url': 'https://accc.gov.au/a.pdf'},
             {'title': 'Phase 2 determination - Statement of reasons', 'date': '2026-06-02T12:00:00Z', 'url': 'https://accc.gov.au/b.pdf'},
+        ]
+        _infer_determination_date_from_events(m)
+        assert m['determination_publication_date'] == '2026-06-02T12:00:00Z'
+
+    def test_uses_latest_date_for_phase1_to_phase2_merger(self):
+        # Phase 1 determination document precedes Phase 2 determination document;
+        # we must pick the Phase 2 (latest) date, not the Phase 1 (earliest) date.
+        m = self._base()
+        m['events'] = [
+            {'title': 'Phase 1 determination - Referred to Phase 2', 'date': '2026-01-20T12:00:00Z', 'url': 'https://accc.gov.au/p1.pdf'},
+            {'title': 'Phase 2 determination', 'date': '2026-06-02T12:00:00Z', 'url': 'https://accc.gov.au/p2.pdf'},
         ]
         _infer_determination_date_from_events(m)
         assert m['determination_publication_date'] == '2026-06-02T12:00:00Z'

--- a/scripts/tests/test_static_data_outputs.py
+++ b/scripts/tests/test_static_data_outputs.py
@@ -349,6 +349,36 @@ class TestUpcomingEventsGenerate:
         excluded_ids = {'WA-0003', 'MN-0004'}
         assert not any(e['merger_id'] in excluded_ids for e in payload['events'])
 
+    def test_excludes_early_determination_missing_pub_date(self):
+        # A Phase 2 merger where accc_determination is set but
+        # determination_publication_date is None (early determination, date not
+        # yet scraped) must not produce a "determination due" event.
+        from datetime import datetime, timedelta, timezone
+        future = (datetime.now(timezone.utc) + timedelta(days=30)).strftime('%Y-%m-%dT12:00:00Z')
+        merger = {
+            'merger_id': 'MN-9999',
+            'merger_name': 'Early Phase 2 determination',
+            'status': 'Assessment completed',
+            'accc_determination': 'Approved',
+            'stage': 'Phase 2 - detailed assessment',
+            'effective_notification_datetime': '2025-01-01T12:00:00Z',
+            'determination_publication_date': None,
+            'end_of_determination_period': future,
+            'page_modified_datetime': '2026-01-01T12:00:00Z',
+            'anzsic_codes': [],
+            'acquirers': [],
+            'targets': [],
+            'other_parties': [],
+            'url': 'https://example.com/MN-9999',
+            'events': [{'title': 'Phase 2 determination', 'date': '2026-01-01T12:00:00Z'}],
+        }
+        enriched = [enrich_merger(merger)]
+        payload = upcoming_events.generate(enriched, days_ahead=60)
+        assert not any(e['merger_id'] == 'MN-9999' for e in payload['events']), (
+            "Merger with accc_determination set should be excluded even if "
+            "determination_publication_date is missing"
+        )
+
 
 # ---------------------------------------------------------------------------
 # questionnaires


### PR DESCRIPTION
The upcoming events candidate filter only checked determination_publication_date,
but the ACCC sometimes sets accc_determination before the publication date field
is scraped (e.g. an early Phase 2 determination). Add a second guard on
accc_determination so any determined merger is excluded regardless of whether
the date was captured.

https://claude.ai/code/session_01VtqaR9YEktcxhSCauwrxVf