### PR TITLE
Clean edit-actions--N suffix in clean_html

### DIFF
--- a/data/raw/acquisitions-register.html
+++ b/data/raw/acquisitions-register.html
@@ -190,7 +190,7 @@
               <input placeholder="Search" data-drupal-selector="edit-query" data-search-api-autocomplete-search="accc_search_site" class="form-autocomplete form-control" data-autocomplete-path="/search_api_autocomplete/accc_search_site?display=search_box&amp;&amp;filter=query" type="text" id="edit-query--2" name="query" value="" size="30" maxlength="128" />
 
           </div>
-<div data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions--2">    <button aria-label="Submit search" data-drupal-selector="edit-submit-accc-search-site" type="submit" id="edit-submit-accc-search-site--STATIC" value="Search" class="button js-form-submit form-submit btn btn-primary">
+<div data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions">    <button aria-label="Submit search" data-drupal-selector="edit-submit-accc-search-site" type="submit" id="edit-submit-accc-search-site--STATIC" value="Search" class="button js-form-submit form-submit btn btn-primary">
   <span>Search</span>              <svg  class="fa-search" aria-hidden="true"><use href="/themes/custom/accc_bootstrap/icons/icons.svg?tSTATIC"></use></svg>
 
       
@@ -1950,8 +1950,8 @@
 <div class="anzsic-badges js-form-wrapper form-wrapper" data-drupal-selector="edit-anzsic-badges" id="edit-anzsic-badges"></div>
 <input data-drupal-selector="edit-unique-email-id" type="hidden" name="unique_email_id" value="" />
 
-  <input data-drupal-selector="edit-captcha-sid" type="hidden" name="captcha_sid" value="96956" />
-<input data-drupal-selector="edit-captcha-token" type="hidden" name="captcha_token" value="kAHwikWSysyxqeJ0U41U0r9viJRnpI-zLyp3rFXbrpM" />
+  <input data-drupal-selector="edit-captcha-sid" type="hidden" name="captcha_sid" value="96996" />
+<input data-drupal-selector="edit-captcha-token" type="hidden" name="captcha_token" value="HGnGw7Fm_ZN_eZmLOMX8mGuCmaPNoG0YHcyuUpVVE8w" />
 <input id="recaptcha-v3-token" class="recaptcha-v3-token" data-recaptcha-v3-action="default" data-recaptcha-v3-site-key="6LfbAC0pAAAAAO6f5xx7XiBzPfuoPh7AiGN-lhtq" data-drupal-selector="edit-captcha-response" type="hidden" name="captcha_response" value="" />
 <input data-drupal-selector="edit-is-recaptcha-v3" type="hidden" name="is_recaptcha_v3" value="1" />
 
@@ -1961,7 +1961,7 @@
   </button>
           </div>
 
-<div data-drupal-selector="edit-actions" class="form-actions webform-actions js-form-wrapper form-wrapper" id="edit-actions--3">  <input class="webform-button--submit button button--primary js-form-submit form-submit btn btn-primary" data-drupal-selector="edit-actions-submit" data-disable-refocus="true" type="submit" id="edit-actions-submit" name="op" value="Sign up now" />
+<div data-drupal-selector="edit-actions" class="form-actions webform-actions js-form-wrapper form-wrapper" id="edit-actions">  <input class="webform-button--submit button button--primary js-form-submit form-submit btn btn-primary" data-drupal-selector="edit-actions-submit" data-disable-refocus="true" type="submit" id="edit-actions-submit" name="op" value="Sign up now" />
 
 <span class="container-unsubscribe"> or <a href="#" class="js-webform-unsubscribe-all">Unsubscribe to all</a></span></div></div>
 <input autocomplete="off" data-drupal-selector="form-STATIC" type="hidden" name="form_build_id" value="form-STATIC" />
@@ -4324,9 +4324,9 @@ MGH is a diversified industrials group, which operates a civil construction and 
     <div class="views-row">
 
 <div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-170236">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/regional-australia-bank-%E2%80%93-south-west-slopes-credit-union">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  Regional Australia Bank – South West Slopes Credit Union
+  <div class="accc-collapsed-card__header" id="heading-169821">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/metro-petroleum-%E2%80%93-retail-sites-part-of-divestiture-remedy-from-ampol-eg-acquisition">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  Metro Petroleum – Retail sites part of divestiture remedy from Ampol-EG acquisition
 </h3>
 </div>
       
@@ -4342,7 +4342,7 @@ MGH is a diversified industrials group, which operates a civil construction and 
 </div>
   <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
     <h3 class="field__label">Case number</h3>
-              <div class="field__item">WA-30021</div>
+              <div class="field__item">WA-60020</div>
           </div>
   <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
     <h3 class="field__label">Waiver application date</h3>
@@ -4354,25 +4354,25 @@ MGH is a diversified industrials group, which operates a civil construction and 
 
   </div>
 </a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-170236" href="#card-170236">
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-169821" href="#card-169821">
       <span>expandable trigger</span>
     </a>
   </div>
-  <div id="card-170236" role="region" aria-labelledby="heading-170236" class="accc-collapsed-card__body collapse">
+  <div id="card-169821" role="region" aria-labelledby="heading-169821" class="accc-collapsed-card__body collapse">
     
 <div >
     <h3 class="border-bottom">About the acquisition</h3>
       <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
   <h3 class="field__label">Acquirer(s)</h3>
       <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638801">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637806">
       <span class="field_acccgov_name">
-            REGIONAL AUSTRALIA BANK LTD
+            DIB GROUP PTY. LIMITED
 
       </span>
       <span>
                         ABN -
-    21 087 650 360
+    87 002 889 474
 
               </span>
     </div>
@@ -4382,14 +4382,26 @@ MGH is a diversified industrials group, which operates a civil construction and 
 <div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
   <h3 class="field__label">Target(s) or vendor(s)</h3>
       <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638811">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637796">
       <span class="field_acccgov_name">
-            SOUTH WEST SLOPES CREDIT UNION LTD
+            AMPOL AUSTRALIA PETROLEUM PTY LTD
 
       </span>
       <span>
                         ABN -
-    80 087 650 673
+    17 000 032 128
+
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637801">
+      <span class="field_acccgov_name">
+            AMPOL RETAIL HOLDING PTY LTD
+
+      </span>
+      <span>
+                        ABN -
+    11 689 777 704
 
               </span>
     </div>
@@ -4399,23 +4411,27 @@ MGH is a diversified industrials group, which operates a civil construction and 
   <div class="field field--name-field-acccgov-anzsic-code field--type-entity-reference field--label-inline field--type-entity-reference--taxonomy_term clearfix">
     <h3 class="field__label">ANZSIC code(s)</h3>
           <div class="field__item">
-              6221 Banking              </div>
+              4000 Fuel Retailing;           4110 Supermarket and Grocery Stores              </div>
       </div>
   <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
     <h3 class="field__label">Description</h3>
               <div class="field__item">
 <div class="read-more-wrapper">
       <div class="summary-text">
-      <p>Regional Australia Bank Ltd (<strong>Regional Australia Bank</strong>) and South West Slopes Credit Union Ltd (trading as <strong>SWSbank</strong>) have lodged a regulatory submission with the Aust</p>
+      <p>Dib Group Pty Limited (<strong>Dib Group</strong>) proposes to acquire 41 retail fuel sites from Ampol Retail Holding Pty Ltd , a wholly owned subsidiary of Ampol Limited (<strong>Ampol</strong>), </p>
     </div>
     <div class="full-text" style="display:none;">
-    <p>Regional Australia Bank Ltd (<strong>Regional Australia Bank</strong>) and South West Slopes Credit Union Ltd (trading as <strong>SWSbank</strong>) have lodged a regulatory submission with the Australian Prudential Regulation Authority (<strong>APRA</strong>) for SWSbank to undertake a Total Transfer of Business of all assets and liabilities to Regional Australia Bank. Upon completion of the Transfer of Business, SWSbank members and customers will be migrated to Regional Australia Bank. All of the assets, liabilities and members of SWSbank will transfer to Regional Australia Bank (the <strong>Acquisition</strong>).</p>
+    <p>Dib Group Pty Limited (<strong>Dib Group</strong>) proposes to acquire 41 retail fuel sites from Ampol Retail Holding Pty Ltd , a wholly owned subsidiary of Ampol Limited (<strong>Ampol</strong>), as part of Ampol’s proposed remedy offered to the ACCC in relation to its acquisition of all of the issued shares in each of EG Group Australia Pty Ltd and EG AsiaPac Holdings Pty Ltd (<strong>Ampol EG Acquisition</strong>).</p>
 
-<p>Regional Australia Bank is a customer owned banking institution and has been providing a full range of banking services to its members across regional Australia for over 55 years. Operating in regional NSW, and with administrative offices located across Armidale, Port Macquarie and Lismore, Regional Australia Bank has over 120,000 members, assets of $5.03 billion and is serviced by 49 branches and offices throughout New South Wales and southern Queensland and around 480 employees.</p>
+<p>The acquirer, Dib Group, is an independent fuel retailer which operates a network of over 300 retail fuel and convenience sites across New South Wales, Victoria, Queensland and Western Australia, under the Metro Petroleum (<strong>Metro</strong>) brand. Metro is also involved in wholesale petroleum supply, fuel logistics and distribution, and related petroleum industry activities. &nbsp;</p>
 
-<p>SWSbank is a customer owned banking institution and has been providing a full range of banking services to its members across the Riverina regions of NSW since its inception in 1972. SWSbank operates 4 branches and 1 agency across its regions with the head office located in Young (NSW). SWSbank employs around 40 staff and has over 14,000 members and $323 million in assets.</p>
+<p>The vendor, Ampol, is a vertically integrated fuel company with upstream fuel production and importing assets, wholesale supply and distribution facilities and a network of retail fuel and convenience sites across Australia.</p>
 
-<p>Regional Australia Bank and SWSbank provide retail loan and deposit banking services, including, personal, home and business loans, transaction accounts, savings accounts and term deposits to members and customers across regional Australia.</p>
+<p>Ampol owns the Lytton refinery in Brisbane, Queensland, where it refines imported crude oil, and a number of terminals nationwide through which it imports finished petrol products from overseas refineries and trading houses.&nbsp;</p>
+
+<p>Ampol operates retail sites under both the Ampol brand and the U-GO brand. Ampol branded sites are full-service sites with fuel and convenience offerings. Launched in 2023, the U-GO branded sites are low cost, unstaffed self-service sites selling only fuel and with no convenience offering. Ampol owns and operates 576 sites under the Ampol brand, and 46 under the U-GO brand.</p>
+
+<p>Metro and Ampol are both active in the retail and wholesale supply of fuel, and the retail supply of convenience products in Australia. &nbsp;</p>
 
   </div>
       <a href="#" class="read-toggle" data-expanded="true">read more</a>
@@ -5262,9 +5278,9 @@ MGH is a diversified industrials group, which operates a civil construction and 
     <div class="views-row">
 
 <div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-169821">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/metro-petroleum-%E2%80%93-retail-sites-part-of-divestiture-remedy-from-ampol-eg-acquisition">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  Metro Petroleum – Retail sites part of divestiture remedy from Ampol-EG acquisition
+  <div class="accc-collapsed-card__header" id="heading-170236">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/regional-australia-bank-%E2%80%93-south-west-slopes-credit-union">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  Regional Australia Bank – South West Slopes Credit Union
 </h3>
 </div>
       
@@ -5280,7 +5296,7 @@ MGH is a diversified industrials group, which operates a civil construction and 
 </div>
   <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
     <h3 class="field__label">Case number</h3>
-              <div class="field__item">WA-60020</div>
+              <div class="field__item">WA-30021</div>
           </div>
   <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
     <h3 class="field__label">Waiver application date</h3>
@@ -5292,25 +5308,25 @@ MGH is a diversified industrials group, which operates a civil construction and 
 
   </div>
 </a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-169821" href="#card-169821">
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-170236" href="#card-170236">
       <span>expandable trigger</span>
     </a>
   </div>
-  <div id="card-169821" role="region" aria-labelledby="heading-169821" class="accc-collapsed-card__body collapse">
+  <div id="card-170236" role="region" aria-labelledby="heading-170236" class="accc-collapsed-card__body collapse">
     
 <div >
     <h3 class="border-bottom">About the acquisition</h3>
       <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
   <h3 class="field__label">Acquirer(s)</h3>
       <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637806">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638801">
       <span class="field_acccgov_name">
-            DIB GROUP PTY. LIMITED
+            REGIONAL AUSTRALIA BANK LTD
 
       </span>
       <span>
                         ABN -
-    87 002 889 474
+    21 087 650 360
 
               </span>
     </div>
@@ -5320,26 +5336,14 @@ MGH is a diversified industrials group, which operates a civil construction and 
 <div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
   <h3 class="field__label">Target(s) or vendor(s)</h3>
       <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637796">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638811">
       <span class="field_acccgov_name">
-            AMPOL AUSTRALIA PETROLEUM PTY LTD
+            SOUTH WEST SLOPES CREDIT UNION LTD
 
       </span>
       <span>
                         ABN -
-    17 000 032 128
-
-              </span>
-    </div>
-  </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637801">
-      <span class="field_acccgov_name">
-            AMPOL RETAIL HOLDING PTY LTD
-
-      </span>
-      <span>
-                        ABN -
-    11 689 777 704
+    80 087 650 673
 
               </span>
     </div>
@@ -5349,27 +5353,23 @@ MGH is a diversified industrials group, which operates a civil construction and 
   <div class="field field--name-field-acccgov-anzsic-code field--type-entity-reference field--label-inline field--type-entity-reference--taxonomy_term clearfix">
     <h3 class="field__label">ANZSIC code(s)</h3>
           <div class="field__item">
-              4000 Fuel Retailing;           4110 Supermarket and Grocery Stores              </div>
+              6221 Banking              </div>
       </div>
   <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
     <h3 class="field__label">Description</h3>
               <div class="field__item">
 <div class="read-more-wrapper">
       <div class="summary-text">
-      <p>Dib Group Pty Limited (<strong>Dib Group</strong>) proposes to acquire 41 retail fuel sites from Ampol Retail Holding Pty Ltd , a wholly owned subsidiary of Ampol Limited (<strong>Ampol</strong>), </p>
+      <p>Regional Australia Bank Ltd (<strong>Regional Australia Bank</strong>) and South West Slopes Credit Union Ltd (trading as <strong>SWSbank</strong>) have lodged a regulatory submission with the Aust</p>
     </div>
     <div class="full-text" style="display:none;">
-    <p>Dib Group Pty Limited (<strong>Dib Group</strong>) proposes to acquire 41 retail fuel sites from Ampol Retail Holding Pty Ltd , a wholly owned subsidiary of Ampol Limited (<strong>Ampol</strong>), as part of Ampol’s proposed remedy offered to the ACCC in relation to its acquisition of all of the issued shares in each of EG Group Australia Pty Ltd and EG AsiaPac Holdings Pty Ltd (<strong>Ampol EG Acquisition</strong>).</p>
+    <p>Regional Australia Bank Ltd (<strong>Regional Australia Bank</strong>) and South West Slopes Credit Union Ltd (trading as <strong>SWSbank</strong>) have lodged a regulatory submission with the Australian Prudential Regulation Authority (<strong>APRA</strong>) for SWSbank to undertake a Total Transfer of Business of all assets and liabilities to Regional Australia Bank. Upon completion of the Transfer of Business, SWSbank members and customers will be migrated to Regional Australia Bank. All of the assets, liabilities and members of SWSbank will transfer to Regional Australia Bank (the <strong>Acquisition</strong>).</p>
 
-<p>The acquirer, Dib Group, is an independent fuel retailer which operates a network of over 300 retail fuel and convenience sites across New South Wales, Victoria, Queensland and Western Australia, under the Metro Petroleum (<strong>Metro</strong>) brand. Metro is also involved in wholesale petroleum supply, fuel logistics and distribution, and related petroleum industry activities. &nbsp;</p>
+<p>Regional Australia Bank is a customer owned banking institution and has been providing a full range of banking services to its members across regional Australia for over 55 years. Operating in regional NSW, and with administrative offices located across Armidale, Port Macquarie and Lismore, Regional Australia Bank has over 120,000 members, assets of $5.03 billion and is serviced by 49 branches and offices throughout New South Wales and southern Queensland and around 480 employees.</p>
 
-<p>The vendor, Ampol, is a vertically integrated fuel company with upstream fuel production and importing assets, wholesale supply and distribution facilities and a network of retail fuel and convenience sites across Australia.</p>
+<p>SWSbank is a customer owned banking institution and has been providing a full range of banking services to its members across the Riverina regions of NSW since its inception in 1972. SWSbank operates 4 branches and 1 agency across its regions with the head office located in Young (NSW). SWSbank employs around 40 staff and has over 14,000 members and $323 million in assets.</p>
 
-<p>Ampol owns the Lytton refinery in Brisbane, Queensland, where it refines imported crude oil, and a number of terminals nationwide through which it imports finished petrol products from overseas refineries and trading houses.&nbsp;</p>
-
-<p>Ampol operates retail sites under both the Ampol brand and the U-GO brand. Ampol branded sites are full-service sites with fuel and convenience offerings. Launched in 2023, the U-GO branded sites are low cost, unstaffed self-service sites selling only fuel and with no convenience offering. Ampol owns and operates 576 sites under the Ampol brand, and 46 under the U-GO brand.</p>
-
-<p>Metro and Ampol are both active in the retail and wholesale supply of fuel, and the retail supply of convenience products in Australia. &nbsp;</p>
+<p>Regional Australia Bank and SWSbank provide retail loan and deposit banking services, including, personal, home and business loans, transaction accounts, savings accounts and term deposits to members and customers across regional Australia.</p>
 
   </div>
       <a href="#" class="read-toggle" data-expanded="true">read more</a>
@@ -5490,123 +5490,6 @@ MGH is a diversified industrials group, which operates a civil construction and 
 <p>CRK is an importer and distributor of photographic, hunting, geospatial, medical and surveillance equipment. CRK's medical division supplies specialised medical equipment, technology, software, and support services primarily to the healthcare sector across Australia and New Zealand.</p>
 
 <p>CRK supplies FUJIFILM-branded endoscopy products to hospitals, day surgeries and medical clinics in Australia for use in endoscopic procedures. CRK also provides servicing and preventative maintenance for endoscopy equipment, from its fully equipped service repair centres in Melbourne and Sydney offering repairs on equipment nationally using advanced diagnostic equipment, tools, multi-function inspection and quality control tests. The Acquisition only concerns the distribution of FUJIFILM Australia’s endoscopy products. CRK will otherwise continue to operate its medical distribution business.</p>
-
-  </div>
-      <a href="#" class="read-toggle" data-expanded="true">read more</a>
-  </div></div>
-          </div>
-
-  </div>
-
-  </div>
-</div>
-
-</div>
-    <div class="views-row">
-
-<div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-170231">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/platinum-equity-group-lmpg">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  Platinum Equity Group - LMPG
-</h3>
-</div>
-      
-<div  class="accc-collapsed-card__header-info">
-        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
-    <h3 class="field__label">Acquisition status</h3>
-              <div class="field__item">Assessment completed</div>
-          </div>
-
-<div  class="accc-collapsed-card__header-content">
-      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
-<div class="field__item">Waiver</div>
-</div>
-  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
-    <h3 class="field__label">Case number</h3>
-              <div class="field__item">WA-80020</div>
-          </div>
-  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
-    <h3 class="field__label">Waiver application date</h3>
-              <div class="field__item"><time datetime="2026-05-22T12:00:00Z" class="datetime">22 May 2026</time>
-</div>
-          </div>
-
-  </div>
-
-  </div>
-</a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-170231" href="#card-170231">
-      <span>expandable trigger</span>
-    </a>
-  </div>
-  <div id="card-170231" role="region" aria-labelledby="heading-170231" class="accc-collapsed-card__body collapse">
-    
-<div >
-    <h3 class="border-bottom">About the acquisition</h3>
-      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Acquirer(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638781">
-      <span class="field_acccgov_name">
-            Fos Acquisition Corporation
-
-      </span>
-      <span>
-                      Corporation No - 1001607698
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Target(s) or vendor(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638796">
-      <span class="field_acccgov_name">
-            LMPG Inc.
-
-      </span>
-      <span>
-                      Corporation No - 1148900-3
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-other-parties field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Other party(ies)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638791">
-      <span class="field_acccgov_name">
-            Platinum Equity Advisors, LLC
-
-      </span>
-      <span>
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-  <div class="field field--name-field-acccgov-anzsic-code field--type-entity-reference field--label-inline field--type-entity-reference--taxonomy_term clearfix">
-    <h3 class="field__label">ANZSIC code(s)</h3>
-          <div class="field__item">
-              2432 Electric Lighting Equipment Manufacturing;           6240 Financial Asset Investing              </div>
-      </div>
-  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
-    <h3 class="field__label">Description</h3>
-              <div class="field__item">
-<div class="read-more-wrapper">
-      <div class="summary-text">
-      <p>Fos Acquisition Corporation (a vehicle ultimately controlled by Platinum Equity Advisors, LLC (<strong>Platinum Equity</strong>)) proposes to acquire 100% of the issued share capital in LMPG Inc.</p>
-    </div>
-    <div class="full-text" style="display:none;">
-    <p>Fos Acquisition Corporation (a vehicle ultimately controlled by Platinum Equity Advisors, LLC (<strong>Platinum Equity</strong>)) proposes to acquire 100% of the issued share capital in LMPG Inc. (<strong>LMPG</strong>) (the <strong>Acquisition</strong>).</p>
-
-<p>Platinum Equity is a US-headquartered global private equity and investment strategies firm. Platinum Equity specialises in the merger, acquisition and operation of companies providing services and solutions to customers in a broad range of sectors including, for example, business services, information technology, telecommunications, logistics, metal services, manufacturing and distribution.</p>
-
-<p>LMPG designs and manufactures specification-grade LED lighting products for the hospitality, infrastructure, workplace, retail and entertainment sectors, primarily in commercial, institutional and urban settings. Its product range includes indoor, outdoor, and site and area LED lighting solutions, available across a range of optics, colours, accessories and finishes, and manufactured to client specifications. LMPG supplies these products under the Lumenpulse, Fluxwerx, Sternberg, Exenia, Pa-Co, Lumca, ALW and Vode brands. Headquartered in Quebec, Canada, LMPG designs and manufactures its lighting solutions across several sites in North America and one site in Italy.</p>
 
   </div>
       <a href="#" class="read-toggle" data-expanded="true">read more</a>
@@ -6483,9 +6366,9 @@ MGH is a diversified industrials group, which operates a civil construction and 
     <div class="views-row">
 
 <div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-170226">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/kkr-%E2%80%93-freshacom">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  KKR – Fresha.com
+  <div class="accc-collapsed-card__header" id="heading-170231">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/platinum-equity-group-lmpg">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  Platinum Equity Group - LMPG
 </h3>
 </div>
       
@@ -6501,11 +6384,11 @@ MGH is a diversified industrials group, which operates a civil construction and 
 </div>
   <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
     <h3 class="field__label">Case number</h3>
-              <div class="field__item">WA-30019</div>
+              <div class="field__item">WA-80020</div>
           </div>
   <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
     <h3 class="field__label">Waiver application date</h3>
-              <div class="field__item"><time datetime="2026-05-21T12:00:00Z" class="datetime">21 May 2026</time>
+              <div class="field__item"><time datetime="2026-05-22T12:00:00Z" class="datetime">22 May 2026</time>
 </div>
           </div>
 
@@ -6513,34 +6396,25 @@ MGH is a diversified industrials group, which operates a civil construction and 
 
   </div>
 </a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-170226" href="#card-170226">
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-170231" href="#card-170231">
       <span>expandable trigger</span>
     </a>
   </div>
-  <div id="card-170226" role="region" aria-labelledby="heading-170226" class="accc-collapsed-card__body collapse">
+  <div id="card-170231" role="region" aria-labelledby="heading-170231" class="accc-collapsed-card__body collapse">
     
 <div >
     <h3 class="border-bottom">About the acquisition</h3>
       <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
   <h3 class="field__label">Acquirer(s)</h3>
       <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638746">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638781">
       <span class="field_acccgov_name">
-            Flamingo UK LP
+            Fos Acquisition Corporation
 
       </span>
       <span>
-                      UK Company Registration Number - LP024570
+                      Corporation No - 1001607698
 
-              </span>
-    </div>
-  </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638751">
-      <span class="field_acccgov_name">
-            Flamingo UK GP Ltd
-
-      </span>
-      <span>
               </span>
     </div>
   </li>
@@ -6549,13 +6423,13 @@ MGH is a diversified industrials group, which operates a civil construction and 
 <div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
   <h3 class="field__label">Target(s) or vendor(s)</h3>
       <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638771">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638796">
       <span class="field_acccgov_name">
-            Fresha.com Holding Inc.
+            LMPG Inc.
 
       </span>
       <span>
-                      British Virgin Islands Company Registration Number - 1862061
+                      Corporation No - 1148900-3
 
               </span>
     </div>
@@ -6565,21 +6439,9 @@ MGH is a diversified industrials group, which operates a civil construction and 
 <div class="field field--name-field-acccgov-other-parties field--type-entity-reference-revisions field--label-inline clearfix">
   <h3 class="field__label">Other party(ies)</h3>
       <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638761">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638791">
       <span class="field_acccgov_name">
-            FRESHA.COM PTY LTD
-
-      </span>
-      <span>
-                        ABN -
-    11 627 580 563
-
-              </span>
-    </div>
-  </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638766">
-      <span class="field_acccgov_name">
-             KKR &amp; Co. Inc
+            Platinum Equity Advisors, LLC
 
       </span>
       <span>
@@ -6591,132 +6453,21 @@ MGH is a diversified industrials group, which operates a civil construction and 
   <div class="field field--name-field-acccgov-anzsic-code field--type-entity-reference field--label-inline field--type-entity-reference--taxonomy_term clearfix">
     <h3 class="field__label">ANZSIC code(s)</h3>
           <div class="field__item">
-              5420 Software Publishing;           6240 Financial Asset Investing              </div>
+              2432 Electric Lighting Equipment Manufacturing;           6240 Financial Asset Investing              </div>
       </div>
   <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
     <h3 class="field__label">Description</h3>
               <div class="field__item">
 <div class="read-more-wrapper">
       <div class="summary-text">
-      <p>Flamingo UK LP, acting by its general partner Flamingo UK GP Ltd, a special purpose vehicle indirectly wholly owned by investment funds, vehicles, and/or accounts advised and managed by various sub</p>
+      <p>Fos Acquisition Corporation (a vehicle ultimately controlled by Platinum Equity Advisors, LLC (<strong>Platinum Equity</strong>)) proposes to acquire 100% of the issued share capital in LMPG Inc.</p>
     </div>
     <div class="full-text" style="display:none;">
-    <p>Flamingo UK LP, acting by its general partner Flamingo UK GP Ltd, a special purpose vehicle indirectly wholly owned by investment funds, vehicles, and/or accounts advised and managed by various subsidiaries of KKR &amp; Co. Inc. (together with its subsidiaries, <strong>KKR</strong>), proposes to acquire issued preference shares in Fresha.com Holding Inc. (the <strong>Acquisition</strong>).</p>
+    <p>Fos Acquisition Corporation (a vehicle ultimately controlled by Platinum Equity Advisors, LLC (<strong>Platinum Equity</strong>)) proposes to acquire 100% of the issued share capital in LMPG Inc. (<strong>LMPG</strong>) (the <strong>Acquisition</strong>).</p>
 
-<p>KKR is a global investment firm that offers alternative asset management as well as capital markets and insurance solutions. KKR sponsors investment funds that invest in private equity, credit, and real assets and has strategic partners that manage hedge funds.&nbsp;</p>
+<p>Platinum Equity is a US-headquartered global private equity and investment strategies firm. Platinum Equity specialises in the merger, acquisition and operation of companies providing services and solutions to customers in a broad range of sectors including, for example, business services, information technology, telecommunications, logistics, metal services, manufacturing and distribution.</p>
 
-<p>Fresha.com Holding Inc. and its affiliated entities, including the Australian wholly owned subsidiary Fresha.com Pty Ltd (together,<strong> </strong><strong>Fresha.com</strong>), operate a global, cloud‑based software platform and online marketplace for the beauty, wellness and self‑care industry. Fresha.com supplies its services under the 'Fresha' brand.&nbsp;</p>
-
-<p>According to the application, the Acquisition will not result in KKR acquiring any controlling interest in Fresha.com. Investment funds, vehicles and/or accounts advised and managed by KKR do not presently hold any interests in software platforms that cater to the beauty, wellness and self-care industry, or provide relevant inputs to such businesses.</p>
-
-  </div>
-      <a href="#" class="read-toggle" data-expanded="true">read more</a>
-  </div></div>
-          </div>
-
-  </div>
-
-  </div>
-</div>
-
-</div>
-    <div class="views-row">
-
-<div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-169736">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/respect-group-jallarah-homes">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  Respect Group - Jallarah Homes
-</h3>
-</div>
-      
-<div  class="accc-collapsed-card__header-info">
-        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
-    <h3 class="field__label">Acquisition status</h3>
-              <div class="field__item">Assessment completed</div>
-          </div>
-
-<div  class="accc-collapsed-card__header-content">
-      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
-<div class="field__item">Waiver</div>
-</div>
-  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
-    <h3 class="field__label">Case number</h3>
-              <div class="field__item">WA-35020</div>
-          </div>
-  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
-    <h3 class="field__label">Waiver application date</h3>
-              <div class="field__item"><time datetime="2026-05-21T12:00:00Z" class="datetime">21 May 2026</time>
-</div>
-          </div>
-
-  </div>
-
-  </div>
-</a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-169736" href="#card-169736">
-      <span>expandable trigger</span>
-    </a>
-  </div>
-  <div id="card-169736" role="region" aria-labelledby="heading-169736" class="accc-collapsed-card__body collapse">
-    
-<div >
-    <h3 class="border-bottom">About the acquisition</h3>
-      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Acquirer(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637551">
-      <span class="field_acccgov_name">
-            RESPECT GROUP LIMITED
-
-      </span>
-      <span>
-                        ABN -
-    74 121 263 545
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Target(s) or vendor(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637561">
-      <span class="field_acccgov_name">
-            JALLARAH HOMES INC
-
-      </span>
-      <span>
-                        ABN -
-    13 238 944 953
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-  <div class="field field--name-field-acccgov-anzsic-code field--type-entity-reference field--label-inline field--type-entity-reference--taxonomy_term clearfix">
-    <h3 class="field__label">ANZSIC code(s)</h3>
-          <div class="field__item">
-              8601 Aged Care Residential Services              </div>
-      </div>
-  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
-    <h3 class="field__label">Description</h3>
-              <div class="field__item">
-<div class="read-more-wrapper">
-      <div class="summary-text">
-      <p>Respect Group Limited (<strong>Respect</strong>) proposes to acquire 100% of the business and assets owned by Jallarah Homes Inc (<strong>Jallarah</strong>) (the <strong>Acquisition</strong>)</p>
-    </div>
-    <div class="full-text" style="display:none;">
-    <p>Respect Group Limited (<strong>Respect</strong>) proposes to acquire 100% of the business and assets owned by Jallarah Homes Inc (<strong>Jallarah</strong>) (the <strong>Acquisition</strong>)</p>
-
-<p>Respect is a not-for-profit registered charity and unlisted public company based in Tasmania which provides residential aged care, retirement living and support at home services focused on dignity and well-being for older adults. Respect owns and operates 40 residential aged care homes and 30 retirement villages across Tasmania, New South Wales, Victoria and Queensland.</p>
-
-<p>Jallarah is a not-for-profit incorporated association and registered charity operating a single site residential aged care facility and co-located independent living units in Meningie, South Australia. The aged care facility has 30 beds and 5 independent living units.</p>
-
-<p>Each of the parties provides residential aged care services in accordance with the <em>Aged Care Act 2024</em> (Cth). Jallarah also provides retirement living services under the <em>Retirement Villages Act 2016</em> (SA) whilst Respect provides retirement living services in accordance with the relevant state legislation in Tasmania, New South Wales, Victoria and Queensland. If the Acquisition proceeds, the Jallarah business would constitute Respect’s first entry into the South Australian residential aged care and retirement living market.</p>
-
-<p>The Acquisition is planned to occur through a two step process in which the parties enter into a merger implementation deed, whereby the directors of Respect are appointed to the board of Jallarah, such that Jallarah becomes an associated entity of Respect, and subsequently, the business and assets (including land) of Jallarah are transferred to Respect. The residential aged care home and independent living units will continue to operate following the transaction.</p>
+<p>LMPG designs and manufactures specification-grade LED lighting products for the hospitality, infrastructure, workplace, retail and entertainment sectors, primarily in commercial, institutional and urban settings. Its product range includes indoor, outdoor, and site and area LED lighting solutions, available across a range of optics, colours, accessories and finishes, and manufactured to client specifications. LMPG supplies these products under the Lumenpulse, Fluxwerx, Sternberg, Exenia, Pa-Co, Lumca, ALW and Vode brands. Headquartered in Quebec, Canada, LMPG designs and manufactures its lighting solutions across several sites in North America and one site in Italy.</p>
 
   </div>
       <a href="#" class="read-toggle" data-expanded="true">read more</a>
@@ -7458,9 +7209,9 @@ MGH is a diversified industrials group, which operates a civil construction and 
     <div class="views-row">
 
 <div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-170146">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/capital-group-big-post">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  Capital Group - Big Post
+  <div class="accc-collapsed-card__header" id="heading-169736">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/respect-group-jallarah-homes">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  Respect Group - Jallarah Homes
 </h3>
 </div>
       
@@ -7476,11 +7227,11 @@ MGH is a diversified industrials group, which operates a civil construction and 
 </div>
   <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
     <h3 class="field__label">Case number</h3>
-              <div class="field__item">WA-95019</div>
+              <div class="field__item">WA-35020</div>
           </div>
   <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
     <h3 class="field__label">Waiver application date</h3>
-              <div class="field__item"><time datetime="2026-05-20T12:00:00Z" class="datetime">20 May 2026</time>
+              <div class="field__item"><time datetime="2026-05-21T12:00:00Z" class="datetime">21 May 2026</time>
 </div>
           </div>
 
@@ -7488,25 +7239,25 @@ MGH is a diversified industrials group, which operates a civil construction and 
 
   </div>
 </a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-170146" href="#card-170146">
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-169736" href="#card-169736">
       <span>expandable trigger</span>
     </a>
   </div>
-  <div id="card-170146" role="region" aria-labelledby="heading-170146" class="accc-collapsed-card__body collapse">
+  <div id="card-169736" role="region" aria-labelledby="heading-169736" class="accc-collapsed-card__body collapse">
     
 <div >
     <h3 class="border-bottom">About the acquisition</h3>
       <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
   <h3 class="field__label">Acquirer(s)</h3>
       <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638556">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637551">
       <span class="field_acccgov_name">
-            Mimeca Nominees Pty Ltd
+            RESPECT GROUP LIMITED
 
       </span>
       <span>
-                        ACN -
-    005 701 253
+                        ABN -
+    74 121 263 545
 
               </span>
     </div>
@@ -7516,14 +7267,14 @@ MGH is a diversified industrials group, which operates a civil construction and 
 <div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
   <h3 class="field__label">Target(s) or vendor(s)</h3>
       <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638571">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637561">
       <span class="field_acccgov_name">
-            Big Post Pty Ltd
+            JALLARAH HOMES INC
 
       </span>
       <span>
                         ABN -
-    19 145 428 002
+    13 238 944 953
 
               </span>
     </div>
@@ -7533,23 +7284,165 @@ MGH is a diversified industrials group, which operates a civil construction and 
   <div class="field field--name-field-acccgov-anzsic-code field--type-entity-reference field--label-inline field--type-entity-reference--taxonomy_term clearfix">
     <h3 class="field__label">ANZSIC code(s)</h3>
           <div class="field__item">
-              4610 Road Freight Transport              </div>
+              8601 Aged Care Residential Services              </div>
       </div>
   <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
     <h3 class="field__label">Description</h3>
               <div class="field__item">
 <div class="read-more-wrapper">
       <div class="summary-text">
-      <p>On 19 May 2026, Mimeca Nominees Pty Ltd as trustee for Mimeca Nominees Trust (<strong>Mimeca Nominees</strong>) entered into a Share Purchase Agreement to acquire 100% of the issued shares in Big P</p>
+      <p>Respect Group Limited (<strong>Respect</strong>) proposes to acquire 100% of the business and assets owned by Jallarah Homes Inc (<strong>Jallarah</strong>) (the <strong>Acquisition</strong>)</p>
     </div>
     <div class="full-text" style="display:none;">
-    <p>On 19 May 2026, Mimeca Nominees Pty Ltd as trustee for Mimeca Nominees Trust (<strong>Mimeca Nominees</strong>) entered into a Share Purchase Agreement to acquire 100% of the issued shares in Big Post Pty Ltd (<strong>Big Post</strong>)(the <strong>Acquisition</strong>).&nbsp;Mimeca Nominees and its connected entities trade under the name <strong>Capital Group</strong>.</p>
+    <p>Respect Group Limited (<strong>Respect</strong>) proposes to acquire 100% of the business and assets owned by Jallarah Homes Inc (<strong>Jallarah</strong>) (the <strong>Acquisition</strong>)</p>
 
-<p>Capital Group is a transport and logistics service provider. It supplies courier and freight services across metropolitan, regional and interstate Australia, primarily to business customers (as well as to residential customers). Its operations are focussed on providing flexible access to external carrier capacity for time-critical freight, with the majority of its revenue derived from same-day metropolitan point-to-point deliveries managed via a fleet of subcontractor owner-drivers.</p>
+<p>Respect is a not-for-profit registered charity and unlisted public company based in Tasmania which provides residential aged care, retirement living and support at home services focused on dignity and well-being for older adults. Respect owns and operates 40 residential aged care homes and 30 retirement villages across Tasmania, New South Wales, Victoria and Queensland.</p>
 
-<p>Capital Group also supplies freight brokerage and logistics services as a complementary part of its broader transport and logistics offering. This involves warehousing services, and the arrangement and coordination of the transport of goods for customers (including linehaul, home delivery, courier, truck) by sourcing external carrier capacity from independent third parties.</p>
+<p>Jallarah is a not-for-profit incorporated association and registered charity operating a single site residential aged care facility and co-located independent living units in Meningie, South Australia. The aged care facility has 30 beds and 5 independent living units.</p>
 
-<p>Big Post is a freight brokerage business supplying road freight transport services across Australia, with a particular focus on small-to-medium enterprise customers across business-to-business, business-to-consumer and business-to-depot channels.</p>
+<p>Each of the parties provides residential aged care services in accordance with the <em>Aged Care Act 2024</em> (Cth). Jallarah also provides retirement living services under the <em>Retirement Villages Act 2016</em> (SA) whilst Respect provides retirement living services in accordance with the relevant state legislation in Tasmania, New South Wales, Victoria and Queensland. If the Acquisition proceeds, the Jallarah business would constitute Respect’s first entry into the South Australian residential aged care and retirement living market.</p>
+
+<p>The Acquisition is planned to occur through a two step process in which the parties enter into a merger implementation deed, whereby the directors of Respect are appointed to the board of Jallarah, such that Jallarah becomes an associated entity of Respect, and subsequently, the business and assets (including land) of Jallarah are transferred to Respect. The residential aged care home and independent living units will continue to operate following the transaction.</p>
+
+  </div>
+      <a href="#" class="read-toggle" data-expanded="true">read more</a>
+  </div></div>
+          </div>
+
+  </div>
+
+  </div>
+</div>
+
+</div>
+    <div class="views-row">
+
+<div  class="accc-collapsed-card contextual-region h-100">
+  <div class="accc-collapsed-card__header" id="heading-170226">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/kkr-%E2%80%93-freshacom">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  KKR – Fresha.com
+</h3>
+</div>
+      
+<div  class="accc-collapsed-card__header-info">
+        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
+    <h3 class="field__label">Acquisition status</h3>
+              <div class="field__item">Assessment completed</div>
+          </div>
+
+<div  class="accc-collapsed-card__header-content">
+      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
+<div class="field__item">Waiver</div>
+</div>
+  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
+    <h3 class="field__label">Case number</h3>
+              <div class="field__item">WA-30019</div>
+          </div>
+  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
+    <h3 class="field__label">Waiver application date</h3>
+              <div class="field__item"><time datetime="2026-05-21T12:00:00Z" class="datetime">21 May 2026</time>
+</div>
+          </div>
+
+  </div>
+
+  </div>
+</a>
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-170226" href="#card-170226">
+      <span>expandable trigger</span>
+    </a>
+  </div>
+  <div id="card-170226" role="region" aria-labelledby="heading-170226" class="accc-collapsed-card__body collapse">
+    
+<div >
+    <h3 class="border-bottom">About the acquisition</h3>
+      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Acquirer(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638746">
+      <span class="field_acccgov_name">
+            Flamingo UK LP
+
+      </span>
+      <span>
+                      UK Company Registration Number - LP024570
+
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638751">
+      <span class="field_acccgov_name">
+            Flamingo UK GP Ltd
+
+      </span>
+      <span>
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Target(s) or vendor(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638771">
+      <span class="field_acccgov_name">
+            Fresha.com Holding Inc.
+
+      </span>
+      <span>
+                      British Virgin Islands Company Registration Number - 1862061
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-other-parties field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Other party(ies)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638761">
+      <span class="field_acccgov_name">
+            FRESHA.COM PTY LTD
+
+      </span>
+      <span>
+                        ABN -
+    11 627 580 563
+
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638766">
+      <span class="field_acccgov_name">
+             KKR &amp; Co. Inc
+
+      </span>
+      <span>
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+  <div class="field field--name-field-acccgov-anzsic-code field--type-entity-reference field--label-inline field--type-entity-reference--taxonomy_term clearfix">
+    <h3 class="field__label">ANZSIC code(s)</h3>
+          <div class="field__item">
+              5420 Software Publishing;           6240 Financial Asset Investing              </div>
+      </div>
+  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
+    <h3 class="field__label">Description</h3>
+              <div class="field__item">
+<div class="read-more-wrapper">
+      <div class="summary-text">
+      <p>Flamingo UK LP, acting by its general partner Flamingo UK GP Ltd, a special purpose vehicle indirectly wholly owned by investment funds, vehicles, and/or accounts advised and managed by various sub</p>
+    </div>
+    <div class="full-text" style="display:none;">
+    <p>Flamingo UK LP, acting by its general partner Flamingo UK GP Ltd, a special purpose vehicle indirectly wholly owned by investment funds, vehicles, and/or accounts advised and managed by various subsidiaries of KKR &amp; Co. Inc. (together with its subsidiaries, <strong>KKR</strong>), proposes to acquire issued preference shares in Fresha.com Holding Inc. (the <strong>Acquisition</strong>).</p>
+
+<p>KKR is a global investment firm that offers alternative asset management as well as capital markets and insurance solutions. KKR sponsors investment funds that invest in private equity, credit, and real assets and has strategic partners that manage hedge funds.&nbsp;</p>
+
+<p>Fresha.com Holding Inc. and its affiliated entities, including the Australian wholly owned subsidiary Fresha.com Pty Ltd (together,<strong> </strong><strong>Fresha.com</strong>), operate a global, cloud‑based software platform and online marketplace for the beauty, wellness and self‑care industry. Fresha.com supplies its services under the 'Fresha' brand.&nbsp;</p>
+
+<p>According to the application, the Acquisition will not result in KKR acquiring any controlling interest in Fresha.com. Investment funds, vehicles and/or accounts advised and managed by KKR do not presently hold any interests in software platforms that cater to the beauty, wellness and self-care industry, or provide relevant inputs to such businesses.</p>
 
   </div>
       <a href="#" class="read-toggle" data-expanded="true">read more</a>
@@ -7769,6 +7662,163 @@ MGH is a diversified industrials group, which operates a civil construction and 
 <p>Little Dot Studios, a social media agency.</p>
 </li>
 </ul>
+
+  </div>
+      <a href="#" class="read-toggle" data-expanded="true">read more</a>
+  </div></div>
+          </div>
+
+  </div>
+
+  </div>
+</div>
+
+</div>
+    <div class="views-row">
+
+<div  class="accc-collapsed-card contextual-region h-100">
+  <div class="accc-collapsed-card__header" id="heading-169241">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/opal-healthcare-bethel-aged-care">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  Opal HealthCare - Bethel Aged Care
+</h3>
+</div>
+      
+<div  class="accc-collapsed-card__header-info">
+        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
+    <h3 class="field__label">Acquisition status</h3>
+              <div class="field__item">Assessment completed</div>
+          </div>
+
+<div  class="accc-collapsed-card__header-content">
+      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
+<div class="field__item">Notification</div>
+</div>
+  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
+    <h3 class="field__label">Case number</h3>
+              <div class="field__item">MN-15019</div>
+          </div>
+  <div class="field field--name-field-acquisition-stage field--type-list-string field--label-inline clearfix">
+    <h3 class="field__label">Stage</h3>
+              <div class="field__item">Phase 1 - initial assessment</div>
+          </div>
+  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
+    <h3 class="field__label">Effective notification date</h3>
+              <div class="field__item"><time datetime="2026-05-20T12:00:00Z" class="datetime">20 May 2026</time>
+</div>
+          </div>
+
+  </div>
+
+  </div>
+</a>
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-169241" href="#card-169241">
+      <span>expandable trigger</span>
+    </a>
+  </div>
+  <div id="card-169241" role="region" aria-labelledby="heading-169241" class="accc-collapsed-card__body collapse">
+    
+<div >
+    <h3 class="border-bottom">About the acquisition</h3>
+      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Acquirer(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--635551">
+      <span class="field_acccgov_name">
+            OHCA PROPERTY HOLDINGS PTY LTD
+
+      </span>
+      <span>
+                        ABN -
+    70 675 807 477
+
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--635556">
+      <span class="field_acccgov_name">
+            DPG SERVICES PTY LTD
+
+      </span>
+      <span>
+                        ABN -
+    38 090 007 999
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Target(s) or vendor(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--635566">
+      <span class="field_acccgov_name">
+            Bethel Amen Pty Ltd
+
+      </span>
+      <span>
+                        ACN -
+    077 379 358
+
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--635571">
+      <span class="field_acccgov_name">
+            Java Dale Pty Ltd
+
+      </span>
+      <span>
+                        ACN -
+    077 379 367
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+  <div class="field field--name-field-acccgov-anzsic-code field--type-entity-reference field--label-inline field--type-entity-reference--taxonomy_term clearfix">
+    <h3 class="field__label">ANZSIC code(s)</h3>
+          <div class="field__item">
+              8601 Aged Care Residential Services              </div>
+      </div>
+  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
+    <h3 class="field__label">Description</h3>
+              <div class="field__item">
+<div class="read-more-wrapper">
+      <div class="summary-text">
+      <p>DPG Services Pty Ltd (<strong>DPG</strong>) and OHCA Property Holdings Pty Limited (<strong>OHCA</strong>) (being related bodies corporate, and together referred to as <strong>Opal HealthCare</strong></p>
+    </div>
+    <div class="full-text" style="display:none;">
+    <p>DPG Services Pty Ltd (<strong>DPG</strong>) and OHCA Property Holdings Pty Limited (<strong>OHCA</strong>) (being related bodies corporate, and together referred to as <strong>Opal HealthCare</strong>) propose to acquire the land, assets and business comprising the following approved aged care homes operated by Java Dale Pty Ltd in Melbourne:</p>
+
+<ul>
+<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="ea22fcb870bebd69d4874d7ba39511d02">
+<p>the Bethel Aged Care residential aged care home, an approved residential care home with 121 beds, located at 600 Plenty Road, Mill Park, Victoria (<strong>Mill Park Community</strong>); and</p>
+</li>
+<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="e7ba976638fd291976c9dc28069217808">
+<p>Anzac Lodge, a residential aged care home, an approved residential care home also with 121 beds, located at 2/12 Anzac Avenue, Coburg North, Victoria (<strong>Coburg North Community</strong>),</p>
+</li>
+</ul>
+
+<p>(the <strong>Acquisition</strong>).</p>
+
+<p>DPG is a registered provider of approved residential care communities and owns and operates 146 residential aged care communities across New South Wales, Victoria, Queensland, Western Australia and South Australia.&nbsp;</p>
+
+<p>Java Dale Pty Ltd provides the services required under the Aged Care Act 2024 (Cth) at each of Mill Park Community and Coburg North Community, including permanent care, respite care and palliative care.</p>
+
+<p>The Acquisition will involve:</p>
+
+<ul>
+<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="e36d243a95fc3dcdc1cf3a63f96eadd0f">
+<p>DPG acquiring the assets comprising the Bethel Aged Care and Anzac Lodge businesses from Java Dale Pty Ltd;</p>
+</li>
+<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="eed1bba4e0bdb7ec75d36dece901b1690">
+<p>OHCA acquiring the land on which Mill Park Community is operated from Java Dale Pty Ltd; and</p>
+</li>
+</ul>
+
+<p>OHCA acquiring the land on which Coburg North Community is operated (via a lease and sale contract) from Bethel Amen Pty Ltd.</p>
 
   </div>
       <a href="#" class="read-toggle" data-expanded="true">read more</a>
@@ -8007,9 +8057,9 @@ MGH is a diversified industrials group, which operates a civil construction and 
     <div class="views-row">
 
 <div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-169241">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/opal-healthcare-bethel-aged-care">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  Opal HealthCare - Bethel Aged Care
+  <div class="accc-collapsed-card__header" id="heading-170146">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/capital-group-big-post">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  Capital Group - Big Post
 </h3>
 </div>
       
@@ -8021,18 +8071,14 @@ MGH is a diversified industrials group, which operates a civil construction and 
 
 <div  class="accc-collapsed-card__header-content">
       <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
-<div class="field__item">Notification</div>
+<div class="field__item">Waiver</div>
 </div>
   <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
     <h3 class="field__label">Case number</h3>
-              <div class="field__item">MN-15019</div>
-          </div>
-  <div class="field field--name-field-acquisition-stage field--type-list-string field--label-inline clearfix">
-    <h3 class="field__label">Stage</h3>
-              <div class="field__item">Phase 1 - initial assessment</div>
+              <div class="field__item">WA-95019</div>
           </div>
   <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
-    <h3 class="field__label">Effective notification date</h3>
+    <h3 class="field__label">Waiver application date</h3>
               <div class="field__item"><time datetime="2026-05-20T12:00:00Z" class="datetime">20 May 2026</time>
 </div>
           </div>
@@ -8041,37 +8087,25 @@ MGH is a diversified industrials group, which operates a civil construction and 
 
   </div>
 </a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-169241" href="#card-169241">
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-170146" href="#card-170146">
       <span>expandable trigger</span>
     </a>
   </div>
-  <div id="card-169241" role="region" aria-labelledby="heading-169241" class="accc-collapsed-card__body collapse">
+  <div id="card-170146" role="region" aria-labelledby="heading-170146" class="accc-collapsed-card__body collapse">
     
 <div >
     <h3 class="border-bottom">About the acquisition</h3>
       <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
   <h3 class="field__label">Acquirer(s)</h3>
       <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--635551">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638556">
       <span class="field_acccgov_name">
-            OHCA PROPERTY HOLDINGS PTY LTD
+            Mimeca Nominees Pty Ltd
 
       </span>
       <span>
-                        ABN -
-    70 675 807 477
-
-              </span>
-    </div>
-  </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--635556">
-      <span class="field_acccgov_name">
-            DPG SERVICES PTY LTD
-
-      </span>
-      <span>
-                        ABN -
-    38 090 007 999
+                        ACN -
+    005 701 253
 
               </span>
     </div>
@@ -8081,26 +8115,14 @@ MGH is a diversified industrials group, which operates a civil construction and 
 <div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
   <h3 class="field__label">Target(s) or vendor(s)</h3>
       <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--635566">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638571">
       <span class="field_acccgov_name">
-            Bethel Amen Pty Ltd
+            Big Post Pty Ltd
 
       </span>
       <span>
-                        ACN -
-    077 379 358
-
-              </span>
-    </div>
-  </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--635571">
-      <span class="field_acccgov_name">
-            Java Dale Pty Ltd
-
-      </span>
-      <span>
-                        ACN -
-    077 379 367
+                        ABN -
+    19 145 428 002
 
               </span>
     </div>
@@ -8110,45 +8132,534 @@ MGH is a diversified industrials group, which operates a civil construction and 
   <div class="field field--name-field-acccgov-anzsic-code field--type-entity-reference field--label-inline field--type-entity-reference--taxonomy_term clearfix">
     <h3 class="field__label">ANZSIC code(s)</h3>
           <div class="field__item">
-              8601 Aged Care Residential Services              </div>
+              4610 Road Freight Transport              </div>
       </div>
   <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
     <h3 class="field__label">Description</h3>
               <div class="field__item">
 <div class="read-more-wrapper">
       <div class="summary-text">
-      <p>DPG Services Pty Ltd (<strong>DPG</strong>) and OHCA Property Holdings Pty Limited (<strong>OHCA</strong>) (being related bodies corporate, and together referred to as <strong>Opal HealthCare</strong></p>
+      <p>On 19 May 2026, Mimeca Nominees Pty Ltd as trustee for Mimeca Nominees Trust (<strong>Mimeca Nominees</strong>) entered into a Share Purchase Agreement to acquire 100% of the issued shares in Big P</p>
     </div>
     <div class="full-text" style="display:none;">
-    <p>DPG Services Pty Ltd (<strong>DPG</strong>) and OHCA Property Holdings Pty Limited (<strong>OHCA</strong>) (being related bodies corporate, and together referred to as <strong>Opal HealthCare</strong>) propose to acquire the land, assets and business comprising the following approved aged care homes operated by Java Dale Pty Ltd in Melbourne:</p>
+    <p>On 19 May 2026, Mimeca Nominees Pty Ltd as trustee for Mimeca Nominees Trust (<strong>Mimeca Nominees</strong>) entered into a Share Purchase Agreement to acquire 100% of the issued shares in Big Post Pty Ltd (<strong>Big Post</strong>)(the <strong>Acquisition</strong>).&nbsp;Mimeca Nominees and its connected entities trade under the name <strong>Capital Group</strong>.</p>
 
-<ul>
-<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="ea22fcb870bebd69d4874d7ba39511d02">
-<p>the Bethel Aged Care residential aged care home, an approved residential care home with 121 beds, located at 600 Plenty Road, Mill Park, Victoria (<strong>Mill Park Community</strong>); and</p>
-</li>
-<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="e7ba976638fd291976c9dc28069217808">
-<p>Anzac Lodge, a residential aged care home, an approved residential care home also with 121 beds, located at 2/12 Anzac Avenue, Coburg North, Victoria (<strong>Coburg North Community</strong>),</p>
-</li>
-</ul>
+<p>Capital Group is a transport and logistics service provider. It supplies courier and freight services across metropolitan, regional and interstate Australia, primarily to business customers (as well as to residential customers). Its operations are focussed on providing flexible access to external carrier capacity for time-critical freight, with the majority of its revenue derived from same-day metropolitan point-to-point deliveries managed via a fleet of subcontractor owner-drivers.</p>
 
-<p>(the <strong>Acquisition</strong>).</p>
+<p>Capital Group also supplies freight brokerage and logistics services as a complementary part of its broader transport and logistics offering. This involves warehousing services, and the arrangement and coordination of the transport of goods for customers (including linehaul, home delivery, courier, truck) by sourcing external carrier capacity from independent third parties.</p>
 
-<p>DPG is a registered provider of approved residential care communities and owns and operates 146 residential aged care communities across New South Wales, Victoria, Queensland, Western Australia and South Australia.&nbsp;</p>
+<p>Big Post is a freight brokerage business supplying road freight transport services across Australia, with a particular focus on small-to-medium enterprise customers across business-to-business, business-to-consumer and business-to-depot channels.</p>
 
-<p>Java Dale Pty Ltd provides the services required under the Aged Care Act 2024 (Cth) at each of Mill Park Community and Coburg North Community, including permanent care, respite care and palliative care.</p>
+  </div>
+      <a href="#" class="read-toggle" data-expanded="true">read more</a>
+  </div></div>
+          </div>
 
-<p>The Acquisition will involve:</p>
+  </div>
 
-<ul>
-<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="e36d243a95fc3dcdc1cf3a63f96eadd0f">
-<p>DPG acquiring the assets comprising the Bethel Aged Care and Anzac Lodge businesses from Java Dale Pty Ltd;</p>
-</li>
-<li class="ck-list-marker-font-size ck-list-marker-font-family" data-list-item-id="eed1bba4e0bdb7ec75d36dece901b1690">
-<p>OHCA acquiring the land on which Mill Park Community is operated from Java Dale Pty Ltd; and</p>
-</li>
-</ul>
+  </div>
+</div>
 
-<p>OHCA acquiring the land on which Coburg North Community is operated (via a lease and sale contract) from Bethel Amen Pty Ltd.</p>
+</div>
+    <div class="views-row">
+
+<div  class="accc-collapsed-card contextual-region h-100">
+  <div class="accc-collapsed-card__header" id="heading-169801">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/kk-group-invest-powercon">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  KK Group Invest - PowerCon
+</h3>
+</div>
+      
+<div  class="accc-collapsed-card__header-info">
+        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
+    <h3 class="field__label">Acquisition status</h3>
+              <div class="field__item">Assessment completed</div>
+          </div>
+
+<div  class="accc-collapsed-card__header-content">
+      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
+<div class="field__item">Waiver</div>
+</div>
+  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
+    <h3 class="field__label">Case number</h3>
+              <div class="field__item">WA-20024</div>
+          </div>
+  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
+    <h3 class="field__label">Waiver application date</h3>
+              <div class="field__item"><time datetime="2026-05-19T12:00:00Z" class="datetime">19 May 2026</time>
+</div>
+          </div>
+
+  </div>
+
+  </div>
+</a>
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-169801" href="#card-169801">
+      <span>expandable trigger</span>
+    </a>
+  </div>
+  <div id="card-169801" role="region" aria-labelledby="heading-169801" class="accc-collapsed-card__body collapse">
+    
+<div >
+    <h3 class="border-bottom">About the acquisition</h3>
+      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Acquirer(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637706">
+      <span class="field_acccgov_name">
+            KK Group Invest A/S
+
+      </span>
+      <span>
+                      CVR - 66821110
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Target(s) or vendor(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637731">
+      <span class="field_acccgov_name">
+            PowerCon Holding ApS
+
+      </span>
+      <span>
+                      CVR - 32269095
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-other-parties field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Other party(ies)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637716">
+      <span class="field_acccgov_name">
+            PowerCon A/S
+
+      </span>
+      <span>
+                      CVR - 32270433
+
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637721">
+      <span class="field_acccgov_name">
+            A.P. Møller Holding A/S
+
+      </span>
+      <span>
+                      CVR - 25679288
+
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637726">
+      <span class="field_acccgov_name">
+            PowerCon USA Inc.
+
+      </span>
+      <span>
+                      Delaware File Number - 6469852
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+  <div class="field field--name-field-acccgov-anzsic-code field--type-entity-reference field--label-inline field--type-entity-reference--taxonomy_term clearfix">
+    <h3 class="field__label">ANZSIC code(s)</h3>
+          <div class="field__item">
+              2439 Other Electrical Equipment Manufacturing              </div>
+      </div>
+  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
+    <h3 class="field__label">Description</h3>
+              <div class="field__item">
+<div class="read-more-wrapper">
+      <div class="summary-text">
+      <p>KK Group Invest A/S (<strong>KK Group Invest</strong>) plans to acquire 100% of the share capital of PowerCon Holding ApS and its wholly-owned subsidiaries PowerCon A/S and PowerCon USA Inc (collec</p>
+    </div>
+    <div class="full-text" style="display:none;">
+    <p>KK Group Invest A/S (<strong>KK Group Invest</strong>) plans to acquire 100% of the share capital of PowerCon Holding ApS and its wholly-owned subsidiaries PowerCon A/S and PowerCon USA Inc (collectively, <strong>PowerCon</strong>), by way of share transfer (the <strong>Acquisition</strong>).</p>
+
+<p>PowerCon is a group of companies headquartered in Denmark that supply infrastructure solutions for shore power supply for use by ships at berth in ports globally, including in Denmark, Germany, the Netherlands, Spain, Australia and the USA. In Australia, PowerCon supplies a shore power supply system for the Port Authority of New South Wales.</p>
+
+<p>KK Group Invest is a Danish-registered global technology company whose core business is the development, production, sale and servicing of power electronics system solutions and technology for onshore and offshore wind turbines. In Australia, KK Group Invest supplies mostly monitoring and service products to customers based in Australia.</p>
+
+<p>KK Group Invest is part of the A.P. Moller Group. A.P. Møller Holding A/S is the parent company of this group and is a wholly-owned subsidiary of the Danish commercial foundation A.P. Møller og Hustru Chastine Mc-Kinney Møllers Fond til almene Formaal.</p>
+
+  </div>
+      <a href="#" class="read-toggle" data-expanded="true">read more</a>
+  </div></div>
+          </div>
+
+  </div>
+
+  </div>
+</div>
+
+</div>
+    <div class="views-row">
+
+<div  class="accc-collapsed-card contextual-region h-100">
+  <div class="accc-collapsed-card__header" id="heading-169596">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/bgis-safe-fire-electrical">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  BGIS - Safe Fire Electrical
+</h3>
+</div>
+      
+<div  class="accc-collapsed-card__header-info">
+        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
+    <h3 class="field__label">Acquisition status</h3>
+              <div class="field__item">Assessment completed</div>
+          </div>
+
+<div  class="accc-collapsed-card__header-content">
+      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
+<div class="field__item">Waiver</div>
+</div>
+  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
+    <h3 class="field__label">Case number</h3>
+              <div class="field__item">WA-55020</div>
+          </div>
+  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
+    <h3 class="field__label">Waiver application date</h3>
+              <div class="field__item"><time datetime="2026-05-19T12:00:00Z" class="datetime">19 May 2026</time>
+</div>
+          </div>
+
+  </div>
+
+  </div>
+</a>
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-169596" href="#card-169596">
+      <span>expandable trigger</span>
+    </a>
+  </div>
+  <div id="card-169596" role="region" aria-labelledby="heading-169596" class="accc-collapsed-card__body collapse">
+    
+<div >
+    <h3 class="border-bottom">About the acquisition</h3>
+      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Acquirer(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637041">
+      <span class="field_acccgov_name">
+            BGIS PTY LTD
+
+      </span>
+      <span>
+                        ABN -
+    83 064 638 197
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Target(s) or vendor(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637051">
+      <span class="field_acccgov_name">
+            FIRE SYSTEMS (S.A.) PTY LTD
+
+      </span>
+      <span>
+                        ABN -
+    45 109 996 876
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+  <div class="field field--name-field-acccgov-anzsic-code field--type-entity-reference field--label-inline field--type-entity-reference--taxonomy_term clearfix">
+    <h3 class="field__label">ANZSIC code(s)</h3>
+          <div class="field__item">
+              3234 Fire and Security Alarm Installation Services              </div>
+      </div>
+  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
+    <h3 class="field__label">Description</h3>
+              <div class="field__item">
+<div class="read-more-wrapper">
+      <div class="summary-text">
+      <p>BGIS Pty Ltd (or its nominated wholly owned subsidiary) (<strong>BGIS</strong>) proposes to acquire the business and assets of Fire Systems (S.A.) Pty Ltd (trading as <strong>Safe Fire Electrical</strong></p>
+    </div>
+    <div class="full-text" style="display:none;">
+    <p>BGIS Pty Ltd (or its nominated wholly owned subsidiary) (<strong>BGIS</strong>) proposes to acquire the business and assets of Fire Systems (S.A.) Pty Ltd (trading as <strong>Safe Fire Electrical</strong>).</p>
+
+<p>The BGIS group provides facilities management and technical services across Australia, including maintenance and operation of buildings and infrastructure.</p>
+
+<p>Safe Fire Electrical is a South Australian business specialising in fire protection services, including the design, installation, maintenance, testing and certification of fire systems such as alarms, sprinklers, hydrants and extinguishers. It services commercial and industrial customers and derives revenue from both installation and recurring maintenance work.</p>
+
+  </div>
+      <a href="#" class="read-toggle" data-expanded="true">read more</a>
+  </div></div>
+          </div>
+
+  </div>
+
+  </div>
+</div>
+
+</div>
+    <div class="views-row">
+
+<div  class="accc-collapsed-card contextual-region h-100">
+  <div class="accc-collapsed-card__header" id="heading-169231">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/integris-related-entities-first-focus">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  Integris &amp; related entities - First Focus
+</h3>
+</div>
+      
+<div  class="accc-collapsed-card__header-info">
+        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline under-assessment clearfix">
+    <h3 class="field__label">Acquisition status</h3>
+              <div class="field__item">Under assessment</div>
+          </div>
+
+<div  class="accc-collapsed-card__header-content">
+      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
+<div class="field__item">Notification</div>
+</div>
+  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
+    <h3 class="field__label">Case number</h3>
+              <div class="field__item">MN-40022</div>
+          </div>
+  <div class="field field--name-field-acquisition-stage field--type-list-string field--label-inline clearfix">
+    <h3 class="field__label">Stage</h3>
+              <div class="field__item">Phase 1 - initial assessment</div>
+          </div>
+  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
+    <h3 class="field__label">Effective notification date</h3>
+              <div class="field__item"><time datetime="2026-05-19T12:00:00Z" class="datetime">19 May 2026</time>
+</div>
+          </div>
+
+  </div>
+
+  </div>
+</a>
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-169231" href="#card-169231">
+      <span>expandable trigger</span>
+    </a>
+  </div>
+  <div id="card-169231" role="region" aria-labelledby="heading-169231" class="accc-collapsed-card__body collapse">
+    
+<div >
+    <h3 class="border-bottom">About the acquisition</h3>
+      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Acquirer(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--635501">
+      <span class="field_acccgov_name">
+            OMERS Apollo Investment Holdings LLC
+
+      </span>
+      <span>
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--635506">
+      <span class="field_acccgov_name">
+            Apollo Australia Bidco Pty Ltd
+
+      </span>
+      <span>
+                        ACN -
+    697 230 096
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Target(s) or vendor(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--635491">
+      <span class="field_acccgov_name">
+            FIRST FOCUS IT PTY LIMITED
+
+      </span>
+      <span>
+                        ABN -
+    73 106 912 350
+
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--635496">
+      <span class="field_acccgov_name">
+            The Trustee for FUTURE FOCUS TRUST
+
+      </span>
+      <span>
+                        ABN -
+    22 698 604 264
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+  <div class="field field--name-field-acccgov-anzsic-code field--type-entity-reference field--label-inline field--type-entity-reference--taxonomy_term clearfix">
+    <h3 class="field__label">ANZSIC code(s)</h3>
+          <div class="field__item">
+              7000 Computer System Design and Related Services              </div>
+      </div>
+  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
+    <h3 class="field__label">Description</h3>
+              <div class="field__item">
+<div class="read-more-wrapper">
+      <div class="summary-text">
+      <p class="lev">OMERS Apollo Investment Holdings LLC (<strong>OMERS Apollo</strong>), which wholly owns Integris, LLC (<strong>Integris</strong>), proposes to acquire 100% of the shares in First Focus </p>
+    </div>
+    <div class="full-text" style="display:none;">
+    <p class="lev">OMERS Apollo Investment Holdings LLC (<strong>OMERS Apollo</strong>), which wholly owns Integris, LLC (<strong>Integris</strong>), proposes to acquire 100% of the shares in First Focus IT Pty Ltd (<strong>First Focus</strong>) both directly and via its controlled entities.</p>
+
+<p class="lev">Integris is an IT managed service provider which supplies mid-sized businesses with end-to-end managed services, including IT helpdesk, cybersecurity services, backup and disaster recovery and remote desktop services. Integris does not currently supply goods or services to Australian customers.</p>
+
+<p class="lev">OMERS Apollo is an investment vehicle established for the Ontario Municipal Employees Retirement System Primary Pension Plan.&nbsp;</p>
+
+<p class="lev">First Focus is an IT managed service provider which supplies services to mid-sized businesses across Australia and New Zealand. Its services include helpdesk support, cybersecurity, cloud services, assessing and providing tailored data services, IT, digital transformation and virtual CIO services consulting, AI implementation, app development, disaster recovery, unified communications and connectivity services. First Focus also provides consultancy services across IT strategy, transformation, and compliance, AI consulting and software development.</p>
+
+  </div>
+      <a href="#" class="read-toggle" data-expanded="true">read more</a>
+  </div></div>
+          </div>
+
+  </div>
+
+  </div>
+</div>
+
+</div>
+    <div class="views-row">
+
+<div  class="accc-collapsed-card contextual-region h-100">
+  <div class="accc-collapsed-card__header" id="heading-169951">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/laundy-%E2%80%93-woy-woy-hotel">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  Laundy – Woy Woy Hotel
+</h3>
+</div>
+      
+<div  class="accc-collapsed-card__header-info">
+        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
+    <h3 class="field__label">Acquisition status</h3>
+              <div class="field__item">Assessment completed</div>
+          </div>
+
+<div  class="accc-collapsed-card__header-content">
+      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
+<div class="field__item">Waiver</div>
+</div>
+  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
+    <h3 class="field__label">Case number</h3>
+              <div class="field__item">WA-25025</div>
+          </div>
+  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
+    <h3 class="field__label">Waiver application date</h3>
+              <div class="field__item"><time datetime="2026-05-19T12:00:00Z" class="datetime">19 May 2026</time>
+</div>
+          </div>
+
+  </div>
+
+  </div>
+</a>
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-169951" href="#card-169951">
+      <span>expandable trigger</span>
+    </a>
+  </div>
+  <div id="card-169951" role="region" aria-labelledby="heading-169951" class="accc-collapsed-card__body collapse">
+    
+<div >
+    <h3 class="border-bottom">About the acquisition</h3>
+      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Acquirer(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638136">
+      <span class="field_acccgov_name">
+            LAUNDY WOY FREEHOLD PTY LTD
+
+      </span>
+      <span>
+                        ABN -
+    65 696 471 306
+
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638141">
+      <span class="field_acccgov_name">
+            LAUNDY WOY TRADING PTY LTD
+
+      </span>
+      <span>
+                        ABN -
+    29 696 470 345
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Target(s) or vendor(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638151">
+      <span class="field_acccgov_name">
+            HARVEST PUB OPERATIONS 2 PTY LTD
+
+      </span>
+      <span>
+                        ABN -
+    51 652 748 242
+
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638156">
+      <span class="field_acccgov_name">
+            AMAL TRUSTEES PTY LIMITED
+
+      </span>
+      <span>
+                        ABN -
+    98 609 737 064
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+  <div class="field field--name-field-acccgov-anzsic-code field--type-entity-reference field--label-inline field--type-entity-reference--taxonomy_term clearfix">
+    <h3 class="field__label">ANZSIC code(s)</h3>
+          <div class="field__item">
+              4520 Pubs, Taverns and Bars;           6712 Non-Residential Property Operators              </div>
+      </div>
+  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
+    <h3 class="field__label">Description</h3>
+              <div class="field__item">
+<div class="read-more-wrapper">
+      <div class="summary-text">
+      <p>Laundy Woy Freehold Pty Ltd and Laundy Woy Trading Pty Ltd (together, <strong>Laundy)</strong> propose to acquire the freehold land and operating business known as the Woy Woy Hotel, located at 33–</p>
+    </div>
+    <div class="full-text" style="display:none;">
+    <p>Laundy Woy Freehold Pty Ltd and Laundy Woy Trading Pty Ltd (together, <strong>Laundy)</strong> propose to acquire the freehold land and operating business known as the Woy Woy Hotel, located at 33–39 The Boulevarde, Woy Woy, NSW from Amal Trustees Pty Limited as trustee for Harvest Pub Fund Trust 2 and Harvest Pub Operations 2 Limited, pursuant to a contract dated 20 April 2026.</p>
+
+<p>Laundy operates a portfolio of licensed hospitality venues across New South Wales,&nbsp;including pubs and hotels located in metropolitan and regional areas.&nbsp;</p>
+
+<p>The Woy Woy Hotel is an existing licensed hotel business comprising gaming, food and beverage, bottle shop and hospitality services.</p>
+
+<p>The acquisition involves the transfer of ownership of both the freehold land and the operating hotel business to Laundy. Following completion, Laundy will operate the Woy Woy Hotel as part of its existing hospitality portfolio.</p>
 
   </div>
       <a href="#" class="read-toggle" data-expanded="true">read more</a>
@@ -8531,9 +9042,9 @@ MGH is a diversified industrials group, which operates a civil construction and 
     <div class="views-row">
 
 <div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-169596">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/bgis-safe-fire-electrical">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  BGIS - Safe Fire Electrical
+  <div class="accc-collapsed-card__header" id="heading-169806">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/soilco-go-grow">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  SOILCO - Go Grow
 </h3>
 </div>
       
@@ -8549,11 +9060,11 @@ MGH is a diversified industrials group, which operates a civil construction and 
 </div>
   <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
     <h3 class="field__label">Case number</h3>
-              <div class="field__item">WA-55020</div>
+              <div class="field__item">WA-80018</div>
           </div>
   <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
     <h3 class="field__label">Waiver application date</h3>
-              <div class="field__item"><time datetime="2026-05-19T12:00:00Z" class="datetime">19 May 2026</time>
+              <div class="field__item"><time datetime="2026-05-18T12:00:00Z" class="datetime">18 May 2026</time>
 </div>
           </div>
 
@@ -8561,25 +9072,25 @@ MGH is a diversified industrials group, which operates a civil construction and 
 
   </div>
 </a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-169596" href="#card-169596">
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-169806" href="#card-169806">
       <span>expandable trigger</span>
     </a>
   </div>
-  <div id="card-169596" role="region" aria-labelledby="heading-169596" class="accc-collapsed-card__body collapse">
+  <div id="card-169806" role="region" aria-labelledby="heading-169806" class="accc-collapsed-card__body collapse">
     
 <div >
     <h3 class="border-bottom">About the acquisition</h3>
       <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
   <h3 class="field__label">Acquirer(s)</h3>
       <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637041">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637736">
       <span class="field_acccgov_name">
-            BGIS PTY LTD
+            SOILCO PTY LIMITED
 
       </span>
       <span>
                         ABN -
-    83 064 638 197
+    85 055 303 243
 
               </span>
     </div>
@@ -8589,380 +9100,26 @@ MGH is a diversified industrials group, which operates a civil construction and 
 <div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
   <h3 class="field__label">Target(s) or vendor(s)</h3>
       <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637051">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637751">
       <span class="field_acccgov_name">
-            FIRE SYSTEMS (S.A.) PTY LTD
+            GARDEN MEDIUMS PTY LIMITED
 
       </span>
       <span>
                         ABN -
-    45 109 996 876
+    44 079 600 230
 
               </span>
     </div>
   </li>
-    </ul>      </div>
-    </div>
-  <div class="field field--name-field-acccgov-anzsic-code field--type-entity-reference field--label-inline field--type-entity-reference--taxonomy_term clearfix">
-    <h3 class="field__label">ANZSIC code(s)</h3>
-          <div class="field__item">
-              3234 Fire and Security Alarm Installation Services              </div>
-      </div>
-  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
-    <h3 class="field__label">Description</h3>
-              <div class="field__item">
-<div class="read-more-wrapper">
-      <div class="summary-text">
-      <p>BGIS Pty Ltd (or its nominated wholly owned subsidiary) (<strong>BGIS</strong>) proposes to acquire the business and assets of Fire Systems (S.A.) Pty Ltd (trading as <strong>Safe Fire Electrical</strong></p>
-    </div>
-    <div class="full-text" style="display:none;">
-    <p>BGIS Pty Ltd (or its nominated wholly owned subsidiary) (<strong>BGIS</strong>) proposes to acquire the business and assets of Fire Systems (S.A.) Pty Ltd (trading as <strong>Safe Fire Electrical</strong>).</p>
-
-<p>The BGIS group provides facilities management and technical services across Australia, including maintenance and operation of buildings and infrastructure.</p>
-
-<p>Safe Fire Electrical is a South Australian business specialising in fire protection services, including the design, installation, maintenance, testing and certification of fire systems such as alarms, sprinklers, hydrants and extinguishers. It services commercial and industrial customers and derives revenue from both installation and recurring maintenance work.</p>
-
-  </div>
-      <a href="#" class="read-toggle" data-expanded="true">read more</a>
-  </div></div>
-          </div>
-
-  </div>
-
-  </div>
-</div>
-
-</div>
-    <div class="views-row">
-
-<div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-169951">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/laundy-%E2%80%93-woy-woy-hotel">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  Laundy – Woy Woy Hotel
-</h3>
-</div>
-      
-<div  class="accc-collapsed-card__header-info">
-        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
-    <h3 class="field__label">Acquisition status</h3>
-              <div class="field__item">Assessment completed</div>
-          </div>
-
-<div  class="accc-collapsed-card__header-content">
-      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
-<div class="field__item">Waiver</div>
-</div>
-  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
-    <h3 class="field__label">Case number</h3>
-              <div class="field__item">WA-25025</div>
-          </div>
-  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
-    <h3 class="field__label">Waiver application date</h3>
-              <div class="field__item"><time datetime="2026-05-19T12:00:00Z" class="datetime">19 May 2026</time>
-</div>
-          </div>
-
-  </div>
-
-  </div>
-</a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-169951" href="#card-169951">
-      <span>expandable trigger</span>
-    </a>
-  </div>
-  <div id="card-169951" role="region" aria-labelledby="heading-169951" class="accc-collapsed-card__body collapse">
-    
-<div >
-    <h3 class="border-bottom">About the acquisition</h3>
-      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Acquirer(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638136">
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637756">
       <span class="field_acccgov_name">
-            LAUNDY WOY FREEHOLD PTY LTD
-
-      </span>
-      <span>
-                        ABN -
-    65 696 471 306
-
-              </span>
-    </div>
-  </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638141">
-      <span class="field_acccgov_name">
-            LAUNDY WOY TRADING PTY LTD
-
-      </span>
-      <span>
-                        ABN -
-    29 696 470 345
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Target(s) or vendor(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638151">
-      <span class="field_acccgov_name">
-            HARVEST PUB OPERATIONS 2 PTY LTD
-
-      </span>
-      <span>
-                        ABN -
-    51 652 748 242
-
-              </span>
-    </div>
-  </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--638156">
-      <span class="field_acccgov_name">
-            AMAL TRUSTEES PTY LIMITED
-
-      </span>
-      <span>
-                        ABN -
-    98 609 737 064
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-  <div class="field field--name-field-acccgov-anzsic-code field--type-entity-reference field--label-inline field--type-entity-reference--taxonomy_term clearfix">
-    <h3 class="field__label">ANZSIC code(s)</h3>
-          <div class="field__item">
-              4520 Pubs, Taverns and Bars;           6712 Non-Residential Property Operators              </div>
-      </div>
-  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
-    <h3 class="field__label">Description</h3>
-              <div class="field__item">
-<div class="read-more-wrapper">
-      <div class="summary-text">
-      <p>Laundy Woy Freehold Pty Ltd and Laundy Woy Trading Pty Ltd (together, <strong>Laundy)</strong> propose to acquire the freehold land and operating business known as the Woy Woy Hotel, located at 33–</p>
-    </div>
-    <div class="full-text" style="display:none;">
-    <p>Laundy Woy Freehold Pty Ltd and Laundy Woy Trading Pty Ltd (together, <strong>Laundy)</strong> propose to acquire the freehold land and operating business known as the Woy Woy Hotel, located at 33–39 The Boulevarde, Woy Woy, NSW from Amal Trustees Pty Limited as trustee for Harvest Pub Fund Trust 2 and Harvest Pub Operations 2 Limited, pursuant to a contract dated 20 April 2026.</p>
-
-<p>Laundy operates a portfolio of licensed hospitality venues across New South Wales,&nbsp;including pubs and hotels located in metropolitan and regional areas.&nbsp;</p>
-
-<p>The Woy Woy Hotel is an existing licensed hotel business comprising gaming, food and beverage, bottle shop and hospitality services.</p>
-
-<p>The acquisition involves the transfer of ownership of both the freehold land and the operating hotel business to Laundy. Following completion, Laundy will operate the Woy Woy Hotel as part of its existing hospitality portfolio.</p>
-
-  </div>
-      <a href="#" class="read-toggle" data-expanded="true">read more</a>
-  </div></div>
-          </div>
-
-  </div>
-
-  </div>
-</div>
-
-</div>
-    <div class="views-row">
-
-<div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-169231">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/integris-related-entities-first-focus">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  Integris &amp; related entities - First Focus
-</h3>
-</div>
-      
-<div  class="accc-collapsed-card__header-info">
-        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline under-assessment clearfix">
-    <h3 class="field__label">Acquisition status</h3>
-              <div class="field__item">Under assessment</div>
-          </div>
-
-<div  class="accc-collapsed-card__header-content">
-      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
-<div class="field__item">Notification</div>
-</div>
-  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
-    <h3 class="field__label">Case number</h3>
-              <div class="field__item">MN-40022</div>
-          </div>
-  <div class="field field--name-field-acquisition-stage field--type-list-string field--label-inline clearfix">
-    <h3 class="field__label">Stage</h3>
-              <div class="field__item">Phase 1 - initial assessment</div>
-          </div>
-  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
-    <h3 class="field__label">Effective notification date</h3>
-              <div class="field__item"><time datetime="2026-05-19T12:00:00Z" class="datetime">19 May 2026</time>
-</div>
-          </div>
-
-  </div>
-
-  </div>
-</a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-169231" href="#card-169231">
-      <span>expandable trigger</span>
-    </a>
-  </div>
-  <div id="card-169231" role="region" aria-labelledby="heading-169231" class="accc-collapsed-card__body collapse">
-    
-<div >
-    <h3 class="border-bottom">About the acquisition</h3>
-      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Acquirer(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--635501">
-      <span class="field_acccgov_name">
-            OMERS Apollo Investment Holdings LLC
-
-      </span>
-      <span>
-              </span>
-    </div>
-  </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--635506">
-      <span class="field_acccgov_name">
-            Apollo Australia Bidco Pty Ltd
+            Lumime Pty Ltd
 
       </span>
       <span>
                         ACN -
-    697 230 096
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Target(s) or vendor(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--635491">
-      <span class="field_acccgov_name">
-            FIRST FOCUS IT PTY LIMITED
-
-      </span>
-      <span>
-                        ABN -
-    73 106 912 350
-
-              </span>
-    </div>
-  </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--635496">
-      <span class="field_acccgov_name">
-            The Trustee for FUTURE FOCUS TRUST
-
-      </span>
-      <span>
-                        ABN -
-    22 698 604 264
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-  <div class="field field--name-field-acccgov-anzsic-code field--type-entity-reference field--label-inline field--type-entity-reference--taxonomy_term clearfix">
-    <h3 class="field__label">ANZSIC code(s)</h3>
-          <div class="field__item">
-              7000 Computer System Design and Related Services              </div>
-      </div>
-  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
-    <h3 class="field__label">Description</h3>
-              <div class="field__item">
-<div class="read-more-wrapper">
-      <div class="summary-text">
-      <p class="lev">OMERS Apollo Investment Holdings LLC (<strong>OMERS Apollo</strong>), which wholly owns Integris, LLC (<strong>Integris</strong>), proposes to acquire 100% of the shares in First Focus </p>
-    </div>
-    <div class="full-text" style="display:none;">
-    <p class="lev">OMERS Apollo Investment Holdings LLC (<strong>OMERS Apollo</strong>), which wholly owns Integris, LLC (<strong>Integris</strong>), proposes to acquire 100% of the shares in First Focus IT Pty Ltd (<strong>First Focus</strong>) both directly and via its controlled entities.</p>
-
-<p class="lev">Integris is an IT managed service provider which supplies mid-sized businesses with end-to-end managed services, including IT helpdesk, cybersecurity services, backup and disaster recovery and remote desktop services. Integris does not currently supply goods or services to Australian customers.</p>
-
-<p class="lev">OMERS Apollo is an investment vehicle established for the Ontario Municipal Employees Retirement System Primary Pension Plan.&nbsp;</p>
-
-<p class="lev">First Focus is an IT managed service provider which supplies services to mid-sized businesses across Australia and New Zealand. Its services include helpdesk support, cybersecurity, cloud services, assessing and providing tailored data services, IT, digital transformation and virtual CIO services consulting, AI implementation, app development, disaster recovery, unified communications and connectivity services. First Focus also provides consultancy services across IT strategy, transformation, and compliance, AI consulting and software development.</p>
-
-  </div>
-      <a href="#" class="read-toggle" data-expanded="true">read more</a>
-  </div></div>
-          </div>
-
-  </div>
-
-  </div>
-</div>
-
-</div>
-    <div class="views-row">
-
-<div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-169801">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/kk-group-invest-powercon">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  KK Group Invest - PowerCon
-</h3>
-</div>
-      
-<div  class="accc-collapsed-card__header-info">
-        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
-    <h3 class="field__label">Acquisition status</h3>
-              <div class="field__item">Assessment completed</div>
-          </div>
-
-<div  class="accc-collapsed-card__header-content">
-      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
-<div class="field__item">Waiver</div>
-</div>
-  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
-    <h3 class="field__label">Case number</h3>
-              <div class="field__item">WA-20024</div>
-          </div>
-  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
-    <h3 class="field__label">Waiver application date</h3>
-              <div class="field__item"><time datetime="2026-05-19T12:00:00Z" class="datetime">19 May 2026</time>
-</div>
-          </div>
-
-  </div>
-
-  </div>
-</a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-169801" href="#card-169801">
-      <span>expandable trigger</span>
-    </a>
-  </div>
-  <div id="card-169801" role="region" aria-labelledby="heading-169801" class="accc-collapsed-card__body collapse">
-    
-<div >
-    <h3 class="border-bottom">About the acquisition</h3>
-      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Acquirer(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637706">
-      <span class="field_acccgov_name">
-            KK Group Invest A/S
-
-      </span>
-      <span>
-                      CVR - 66821110
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Target(s) or vendor(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637731">
-      <span class="field_acccgov_name">
-            PowerCon Holding ApS
-
-      </span>
-      <span>
-                      CVR - 32269095
+    001 931 228
 
               </span>
     </div>
@@ -8972,35 +9129,171 @@ MGH is a diversified industrials group, which operates a civil construction and 
 <div class="field field--name-field-acccgov-other-parties field--type-entity-reference-revisions field--label-inline clearfix">
   <h3 class="field__label">Other party(ies)</h3>
       <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637716">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637746">
       <span class="field_acccgov_name">
-            PowerCon A/S
+            I Squared Capital, LLC
 
       </span>
       <span>
-                      CVR - 32270433
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+  <div class="field field--name-field-acccgov-anzsic-code field--type-entity-reference field--label-inline field--type-entity-reference--taxonomy_term clearfix">
+    <h3 class="field__label">ANZSIC code(s)</h3>
+          <div class="field__item">
+              3291 Landscape Construction Services;           4232 Garden Supplies Retailing              </div>
+      </div>
+  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
+    <h3 class="field__label">Description</h3>
+              <div class="field__item">
+<div class="read-more-wrapper">
+      <div class="summary-text">
+      <p class="Default">SOILCO Pty Ltd (<strong>SOILCO</strong>) proposes to acquire 100% of the shares in Garden Mediums Pty Ltd (trading as <strong>Go Grow</strong>) from Lumime Pty Ltd and trustee of th</p>
+    </div>
+    <div class="full-text" style="display:none;">
+    <p class="Default">SOILCO Pty Ltd (<strong>SOILCO</strong>) proposes to acquire 100% of the shares in Garden Mediums Pty Ltd (trading as <strong>Go Grow</strong>) from Lumime Pty Ltd and trustee of the Honey &amp; Nut Unit Trust (the <strong>Acquisition</strong>).&nbsp;</p>
+
+<p class="Default">SOILCO operates organic waste recycling facilities in New South Wales, ACT and Victoria, including a facility at Tweed Heads in northern NSW.&nbsp;SOILCO’s facilities process food and garden organic (<strong>FOGO</strong>) waste from local councils, blending it with forestry and agricultural feedstocks (and other suppliers’ inputs) to manufacture compost and soil improvement products.&nbsp;SOILCO supplies these products for a range of applications including, including urban landscaping and projects and agriculture and horticulture production systems (orchards, viticulture, turf farms, nurseries, and greenlife).</p>
+
+<p class="Default">SOILCOs majority shareholder, Australian Waste Management Investments is part of the I Squared Capital group (<strong>I Squared</strong>). I Squared is a global infrastructure investment firm headquartered in the United States,&nbsp;</p>
+
+<p>Go Grow manufactures and supplies potting mixes, fertilisers and garden products from a single site in Ballina NSW. Part of Go Grow’s business involves processing locally sourced garden waste to produce compost and mulch which is supplied directly to retail customers, as well as farms and nurseries. Go Grow does not acquire or process FOGO waste.&nbsp;</p>
+
+  </div>
+      <a href="#" class="read-toggle" data-expanded="true">read more</a>
+  </div></div>
+          </div>
+
+  </div>
+
+  </div>
+</div>
+
+</div>
+    <div class="views-row">
+
+<div  class="accc-collapsed-card contextual-region h-100">
+  <div class="accc-collapsed-card__header" id="heading-169796">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/direct-couriers-%E2%80%93-phoenix-transport">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  Direct Couriers – Phoenix Transport
+</h3>
+</div>
+      
+<div  class="accc-collapsed-card__header-info">
+        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
+    <h3 class="field__label">Acquisition status</h3>
+              <div class="field__item">Assessment completed</div>
+          </div>
+
+<div  class="accc-collapsed-card__header-content">
+      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
+<div class="field__item">Waiver</div>
+</div>
+  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
+    <h3 class="field__label">Case number</h3>
+              <div class="field__item">WA-80017</div>
+          </div>
+  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
+    <h3 class="field__label">Waiver application date</h3>
+              <div class="field__item"><time datetime="2026-05-18T12:00:00Z" class="datetime">18 May 2026</time>
+</div>
+          </div>
+
+  </div>
+
+  </div>
+</a>
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-169796" href="#card-169796">
+      <span>expandable trigger</span>
+    </a>
+  </div>
+  <div id="card-169796" role="region" aria-labelledby="heading-169796" class="accc-collapsed-card__body collapse">
+    
+<div >
+    <h3 class="border-bottom">About the acquisition</h3>
+      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Acquirer(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637671">
+      <span class="field_acccgov_name">
+            DIRECT COURIERS (AUST.) PTY. LIMITED
+
+      </span>
+      <span>
+                        ABN -
+    87 063 478 295
 
               </span>
     </div>
   </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637721">
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Target(s) or vendor(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637696">
       <span class="field_acccgov_name">
-            A.P. Møller Holding A/S
+            PHOENIX TRANSPORT HOLDINGS PTY LTD
 
       </span>
       <span>
-                      CVR - 25679288
+                        ABN -
+    75 062 309 773
 
               </span>
     </div>
   </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637726">
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637701">
       <span class="field_acccgov_name">
-            PowerCon USA Inc.
+            PHOENIX DISTRIBUTION (NSW) PTY LTD
 
       </span>
       <span>
-                      Delaware File Number - 6469852
+                        ABN -
+    24 073 843 982
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-other-parties field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Other party(ies)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637681">
+      <span class="field_acccgov_name">
+            DIRECT COURIERS GROUP PTY LTD
+
+      </span>
+      <span>
+                        ABN -
+    70 637 899 051
+
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637686">
+      <span class="field_acccgov_name">
+            FRF GROUP PTY LTD
+
+      </span>
+      <span>
+                        ABN -
+    11 624 735 459
+
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637691">
+      <span class="field_acccgov_name">
+            ANACACIA CAPITAL PTY LIMITED
+
+      </span>
+      <span>
+                        ABN -
+    82 123 237 114
 
               </span>
     </div>
@@ -9010,23 +9303,173 @@ MGH is a diversified industrials group, which operates a civil construction and 
   <div class="field field--name-field-acccgov-anzsic-code field--type-entity-reference field--label-inline field--type-entity-reference--taxonomy_term clearfix">
     <h3 class="field__label">ANZSIC code(s)</h3>
           <div class="field__item">
-              2439 Other Electrical Equipment Manufacturing              </div>
+              4610 Road Freight Transport;           5102 Courier Pick-up and Delivery Services;           5309 Other Warehousing and Storage Services              </div>
       </div>
   <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
     <h3 class="field__label">Description</h3>
               <div class="field__item">
 <div class="read-more-wrapper">
       <div class="summary-text">
-      <p>KK Group Invest A/S (<strong>KK Group Invest</strong>) plans to acquire 100% of the share capital of PowerCon Holding ApS and its wholly-owned subsidiaries PowerCon A/S and PowerCon USA Inc (collec</p>
+      <p>Direct Couriers (Aust) Pty Ltd (<strong>DC</strong>), a wholly owned subsidiary of Direct Couriers Group Pty Ltd (together, <strong>Direct Couriers</strong>), proposes to acquire 100% of the shares</p>
     </div>
     <div class="full-text" style="display:none;">
-    <p>KK Group Invest A/S (<strong>KK Group Invest</strong>) plans to acquire 100% of the share capital of PowerCon Holding ApS and its wholly-owned subsidiaries PowerCon A/S and PowerCon USA Inc (collectively, <strong>PowerCon</strong>), by way of share transfer (the <strong>Acquisition</strong>).</p>
+    <p>Direct Couriers (Aust) Pty Ltd (<strong>DC</strong>), a wholly owned subsidiary of Direct Couriers Group Pty Ltd (together, <strong>Direct Couriers</strong>), proposes to acquire 100% of the shares in Phoenix Transport Holdings Pty Ltd, along with its 100% wholly owned subsidiary, Phoenix Distribution (NSW) Pty Ltd (together, <strong>Phoenix Transport</strong>).&nbsp;</p>
 
-<p>PowerCon is a group of companies headquartered in Denmark that supply infrastructure solutions for shore power supply for use by ships at berth in ports globally, including in Denmark, Germany, the Netherlands, Spain, Australia and the USA. In Australia, PowerCon supplies a shore power supply system for the Port Authority of New South Wales.</p>
+<p>Direct Couriers is an Australian provider of business-to-business courier, interstate delivery and warehousing services. It services logistics, freight forwarder, commercial and retail customers across Australia and New Zealand, and operates a number of sub-brands including ‘Direct Cold’ and ‘Direct Road’. It focuses on same day point-to-point services.&nbsp;</p>
 
-<p>KK Group Invest is a Danish-registered global technology company whose core business is the development, production, sale and servicing of power electronics system solutions and technology for onshore and offshore wind turbines. In Australia, KK Group Invest supplies mostly monitoring and service products to customers based in Australia.</p>
+<p>Anacacia V Fund A and Anacacia V Fund B (together, the <strong>Fund</strong>), which are both unregistered Australian unlisted unit trusts, together own 49.7% of the shares in DC, with the remaining 50.3% held by existing and past management, as well as a passive investor.&nbsp;</p>
 
-<p>KK Group Invest is part of the A.P. Moller Group. A.P. Møller Holding A/S is the parent company of this group and is a wholly-owned subsidiary of the Danish commercial foundation A.P. Møller og Hustru Chastine Mc-Kinney Møllers Fond til almene Formaal.</p>
+<p>Phoenix Transport is also an Australian provider of business-to-business courier, interstate delivery and warehousing services, operating in New South Wales and Queensland. Although Phoenix Transport has national customers, its coverage is primarily limited to Brisbane and Sydney. Phoenix Transport services a mix of logistics, retail and commercial customers, with a stronger focus on third-party warehousing and distribution, larger-scale heavy-freight dedicated hire work, and on- transport for warehouse relocations and other similar project work.</p>
+
+  </div>
+      <a href="#" class="read-toggle" data-expanded="true">read more</a>
+  </div></div>
+          </div>
+
+  </div>
+
+  </div>
+</div>
+
+</div>
+    <div class="views-row">
+
+<div  class="accc-collapsed-card contextual-region h-100">
+  <div class="accc-collapsed-card__header" id="heading-169721">
+  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/tinicum-and-blackstone-led-consortium-%E2%80%93-senior">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
+  Tinicum and Blackstone led consortium – Senior
+</h3>
+</div>
+      
+<div  class="accc-collapsed-card__header-info">
+        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
+    <h3 class="field__label">Acquisition status</h3>
+              <div class="field__item">Assessment completed</div>
+          </div>
+
+<div  class="accc-collapsed-card__header-content">
+      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
+<div class="field__item">Waiver</div>
+</div>
+  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
+    <h3 class="field__label">Case number</h3>
+              <div class="field__item">WA-30018</div>
+          </div>
+  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
+    <h3 class="field__label">Waiver application date</h3>
+              <div class="field__item"><time datetime="2026-05-18T12:00:00Z" class="datetime">18 May 2026</time>
+</div>
+          </div>
+
+  </div>
+
+  </div>
+</a>
+    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-169721" href="#card-169721">
+      <span>expandable trigger</span>
+    </a>
+  </div>
+  <div id="card-169721" role="region" aria-labelledby="heading-169721" class="accc-collapsed-card__body collapse">
+    
+<div >
+    <h3 class="border-bottom">About the acquisition</h3>
+      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Acquirer(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637481">
+      <span class="field_acccgov_name">
+            Zeus UK Bidco Limited
+
+      </span>
+      <span>
+                      UK company number - 17118800
+
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637486">
+      <span class="field_acccgov_name">
+            Tinicum L.P.
+
+      </span>
+      <span>
+                      Incorporation number - 5040692
+
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637491">
+      <span class="field_acccgov_name">
+            BMA IX LLC
+
+      </span>
+      <span>
+                      File number - 6549791
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Target(s) or vendor(s)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637511">
+      <span class="field_acccgov_name">
+            Senior plc
+
+      </span>
+      <span>
+                      Company number - 00282772
+
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+<div class="field field--name-field-acccgov-other-parties field--type-entity-reference-revisions field--label-inline clearfix">
+  <h3 class="field__label">Other party(ies)</h3>
+      <div class="field__items">
+    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637501">
+      <span class="field_acccgov_name">
+            AeroFlow Technologies, LLC
+
+      </span>
+      <span>
+              </span>
+    </div>
+  </li>
+      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637506">
+      <span class="field_acccgov_name">
+            PennAero
+
+      </span>
+      <span>
+              </span>
+    </div>
+  </li>
+    </ul>      </div>
+    </div>
+  <div class="field field--name-field-acccgov-anzsic-code field--type-entity-reference field--label-inline field--type-entity-reference--taxonomy_term clearfix">
+    <h3 class="field__label">ANZSIC code(s)</h3>
+          <div class="field__item">
+              2394 Aircraft Manufacturing and Repair Services              </div>
+      </div>
+  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
+    <h3 class="field__label">Description</h3>
+              <div class="field__item">
+<div class="read-more-wrapper">
+      <div class="summary-text">
+      <p>BMA IX LLC is a wholly owned Delaware subsidiary of Blackstone, Inc. (together with its subsidiaries, <strong>Blackstone</strong>).</p>
+    </div>
+    <div class="full-text" style="display:none;">
+    <p>BMA IX LLC is a wholly owned Delaware subsidiary of Blackstone, Inc. (together with its subsidiaries, <strong>Blackstone</strong>). Zeus UK Bidco Limited (Bidco),a newly formed company which will be indirectly jointly controlled by funds managed and/or advised by Tinicum Incorporated (<strong>Tinicum</strong>) and by funds advised and/or managed by affiliates of Blackstone (together, the <strong>Consortium</strong>), propose to acquire 100% of the shares in Senior plc (together with its subsidiaries, <strong>Senior</strong>), by way of a Court approved scheme of arrangement (Scheme) under Part 26 of the UK Companies Act 2006 (the <strong>Acquisition</strong>). Following the Acquisition, Tinicum and Blackstone will have a controlling interest in Senior.&nbsp;</p>
+
+<p>Tinicum is a US-based private investment firm, focused on investing in both private and public companies across various sectors, including engineered products, industrial distribution and services, industrial software and technology, and specialty infrastructure. Funds managed and/or advised by Tinicum control two portfolio companies active in the aerospace fluid conveyance sector, PennAero and AeroFlow.&nbsp;</p>
+
+<p>Blackstone is a US-headquartered global alternative asset manager. Blackstone has a broad portfolio of investments across multiple sectors. As part of the structure of the Acquisition, Blackstone will acquire joint control of Tinicum subsidiary, AeroFlow.&nbsp;</p>
+
+<p>Senior is a UK publicly listed company that designs and manufactures high-technology components and systems for principal original equipment manufacturers in the worldwide aerospace and defence, land vehicle, power and energy, and industrials markets.</p>
 
   </div>
       <a href="#" class="read-toggle" data-expanded="true">read more</a>
@@ -9541,414 +9984,6 @@ MGH is a diversified industrials group, which operates a civil construction and 
     <p>Primary Wave KB Holdings, LP (together with its group companies, <strong>Primary Wave</strong>), intends to acquire substantially all of the interest units of Kobalt Music Group Topco L.P. (together with its subsidiaries, <strong>Kobalt</strong>) from Francisco Partners Management, L.P. (together with its affiliated funds, <strong>Francisco Partners</strong>) (the <strong>Acquisition</strong>).<br />
 Primary Wave is a US-based music acquisition, publishing and estate management company engaged in acquiring, managing and commercialising music rights and related intellectual property.<br />
 Kobalt is a digital royalty collection and music publishing administration company, servicing artists and other constituents in the music industry. Kobalt’s main business activities relate to the provision of music publishing administration services, to third-party music rights holders.&nbsp;</p>
-
-  </div>
-      <a href="#" class="read-toggle" data-expanded="true">read more</a>
-  </div></div>
-          </div>
-
-  </div>
-
-  </div>
-</div>
-
-</div>
-    <div class="views-row">
-
-<div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-169731">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/up-education-%E2%80%93-australian-academy-of-beauty-dermal-laser">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  UP Education – Australian Academy of Beauty Dermal &amp; Laser
-</h3>
-</div>
-      
-<div  class="accc-collapsed-card__header-info">
-        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
-    <h3 class="field__label">Acquisition status</h3>
-              <div class="field__item">Assessment completed</div>
-          </div>
-
-<div  class="accc-collapsed-card__header-content">
-      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
-<div class="field__item">Waiver</div>
-</div>
-  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
-    <h3 class="field__label">Case number</h3>
-              <div class="field__item">WA-85030</div>
-          </div>
-  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
-    <h3 class="field__label">Waiver application date</h3>
-              <div class="field__item"><time datetime="2026-05-18T12:00:00Z" class="datetime">18 May 2026</time>
-</div>
-          </div>
-
-  </div>
-
-  </div>
-</a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-169731" href="#card-169731">
-      <span>expandable trigger</span>
-    </a>
-  </div>
-  <div id="card-169731" role="region" aria-labelledby="heading-169731" class="accc-collapsed-card__body collapse">
-    
-<div >
-    <h3 class="border-bottom">About the acquisition</h3>
-      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Acquirer(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637531">
-      <span class="field_acccgov_name">
-            UP EDUCATION AUSTRALIA PTY LTD
-
-      </span>
-      <span>
-                        ABN -
-    58 095 741 227
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Target(s) or vendor(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637546">
-      <span class="field_acccgov_name">
-            AUSTRALIAN ACADEMY OF BEAUTY DERMAL AND LASER PTY LTD
-
-      </span>
-      <span>
-                        ABN -
-    88 089 942 647
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-other-parties field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Other party(ies)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637541">
-      <span class="field_acccgov_name">
-            Pacific Equity Partners
-
-      </span>
-      <span>
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-  <div class="field field--name-field-acccgov-anzsic-code field--type-entity-reference field--label-inline field--type-entity-reference--taxonomy_term clearfix">
-    <h3 class="field__label">ANZSIC code(s)</h3>
-          <div class="field__item">
-              8101 Technical and Vocational Education and Training;           8102 Higher Education              </div>
-      </div>
-  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
-    <h3 class="field__label">Description</h3>
-              <div class="field__item">
-<div class="read-more-wrapper">
-      <div class="summary-text">
-      <p>UP Education Australia Pty Limited, the Australian subsidiary of New Zealand Parent company UP Education HoldCo Limited (<strong>UP Education</strong>), proposes to acquire Australian Academy of Be</p>
-    </div>
-    <div class="full-text" style="display:none;">
-    <p>UP Education Australia Pty Limited, the Australian subsidiary of New Zealand Parent company UP Education HoldCo Limited (<strong>UP Education</strong>), proposes to acquire Australian Academy of Beauty Dermal &amp; Laser Pty Ltd (<strong>AABDL</strong>) by entering into a share sale deed (the <strong>Acquisition</strong>).</p>
-
-<p>AABDL is an Australian tertiary education provider providing beauty, laser and dermal training courses to approximately 487 students. It has four campuses in NSW (Bella Vista, North Strathfield, Rockdale and Sydney CBD).</p>
-
-<p>UP Education is a tertiary education provider in Australia and New Zealand which provides higher education, vocational education and training courses and university partnerships. UP Education offers courses in various topic areas such as health, hospitality, community services, construction and creative arts.</p>
-
-<p>UP Education operates a group of higher education and vocational education and training providers across Australia and New Zealand, including 10 registered providers in Australia. This includes 4 providers that have campuses in New South Wales (including online courses), with 3 providers located in Sydney. UP Education also delivers online qualifications nationally through several providers, including to students in NSW.</p>
-
-<p>UP Education does not currently supply any beauty, laser or dermal training courses in Australia.&nbsp;</p>
-
-<p>UP Education is owned and operated by funds managed and/or advised by Pacific Equity Partners (the <strong>PEP Funds</strong>). UP Education is the only tertiary education business owned by the PEP Funds.</p>
-
-  </div>
-      <a href="#" class="read-toggle" data-expanded="true">read more</a>
-  </div></div>
-          </div>
-
-  </div>
-
-  </div>
-</div>
-
-</div>
-    <div class="views-row">
-
-<div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-169721">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/tinicum-and-blackstone-led-consortium-%E2%80%93-senior">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  Tinicum and Blackstone led consortium – Senior
-</h3>
-</div>
-      
-<div  class="accc-collapsed-card__header-info">
-        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
-    <h3 class="field__label">Acquisition status</h3>
-              <div class="field__item">Assessment completed</div>
-          </div>
-
-<div  class="accc-collapsed-card__header-content">
-      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
-<div class="field__item">Waiver</div>
-</div>
-  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
-    <h3 class="field__label">Case number</h3>
-              <div class="field__item">WA-30018</div>
-          </div>
-  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
-    <h3 class="field__label">Waiver application date</h3>
-              <div class="field__item"><time datetime="2026-05-18T12:00:00Z" class="datetime">18 May 2026</time>
-</div>
-          </div>
-
-  </div>
-
-  </div>
-</a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-169721" href="#card-169721">
-      <span>expandable trigger</span>
-    </a>
-  </div>
-  <div id="card-169721" role="region" aria-labelledby="heading-169721" class="accc-collapsed-card__body collapse">
-    
-<div >
-    <h3 class="border-bottom">About the acquisition</h3>
-      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Acquirer(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637481">
-      <span class="field_acccgov_name">
-            Zeus UK Bidco Limited
-
-      </span>
-      <span>
-                      UK company number - 17118800
-
-              </span>
-    </div>
-  </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637486">
-      <span class="field_acccgov_name">
-            Tinicum L.P.
-
-      </span>
-      <span>
-                      Incorporation number - 5040692
-
-              </span>
-    </div>
-  </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637491">
-      <span class="field_acccgov_name">
-            BMA IX LLC
-
-      </span>
-      <span>
-                      File number - 6549791
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Target(s) or vendor(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637511">
-      <span class="field_acccgov_name">
-            Senior plc
-
-      </span>
-      <span>
-                      Company number - 00282772
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-other-parties field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Other party(ies)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637501">
-      <span class="field_acccgov_name">
-            AeroFlow Technologies, LLC
-
-      </span>
-      <span>
-              </span>
-    </div>
-  </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637506">
-      <span class="field_acccgov_name">
-            PennAero
-
-      </span>
-      <span>
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-  <div class="field field--name-field-acccgov-anzsic-code field--type-entity-reference field--label-inline field--type-entity-reference--taxonomy_term clearfix">
-    <h3 class="field__label">ANZSIC code(s)</h3>
-          <div class="field__item">
-              2394 Aircraft Manufacturing and Repair Services              </div>
-      </div>
-  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
-    <h3 class="field__label">Description</h3>
-              <div class="field__item">
-<div class="read-more-wrapper">
-      <div class="summary-text">
-      <p>BMA IX LLC is a wholly owned Delaware subsidiary of Blackstone, Inc. (together with its subsidiaries, <strong>Blackstone</strong>).</p>
-    </div>
-    <div class="full-text" style="display:none;">
-    <p>BMA IX LLC is a wholly owned Delaware subsidiary of Blackstone, Inc. (together with its subsidiaries, <strong>Blackstone</strong>). Zeus UK Bidco Limited (Bidco),a newly formed company which will be indirectly jointly controlled by funds managed and/or advised by Tinicum Incorporated (<strong>Tinicum</strong>) and by funds advised and/or managed by affiliates of Blackstone (together, the <strong>Consortium</strong>), propose to acquire 100% of the shares in Senior plc (together with its subsidiaries, <strong>Senior</strong>), by way of a Court approved scheme of arrangement (Scheme) under Part 26 of the UK Companies Act 2006 (the <strong>Acquisition</strong>). Following the Acquisition, Tinicum and Blackstone will have a controlling interest in Senior.&nbsp;</p>
-
-<p>Tinicum is a US-based private investment firm, focused on investing in both private and public companies across various sectors, including engineered products, industrial distribution and services, industrial software and technology, and specialty infrastructure. Funds managed and/or advised by Tinicum control two portfolio companies active in the aerospace fluid conveyance sector, PennAero and AeroFlow.&nbsp;</p>
-
-<p>Blackstone is a US-headquartered global alternative asset manager. Blackstone has a broad portfolio of investments across multiple sectors. As part of the structure of the Acquisition, Blackstone will acquire joint control of Tinicum subsidiary, AeroFlow.&nbsp;</p>
-
-<p>Senior is a UK publicly listed company that designs and manufactures high-technology components and systems for principal original equipment manufacturers in the worldwide aerospace and defence, land vehicle, power and energy, and industrials markets.</p>
-
-  </div>
-      <a href="#" class="read-toggle" data-expanded="true">read more</a>
-  </div></div>
-          </div>
-
-  </div>
-
-  </div>
-</div>
-
-</div>
-    <div class="views-row">
-
-<div  class="accc-collapsed-card contextual-region h-100">
-  <div class="accc-collapsed-card__header" id="heading-169806">
-  <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/soilco-go-grow">            <div class="field field--name-node-title field--type-ds field--label-hidden field__item"><h3>
-  SOILCO - Go Grow
-</h3>
-</div>
-      
-<div  class="accc-collapsed-card__header-info">
-        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
-    <h3 class="field__label">Acquisition status</h3>
-              <div class="field__item">Assessment completed</div>
-          </div>
-
-<div  class="accc-collapsed-card__header-content">
-      <div class="field field--acccgov-type field--label-inline"><h3 class="field__label">Type</h3>
-<div class="field__item">Waiver</div>
-</div>
-  <div class="field field--name-field-acccgov-mcmsmergermatterno field--type-string field--label-inline clearfix">
-    <h3 class="field__label">Case number</h3>
-              <div class="field__item">WA-80018</div>
-          </div>
-  <div class="field field--name-field-acccgov-pub-reg-date field--type-datetime field--label-inline clearfix">
-    <h3 class="field__label">Waiver application date</h3>
-              <div class="field__item"><time datetime="2026-05-18T12:00:00Z" class="datetime">18 May 2026</time>
-</div>
-          </div>
-
-  </div>
-
-  </div>
-</a>
-    <a class="display" role="button" aria-expanded="false" data-toggle="collapse" aria-controls="card-169806" href="#card-169806">
-      <span>expandable trigger</span>
-    </a>
-  </div>
-  <div id="card-169806" role="region" aria-labelledby="heading-169806" class="accc-collapsed-card__body collapse">
-    
-<div >
-    <h3 class="border-bottom">About the acquisition</h3>
-      <div class="field field--name-field-acccgov-applicants field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Acquirer(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637736">
-      <span class="field_acccgov_name">
-            SOILCO PTY LIMITED
-
-      </span>
-      <span>
-                        ABN -
-    85 055 303 243
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-pub-reg-targets field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Target(s) or vendor(s)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637751">
-      <span class="field_acccgov_name">
-            GARDEN MEDIUMS PTY LIMITED
-
-      </span>
-      <span>
-                        ABN -
-    44 079 600 230
-
-              </span>
-    </div>
-  </li>
-      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637756">
-      <span class="field_acccgov_name">
-            Lumime Pty Ltd
-
-      </span>
-      <span>
-                        ACN -
-    001 931 228
-
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-<div class="field field--name-field-acccgov-other-parties field--type-entity-reference-revisions field--label-inline clearfix">
-  <h3 class="field__label">Other party(ies)</h3>
-      <div class="field__items">
-    <ul>      <li>      <div class="paragraph paragraph--type--acccgov-trader paragraph--view-mode--detailed-list paragraph--id--637746">
-      <span class="field_acccgov_name">
-            I Squared Capital, LLC
-
-      </span>
-      <span>
-              </span>
-    </div>
-  </li>
-    </ul>      </div>
-    </div>
-  <div class="field field--name-field-acccgov-anzsic-code field--type-entity-reference field--label-inline field--type-entity-reference--taxonomy_term clearfix">
-    <h3 class="field__label">ANZSIC code(s)</h3>
-          <div class="field__item">
-              3291 Landscape Construction Services;           4232 Garden Supplies Retailing              </div>
-      </div>
-  <div class="field field--name-field-accc-body field--type-text-with-summary field--label-inline clearfix text-formatted">
-    <h3 class="field__label">Description</h3>
-              <div class="field__item">
-<div class="read-more-wrapper">
-      <div class="summary-text">
-      <p class="Default">SOILCO Pty Ltd (<strong>SOILCO</strong>) proposes to acquire 100% of the shares in Garden Mediums Pty Ltd (trading as <strong>Go Grow</strong>) from Lumime Pty Ltd and trustee of th</p>
-    </div>
-    <div class="full-text" style="display:none;">
-    <p class="Default">SOILCO Pty Ltd (<strong>SOILCO</strong>) proposes to acquire 100% of the shares in Garden Mediums Pty Ltd (trading as <strong>Go Grow</strong>) from Lumime Pty Ltd and trustee of the Honey &amp; Nut Unit Trust (the <strong>Acquisition</strong>).&nbsp;</p>
-
-<p class="Default">SOILCO operates organic waste recycling facilities in New South Wales, ACT and Victoria, including a facility at Tweed Heads in northern NSW.&nbsp;SOILCO’s facilities process food and garden organic (<strong>FOGO</strong>) waste from local councils, blending it with forestry and agricultural feedstocks (and other suppliers’ inputs) to manufacture compost and soil improvement products.&nbsp;SOILCO supplies these products for a range of applications including, including urban landscaping and projects and agriculture and horticulture production systems (orchards, viticulture, turf farms, nurseries, and greenlife).</p>
-
-<p class="Default">SOILCOs majority shareholder, Australian Waste Management Investments is part of the I Squared Capital group (<strong>I Squared</strong>). I Squared is a global infrastructure investment firm headquartered in the United States,&nbsp;</p>
-
-<p>Go Grow manufactures and supplies potting mixes, fertilisers and garden products from a single site in Ballina NSW. Part of Go Grow’s business involves processing locally sourced garden waste to produce compost and mulch which is supplied directly to retail customers, as well as farms and nurseries. Go Grow does not acquire or process FOGO waste.&nbsp;</p>
 
   </div>
       <a href="#" class="read-toggle" data-expanded="true">read more</a>
@@ -10534,7 +10569,7 @@ Notification / waiver application date</span>
   </div>
 
     
-    <script type="application/json" data-drupal-selector="drupal-settings-json">{"path":{"baseUrl":"\/","pathPrefix":"","currentPath":"node\/165685","currentPathIsAdmin":false,"isFront":false,"currentLanguage":"en","currentQuery":{"init":"1","items_per_page":"50"}},"pluralDelimiter":"\u0003","suppressDeprecationErrors":true,"ajaxPageState":{"libraries":"STATIC_LIBRARIES","theme":"acccgov_theme","theme_token":null},"ajaxTrustedUrl":{"\/public-registers\/mergers-and-acquisitions-registers\/acquisitions-register":true,"form_action_p_pvdeGsVG5zNF_XLGPTvYSKCf43t8qZYSwcfZl2uzM":true,"\/public-registers\/mergers-and-acquisitions-registers\/acquisitions-register?init=1\u0026items_per_page=50\u0026ajax_form=1":true,"\/search":true},"google_analytics":{"account":"G-S5TGQHQ4G8"},"data":{"extlink":{"extTarget":false,"extTargetNoOverride":false,"extNofollow":false,"extNoreferrer":false,"extFollowNoOverride":false,"extClass":"ext","extLabel":"(link is external)","extImgClass":false,"extSubdomains":false,"extExclude":"","extInclude":"","extCssExclude":".no-extlink, .rsbtn_play, .region-header-top","extCssExplicit":"","extAlert":false,"extAlertText":"This link will take you to an external web site. We are not responsible for their content.","mailtoClass":"mailto","mailtoLabel":"(link sends email)","extUseFontAwesome":false,"extIconPlacement":"append","extFaLinkClasses":"fa fa-external-link","extFaMailtoClasses":"fa fa-envelope-o","whitelistedDomains":["www.accc.gov.au"]}},"acccWebchat":{"deploymentKey":"79cdc325-9942-4e22-919b-15fbf3b66c26","orgGuid":null,"queueTargetAddress":null,"completionMessage":null},"acccBootstrap":{"css_js_query_string":"STATIC"},"views":{"ajax_path":"\/views\/ajax","ajaxViews":{"views_dom_id:STATIC":{"view_name":"acccgov_acquisitions_register","view_display_id":"browse","view_args":"","view_path":"\/node\/165685","view_base_path":null,"view_dom_id":"STATIC"","pager_element":0}}},"field_group":{"html_element":{"mode":"teaser","context":"view","settings":{"classes":"accc-collapsed-card__header-content","show_empty_fields":false,"id":"","element":"div","show_label":false,"label_element":"h3","label_element_classes":"","attributes":"","effect":"none","speed":"fast"}}},"ajax":{"edit-actions-submit":{"callback":"::submitAjaxForm","event":"click","effect":"none","speed":500,"progress":{"type":"throbber","message":""},"disable-refocus":true,"url":"\/public-registers\/mergers-and-acquisitions-registers\/acquisitions-register?init=1\u0026items_per_page=50\u0026ajax_form=1","httpMethod":"POST","dialogType":"ajax","submit":{"_triggering_element_name":"op","_triggering_element_value":"Sign up now"}},"edit-captcha-response":{"callback":"recaptcha_v3_ajax_callback","event":"change","url":"\/public-registers\/mergers-and-acquisitions-registers\/acquisitions-register?init=1\u0026items_per_page=50\u0026ajax_form=1","httpMethod":"POST","dialogType":"ajax","submit":{"_triggering_element_name":"captcha_response"}}},"icon_select":{"icon_select_url":"\/sites\/www.accc.gov.au\/files\/icons\/icon_select_map.svg?hash=2661be60a2021b5bd51b6f74d38883a5"},"search_api_autocomplete":{"accc_search_site":{"auto_submit":true,"min_length":3}},"user":{"uid":0,"permissionsHash":"STATIC_HASH"}}</script>
+    <script type="application/json" data-drupal-selector="drupal-settings-json">{"path":{"baseUrl":"\/","pathPrefix":"","currentPath":"node\/165685","currentPathIsAdmin":false,"isFront":false,"currentLanguage":"en","currentQuery":{"init":"1","items_per_page":"50"}},"pluralDelimiter":"\u0003","suppressDeprecationErrors":true,"ajaxPageState":{"libraries":"STATIC_LIBRARIES","theme":"acccgov_theme","theme_token":null},"ajaxTrustedUrl":{"\/public-registers\/mergers-and-acquisitions-registers\/acquisitions-register":true,"form_action_p_pvdeGsVG5zNF_XLGPTvYSKCf43t8qZYSwcfZl2uzM":true,"\/public-registers\/mergers-and-acquisitions-registers\/acquisitions-register?init=1\u0026ajax_form=1":true,"\/search":true},"google_analytics":{"account":"G-S5TGQHQ4G8"},"data":{"extlink":{"extTarget":false,"extTargetNoOverride":false,"extNofollow":false,"extNoreferrer":false,"extFollowNoOverride":false,"extClass":"ext","extLabel":"(link is external)","extImgClass":false,"extSubdomains":false,"extExclude":"","extInclude":"","extCssExclude":".no-extlink, .rsbtn_play, .region-header-top","extCssExplicit":"","extAlert":false,"extAlertText":"This link will take you to an external web site. We are not responsible for their content.","mailtoClass":"mailto","mailtoLabel":"(link sends email)","extUseFontAwesome":false,"extIconPlacement":"append","extFaLinkClasses":"fa fa-external-link","extFaMailtoClasses":"fa fa-envelope-o","whitelistedDomains":["www.accc.gov.au"]}},"acccWebchat":{"deploymentKey":"79cdc325-9942-4e22-919b-15fbf3b66c26","orgGuid":null,"queueTargetAddress":null,"completionMessage":null},"acccBootstrap":{"css_js_query_string":"STATIC"},"views":{"ajax_path":"\/views\/ajax","ajaxViews":{"views_dom_id:STATIC":{"view_name":"acccgov_acquisitions_register","view_display_id":"browse","view_args":"","view_path":"\/node\/165685","view_base_path":null,"view_dom_id":"STATIC"","pager_element":0}}},"field_group":{"html_element":{"mode":"teaser","context":"view","settings":{"classes":"accc-collapsed-card__header-content","show_empty_fields":false,"id":"","element":"div","show_label":false,"label_element":"h3","label_element_classes":"","attributes":"","effect":"none","speed":"fast"}}},"ajax":{"edit-actions-submit":{"callback":"::submitAjaxForm","event":"click","effect":"none","speed":500,"progress":{"type":"throbber","message":""},"disable-refocus":true,"url":"\/public-registers\/mergers-and-acquisitions-registers\/acquisitions-register?init=1\u0026ajax_form=1","httpMethod":"POST","dialogType":"ajax","submit":{"_triggering_element_name":"op","_triggering_element_value":"Sign up now"}},"edit-captcha-response":{"callback":"recaptcha_v3_ajax_callback","event":"change","url":"\/public-registers\/mergers-and-acquisitions-registers\/acquisitions-register?init=1\u0026ajax_form=1","httpMethod":"POST","dialogType":"ajax","submit":{"_triggering_element_name":"captcha_response"}}},"icon_select":{"icon_select_url":"\/sites\/www.accc.gov.au\/files\/icons\/icon_select_map.svg?hash=2661be60a2021b5bd51b6f74d38883a5"},"search_api_autocomplete":{"accc_search_site":{"auto_submit":true,"min_length":3}},"user":{"uid":0,"permissionsHash":"STATIC_HASH"}}</script>
 <script src="https://www.google.com/recaptcha/api.js?render=6LfbAC0pAAAAAO6f5xx7XiBzPfuoPh7AiGN-lhtq" defer async></script>
 <script src="/sites/www.accc.gov.au/files/js/js_STATIC.js?scope=footer&amp;delta=1&amp;language=en&amp;theme=acccgov_theme&amp;include=STATIC"></script>
 <script src="https://app-script.monsido.com/v2/monsido-script.js" async></script>

--- a/data/raw/matters/WA-05023.html
+++ b/data/raw/matters/WA-05023.html
@@ -186,7 +186,7 @@
               <input placeholder="Search" data-drupal-selector="edit-query" data-search-api-autocomplete-search="accc_search_site" class="form-autocomplete form-control" data-autocomplete-path="/search_api_autocomplete/accc_search_site?display=search_box&amp;&amp;filter=query" type="text" id="edit-query" name="query" value="" size="30" maxlength="128" />
 
           </div>
-<div data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions--2">    <button aria-label="Submit search" data-drupal-selector="edit-submit-accc-search-site" type="submit" id="edit-submit-accc-search-site--STATIC" value="Search" class="button js-form-submit form-submit btn btn-primary">
+<div data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions">    <button aria-label="Submit search" data-drupal-selector="edit-submit-accc-search-site" type="submit" id="edit-submit-accc-search-site--STATIC" value="Search" class="button js-form-submit form-submit btn btn-primary">
   <span>Search</span>              <svg  class="fa-search" aria-hidden="true"><use href="/themes/custom/accc_bootstrap/icons/icons.svg?tSTATIC"></use></svg>
 
       

--- a/data/raw/matters/WA-30018.html
+++ b/data/raw/matters/WA-30018.html
@@ -186,7 +186,7 @@
               <input placeholder="Search" data-drupal-selector="edit-query" data-search-api-autocomplete-search="accc_search_site" class="form-autocomplete form-control" data-autocomplete-path="/search_api_autocomplete/accc_search_site?display=search_box&amp;&amp;filter=query" type="text" id="edit-query" name="query" value="" size="30" maxlength="128" />
 
           </div>
-<div data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions--2">    <button aria-label="Submit search" data-drupal-selector="edit-submit-accc-search-site" type="submit" id="edit-submit-accc-search-site--STATIC" value="Search" class="button js-form-submit form-submit btn btn-primary">
+<div data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions">    <button aria-label="Submit search" data-drupal-selector="edit-submit-accc-search-site" type="submit" id="edit-submit-accc-search-site--STATIC" value="Search" class="button js-form-submit form-submit btn btn-primary">
   <span>Search</span>              <svg  class="fa-search" aria-hidden="true"><use href="/themes/custom/accc_bootstrap/icons/icons.svg?tSTATIC"></use></svg>
 
       

--- a/data/raw/matters/WA-80017.html
+++ b/data/raw/matters/WA-80017.html
@@ -186,7 +186,7 @@
               <input placeholder="Search" data-drupal-selector="edit-query" data-search-api-autocomplete-search="accc_search_site" class="form-autocomplete form-control" data-autocomplete-path="/search_api_autocomplete/accc_search_site?display=search_box&amp;&amp;filter=query" type="text" id="edit-query" name="query" value="" size="30" maxlength="128" />
 
           </div>
-<div data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions--2">    <button aria-label="Submit search" data-drupal-selector="edit-submit-accc-search-site" type="submit" id="edit-submit-accc-search-site--STATIC" value="Search" class="button js-form-submit form-submit btn btn-primary">
+<div data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions">    <button aria-label="Submit search" data-drupal-selector="edit-submit-accc-search-site" type="submit" id="edit-submit-accc-search-site--STATIC" value="Search" class="button js-form-submit form-submit btn btn-primary">
   <span>Search</span>              <svg  class="fa-search" aria-hidden="true"><use href="/themes/custom/accc_bootstrap/icons/icons.svg?tSTATIC"></use></svg>
 
       

--- a/data/raw/matters/WA-85030.html
+++ b/data/raw/matters/WA-85030.html
@@ -186,7 +186,7 @@
               <input placeholder="Search" data-drupal-selector="edit-query" data-search-api-autocomplete-search="accc_search_site" class="form-autocomplete form-control" data-autocomplete-path="/search_api_autocomplete/accc_search_site?display=search_box&amp;&amp;filter=query" type="text" id="edit-query" name="query" value="" size="30" maxlength="128" />
 
           </div>
-<div data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions--2">    <button aria-label="Submit search" data-drupal-selector="edit-submit-accc-search-site" type="submit" id="edit-submit-accc-search-site--STATIC" value="Search" class="button js-form-submit form-submit btn btn-primary">
+<div data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions">    <button aria-label="Submit search" data-drupal-selector="edit-submit-accc-search-site" type="submit" id="edit-submit-accc-search-site--STATIC" value="Search" class="button js-form-submit form-submit btn btn-primary">
   <span>Search</span>              <svg  class="fa-search" aria-hidden="true"><use href="/themes/custom/accc_bootstrap/icons/icons.svg?tSTATIC"></use></svg>
 
       

--- a/data/raw/matters/WA-95020.html
+++ b/data/raw/matters/WA-95020.html
@@ -186,7 +186,7 @@
               <input placeholder="Search" data-drupal-selector="edit-query" data-search-api-autocomplete-search="accc_search_site" class="form-autocomplete form-control" data-autocomplete-path="/search_api_autocomplete/accc_search_site?display=search_box&amp;&amp;filter=query" type="text" id="edit-query" name="query" value="" size="30" maxlength="128" />
 
           </div>
-<div data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions--2">    <button aria-label="Submit search" data-drupal-selector="edit-submit-accc-search-site" type="submit" id="edit-submit-accc-search-site--STATIC" value="Search" class="button js-form-submit form-submit btn btn-primary">
+<div data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-wrapper" id="edit-actions">    <button aria-label="Submit search" data-drupal-selector="edit-submit-accc-search-site" type="submit" id="edit-submit-accc-search-site--STATIC" value="Search" class="button js-form-submit form-submit btn btn-primary">
   <span>Search</span>              <svg  class="fa-search" aria-hidden="true"><use href="/themes/custom/accc_bootstrap/icons/icons.svg?tSTATIC"></use></svg>
 
       

--- a/scripts/scrape.sh
+++ b/scripts/scrape.sh
@@ -67,6 +67,7 @@ clean_file() {
   perl -i -0777 -pe '
     s/js-view-dom-id-[a-f0-9]{64}/js-view-dom-id-STATIC/g;
     s/(id="edit-submit-accc-search-site--)[^"\n]+"/${1}STATIC"/g;
+    s/(id="edit-actions)--[0-9]+"/${1}"/g;
     s/(data-drupal-selector="form-)[^"\n]+(" type="hidden" name="form_build_id")/${1}STATIC${2}/g;
     s/(name="form_build_id" value="form-)[^"\n]+"/${1}STATIC"/g;
     s/(css\/css_)[^.\n]+\.css/${1}STATIC.css/g;


### PR DESCRIPTION
Drupal appends --N to deduplicate element IDs when multiple forms appear
on the same page. Add a perl substitution to normalise id="edit-actions--N"
back to id="edit-actions" during HTML cleaning, and apply it to WA-85030.html.

https://claude.ai/code/session_01EVnwgnaY7w1CE7VGF2Ljwf