### PR TITLE
Scroll to top on route change

### DIFF
--- a/merger-tracker/frontend/src/App.jsx
+++ b/merger-tracker/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import KeyboardShortcutsHelp from './components/KeyboardShortcutsHelp';
 import FeedbackPopup from './components/FeedbackPopup';
 import { TrackingProvider } from './context/TrackingContext';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
+import ScrollToTop from './components/ScrollToTop';
 import Dashboard from './pages/Dashboard';
 import Mergers from './pages/Mergers';
 import MergerDetail from './pages/MergerDetail';
@@ -30,6 +31,7 @@ function AppContent() {
 
   return (
     <>
+      <ScrollToTop />
       <div className="min-h-screen gradient-mesh flex flex-col">
         <Navbar />
         <main id="main-content" className="flex-grow pt-16">

--- a/merger-tracker/frontend/src/components/Footer.jsx
+++ b/merger-tracker/frontend/src/components/Footer.jsx
@@ -8,11 +8,6 @@ function Footer() {
           <span className="font-semibold text-gray-600">Disclaimer:</span> This is an unofficial website created by{' '}
           <Link
             to="/nick-twort"
-            onClick={() => window.scrollTo({
-              top: 0,
-              left: 0,
-              behaviour: "smooth",
-            })}
             className="text-primary hover:text-primary-dark font-medium hover:underline transition-colors"
           >
             Nick Twort
@@ -36,11 +31,6 @@ function Footer() {
           .{' '}
           <Link
             to="/privacy"
-            onClick={() => window.scrollTo({
-              top: 0,
-              left: 0,
-              behaviour: "smooth",
-            })}
             className="text-primary hover:text-primary-dark font-medium hover:underline transition-colors"
           >
             Privacy Policy

--- a/merger-tracker/frontend/src/components/ScrollToTop.jsx
+++ b/merger-tracker/frontend/src/components/ScrollToTop.jsx
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
Adds a ScrollToTop component that resets window scroll position on every
route transition, so navigating from the dashboard to a merger detail page
always opens at the top of the page.

https://claude.ai/code/session_01EH1rBDwxbR9rnyoeD4hsLr