### PR TITLE
Enrich deal-page SEO: article OG tags + improved JSON-LD

### DIFF
--- a/merger-tracker/frontend/src/components/SEO.jsx
+++ b/merger-tracker/frontend/src/components/SEO.jsx
@@ -8,7 +8,12 @@ import { Helmet } from 'react-helmet-async';
  * @param {string} props.description - Page description
  * @param {string} [props.url] - Canonical URL
  * @param {string} [props.image] - Open Graph image URL
- * @param {string} [props.type='website'] - Open Graph type
+ * @param {string} [props.imageAlt] - Alt text for the Open Graph image
+ * @param {string} [props.type='website'] - Open Graph type (e.g. 'website', 'article')
+ * @param {string} [props.locale='en_AU'] - Open Graph locale
+ * @param {string} [props.publishedTime] - ISO date the article was published (type='article')
+ * @param {string} [props.modifiedTime] - ISO date the article was last modified (type='article')
+ * @param {string} [props.section] - Article section / category (type='article')
  * @param {Object} [props.structuredData] - JSON-LD structured data
  */
 export default function SEO({
@@ -16,7 +21,12 @@ export default function SEO({
   description,
   url,
   image,
+  imageAlt = 'Australian Merger Tracker',
   type = 'website',
+  locale = 'en_AU',
+  publishedTime,
+  modifiedTime,
+  section,
   structuredData
 }) {
   const siteTitle = 'Australian Merger Tracker';
@@ -40,9 +50,22 @@ export default function SEO({
       <meta property="og:description" content={description} />
       <meta property="og:url" content={canonicalUrl} />
       <meta property="og:site_name" content={siteTitle} />
+      <meta property="og:locale" content={locale} />
       <meta property="og:image" content={ogImage} />
       <meta property="og:image:width" content="1200" />
       <meta property="og:image:height" content="630" />
+      <meta property="og:image:alt" content={imageAlt} />
+
+      {/* Article Tags */}
+      {type === 'article' && publishedTime && (
+        <meta property="article:published_time" content={publishedTime} />
+      )}
+      {type === 'article' && modifiedTime && (
+        <meta property="article:modified_time" content={modifiedTime} />
+      )}
+      {type === 'article' && section && (
+        <meta property="article:section" content={section} />
+      )}
 
       {/* Twitter Card Tags */}
       <meta name="twitter:card" content="summary_large_image" />

--- a/merger-tracker/frontend/src/pages/MergerDetail.jsx
+++ b/merger-tracker/frontend/src/pages/MergerDetail.jsx
@@ -118,37 +118,65 @@ function MergerDetail() {
     : null;
   const determinationDocUrl = statementOfReasonsEvent?.url_gh ?? determinationEvent?.url_gh;
 
-  const structuredData = {
+  const siteUrl = 'https://mergers.fyi';
+  const pagePath = `/mergers/${merger.merger_id}`;
+  const pageUrl = `${siteUrl}${pagePath}`;
+  const modifiedTime = merger.determination_publication_date || merger.effective_notification_datetime;
+  const articleSection = merger.anzsic_codes?.[0]?.name;
+
+  const articleSchema = {
     "@context": "https://schema.org",
     "@type": "Article",
     "headline": merger.merger_name,
     "description": merger.merger_description || `Merger between ${merger.acquirers.map(a => a.name).join(', ')} and ${merger.targets.map(t => t.name).join(', ')}`,
     "datePublished": merger.effective_notification_datetime,
+    "dateModified": modifiedTime,
+    "mainEntityOfPage": {
+      "@type": "WebPage",
+      "@id": pageUrl
+    },
     "author": {
       "@type": "Person",
       "name": "Nick Twort",
-      "url": "https://mergers.fyi"
+      "url": siteUrl
     },
-    "about": {
-      "@type": "MergerAcquisition",
-      "name": merger.merger_name,
-      "acquirer": merger.acquirers.map(a => ({
-        "@type": "Organization",
-        "name": a.name
-      })),
-      "target": merger.targets.map(t => ({
-        "@type": "Organization",
-        "name": t.name
-      }))
-    }
+    "publisher": {
+      "@type": "Organization",
+      "name": "Australian Merger Tracker",
+      "url": siteUrl,
+      "logo": {
+        "@type": "ImageObject",
+        "url": `${siteUrl}/og-image.png`
+      }
+    },
+    "about": [
+      ...merger.acquirers.map(a => ({ "@type": "Organization", "name": a.name })),
+      ...merger.targets.map(t => ({ "@type": "Organization", "name": t.name }))
+    ]
   };
+
+  const breadcrumbSchema = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": siteUrl },
+      { "@type": "ListItem", "position": 2, "name": "Mergers", "item": `${siteUrl}/mergers` },
+      { "@type": "ListItem", "position": 3, "name": merger.merger_name, "item": pageUrl }
+    ]
+  };
+
+  const structuredData = [articleSchema, breadcrumbSchema];
 
   return (
     <>
       <SEO
         title={merger.merger_name}
         description={merger.merger_description || `ACCC merger review: ${merger.acquirers.map(a => a.name).join(', ')} acquiring ${merger.targets.map(t => t.name).join(', ')}. Status: ${merger.status}`}
-        url={`/mergers/${merger.merger_id}`}
+        url={pagePath}
+        type="article"
+        publishedTime={merger.effective_notification_datetime}
+        modifiedTime={modifiedTime}
+        section={articleSection}
         structuredData={structuredData}
       />
       <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8 animate-fade-in">


### PR DESCRIPTION
- SEO component now emits og:locale, og:image:alt, and article:* tags
  (published_time, modified_time, section) when type='article'
- MergerDetail marks deal pages as og:type=article and passes
  publish/modify dates and industry section
- Article JSON-LD gains publisher, dateModified, and mainEntityOfPage
  to meet Google Article rich-result requirements
- Replace invalid schema.org type 'MergerAcquisition' with valid
  Organization entities under 'about'
- Add BreadcrumbList structured data