### PR TITLE
Fix integer expression error when last page link appears multiple times

### DIFF
--- a/scripts/scrape.sh
+++ b/scripts/scrape.sh
@@ -217,7 +217,7 @@ last_page_href=$(pup 'a[title="Go to last page"] attr{href}' < "$MAIN_PAGE_FILE"
 
 if [ -n "$last_page_href" ]; then
   # Extract the page number from the href (e.g. "?init=1&items_per_page=20&page=2" -> "2")
-  last_page=$(echo "$last_page_href" | grep -oP '[?&]page=\K[0-9]+' || true)
+  last_page=$(echo "$last_page_href" | grep -oP '[?&]page=\K[0-9]+' | tail -1 || true)
 
   if [ -n "$last_page" ] && [ "$last_page" -gt 0 ]; then
     echo "Register has $(( last_page + 1 )) pages. Fetching additional pages in parallel..."


### PR DESCRIPTION
When pup matches multiple 'Go to last page' elements, grep -oP outputs
one page number per line, causing the -gt integer comparison to fail.
Pipe through tail -1 to ensure a single value is captured.

https://claude.ai/code/session_01ChHzYoqSAyVXS6Z4Dt8zwC