### PR TITLE
fix: don't flag same-family documents as likely duplicates when subtypes differ

### DIFF
--- a/scripts/detect_duplicates.py
+++ b/scripts/detect_duplicates.py
@@ -64,17 +64,45 @@ def title_similarity(a: str, b: str) -> float:
     return SequenceMatcher(None, normalise_title(a), normalise_title(b)).ratio()
 
 
-def titles_are_different_event_types(a: str, b: str) -> bool:
-    """Return True if a and b begin with distinct, non-empty type prefixes.
+_MIN_SEGMENT_LEN = 5
+_SEGMENT_SIMILARITY_THRESHOLD = 0.70
 
-    This prevents events that are genuinely different documents (e.g. a
-    Questionnaire and a Remedy offer published on the same date for the same
-    merger) from being flagged as likely duplicates just because they share a
-    long common merger name.
+
+def titles_are_different_event_types(a: str, b: str) -> bool:
+    """Return True if a and b represent distinct document types.
+
+    Two checks are applied:
+
+    1. First-segment (type prefix) check: if the leading segment before the
+       first ' - ' separator differs between titles, they are clearly different
+       document types (e.g. 'Questionnaire' vs 'Remedy offer').
+
+    2. All-segments check: when titles split into the same number of segments,
+       compare each segment pair.  If any pair is substantially different
+       (segment similarity < 0.70 and both segments are at least 5 characters
+       long), the titles refer to different document types even when the overall
+       string similarity is high — e.g. 'Phase 2 determination – Statement of
+       Reasons' vs 'Phase 2 determination – Summary of reasons' share a long
+       common prefix but are genuinely distinct documents.
     """
     prefix_a = extract_type_prefix(a)
     prefix_b = extract_type_prefix(b)
-    return bool(prefix_a and prefix_b and prefix_a != prefix_b)
+    if prefix_a and prefix_b and prefix_a != prefix_b:
+        return True
+
+    segs_a = [s.strip().lower() for s in re.split(r"\s+[-–]\s+", a)]
+    segs_b = [s.strip().lower() for s in re.split(r"\s+[-–]\s+", b)]
+    if len(segs_a) == len(segs_b) and len(segs_a) > 1:
+        for sa, sb in zip(segs_a, segs_b):
+            if (
+                sa != sb
+                and len(sa) >= _MIN_SEGMENT_LEN
+                and len(sb) >= _MIN_SEGMENT_LEN
+                and SequenceMatcher(None, sa, sb).ratio() < _SEGMENT_SIMILARITY_THRESHOLD
+            ):
+                return True
+
+    return False
 
 
 def parse_date(raw: str):

--- a/scripts/tests/test_resolver.py
+++ b/scripts/tests/test_resolver.py
@@ -27,6 +27,7 @@ from detect_duplicates import (
     parse_date,
     suggest_deletion,
     title_similarity,
+    titles_are_different_event_types,
 )
 
 
@@ -83,6 +84,73 @@ class TestTitleSimilarity:
             "Public competition assessment published",
         )
         assert ratio < 0.8
+
+
+# ---------------------------------------------------------------------------
+# titles_are_different_event_types
+# ---------------------------------------------------------------------------
+
+class TestTitlesAreDifferentEventTypes:
+    def test_different_first_segment(self):
+        assert titles_are_different_event_types(
+            "Questionnaire - Ampol EG Australia",
+            "Remedy offer - Ampol EG Australia",
+        )
+
+    def test_same_first_segment_is_not_different(self):
+        assert not titles_are_different_event_types(
+            "Questionnaire - Ampol EG Australia",
+            "Questionnaire - Ampol EG Australia",
+        )
+
+    def test_no_separator_is_not_different(self):
+        # Single-segment titles have no type prefix — not flagged.
+        assert not titles_are_different_event_types(
+            "Notification received",
+            "Notification received.",
+        )
+
+    def test_statement_vs_summary_of_reasons(self):
+        # Core regression case: these are different documents even though the
+        # full-title string similarity is ~0.80.
+        assert titles_are_different_event_types(
+            "Phase 2 determination - Statement of Reasons",
+            "Phase 2 determination - Summary of reasons",
+        )
+
+    def test_em_dash_separator_handled(self):
+        assert titles_are_different_event_types(
+            "Phase 2 determination – Statement of Reasons",
+            "Phase 2 determination – Summary of reasons",
+        )
+
+    def test_minor_variation_in_second_segment_is_not_different(self):
+        # Trailing punctuation difference in the second segment should not
+        # trigger the all-segments check.
+        assert not titles_are_different_event_types(
+            "Phase 2 determination - Statement of Reasons",
+            "Phase 2 determination - Statement of Reasons.",
+        )
+
+
+class TestFindDuplicatesStatementVsSummary:
+    """Regression: Statement of Reasons vs Summary of reasons must not be
+    flagged as likely duplicates — they are genuinely different documents."""
+
+    def test_statement_vs_summary_not_flagged(self):
+        merger = {
+            'events': [
+                {
+                    'date': '2026-06-02T12:00:00Z',
+                    'title': 'Phase 2 determination - Statement of Reasons',
+                },
+                {
+                    'date': '2026-06-02T12:00:00Z',
+                    'title': 'Phase 2 determination - Summary of reasons',
+                },
+            ]
+        }
+        assert find_duplicates(merger) == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Extends titles_are_different_event_types to check all same-position
segment pairs, not just the first.  A pair with similarity < 0.70
(and both segments >= 5 chars) signals genuinely different document
types — preventing 'Phase 2 determination – Statement of Reasons' and
'Phase 2 determination – Summary of reasons' from being treated as
duplicates.

https://claude.ai/code/session_01V4mv95zKEyrWe3QAvdB2BM