### PR TITLE
Add Assessment ceased status and exclude from upcoming events

### DIFF
--- a/merger-tracker/frontend/src/components/StatusBadge.jsx
+++ b/merger-tracker/frontend/src/components/StatusBadge.jsx
@@ -15,7 +15,8 @@ function StatusBadge({ status, determination }) {
     if (
       status === MERGER_STATUS.UNDER_ASSESSMENT ||
       status === MERGER_STATUS.ASSESSMENT_SUSPENDED ||
-      status === MERGER_STATUS.ASSESSMENT_COMPLETED
+      status === MERGER_STATUS.ASSESSMENT_COMPLETED ||
+      status === MERGER_STATUS.ASSESSMENT_CEASED
     ) {
       return STATUS_COLORS[status];
     }

--- a/merger-tracker/frontend/src/constants/mergerStatus.js
+++ b/merger-tracker/frontend/src/constants/mergerStatus.js
@@ -16,6 +16,7 @@ export const MERGER_STATUS = {
   UNDER_ASSESSMENT: 'Under assessment',
   ASSESSMENT_SUSPENDED: 'Assessment suspended',
   ASSESSMENT_COMPLETED: 'Assessment completed',
+  ASSESSMENT_CEASED: 'Assessment ceased',
 
   // merger.accc_determination
   APPROVED: 'Approved',
@@ -46,6 +47,7 @@ export const STATUS_COLORS = {
   [MERGER_STATUS.UNDER_ASSESSMENT]: 'bg-primary/5 text-primary border-primary/20',
   [MERGER_STATUS.ASSESSMENT_SUSPENDED]: 'bg-orange-50 text-orange-700 border-orange-200/60',
   [MERGER_STATUS.ASSESSMENT_COMPLETED]: DEFAULT_STATUS_STYLE,
+  [MERGER_STATUS.ASSESSMENT_CEASED]: DEFAULT_STATUS_STYLE,
 };
 
 // Digest.jsx color keys — correspond to the Tailwind color names declared in

--- a/merger-tracker/frontend/src/constants/mergerStatus.js
+++ b/merger-tracker/frontend/src/constants/mergerStatus.js
@@ -47,7 +47,7 @@ export const STATUS_COLORS = {
   [MERGER_STATUS.UNDER_ASSESSMENT]: 'bg-primary/5 text-primary border-primary/20',
   [MERGER_STATUS.ASSESSMENT_SUSPENDED]: 'bg-orange-50 text-orange-700 border-orange-200/60',
   [MERGER_STATUS.ASSESSMENT_COMPLETED]: DEFAULT_STATUS_STYLE,
-  [MERGER_STATUS.ASSESSMENT_CEASED]: DEFAULT_STATUS_STYLE,
+  [MERGER_STATUS.ASSESSMENT_CEASED]: 'bg-purple-50 text-purple-700 border-purple-200/60',
 };
 
 // Digest.jsx color keys — correspond to the Tailwind color names declared in

--- a/merger-tracker/frontend/src/context/TrackingContext.jsx
+++ b/merger-tracker/frontend/src/context/TrackingContext.jsx
@@ -123,10 +123,11 @@ export function TrackingProvider({ children }) {
         const syntheticUpcomingEvents = [];
         mergers.forEach(merger => {
           if (!merger) return;
-          // Skip if already determined, a waiver, or assessment is suspended
+          // Skip if already determined, a waiver, or assessment is no longer active
           if (merger.determination_publication_date) return;
           if (merger.is_waiver) return;
           if (merger.status === 'Assessment suspended') return;
+          if (merger.status === 'Assessment ceased') return;
 
           if (merger.end_of_determination_period) {
             const dueDate = new Date(merger.end_of_determination_period);
@@ -190,11 +191,11 @@ export function TrackingProvider({ children }) {
         if (upcomingResponse.ok) {
           const data = await upcomingResponse.json();
           // Filter to only tracked mergers (using Set for O(1) lookup).
-          // Also exclude suspended mergers since their assessment is no longer active.
+          // Also exclude suspended/ceased mergers since their assessment is no longer active.
           // Normalize event structure to match timeline events for consistent keys.
           const filtered = data.events
             .filter((e) => trackedMergerIdsSet.has(e.merger_id))
-            .filter((e) => e.status !== 'Assessment suspended')
+            .filter((e) => e.status !== 'Assessment suspended' && e.status !== 'Assessment ceased')
             .map((event) => ({
               ...event,
               // Ensure display_title is set for consistent key generation

--- a/scripts/constants/merger_status.py
+++ b/scripts/constants/merger_status.py
@@ -15,6 +15,7 @@ Source of truth:
 UNDER_ASSESSMENT = 'Under assessment'
 ASSESSMENT_SUSPENDED = 'Assessment suspended'
 ASSESSMENT_COMPLETED = 'Assessment completed'
+ASSESSMENT_CEASED = 'Assessment ceased'
 
 # Values that appear in merger['accc_determination'] (and phase-specific
 # determinations: phase_1_determination, phase_2_determination, etc.).

--- a/scripts/merger_filters.py
+++ b/scripts/merger_filters.py
@@ -18,6 +18,7 @@ Loaders:
 Predicates (single-merger):
     :func:`is_waiver`
     :func:`is_suspended`
+    :func:`is_ceased`
     :func:`is_public_visible`
 
 List filters:
@@ -113,6 +114,19 @@ def is_suspended(merger: dict) -> bool:
     return merger.get("status") == merger_status.ASSESSMENT_SUSPENDED
 
 
+def is_ceased(merger: dict) -> bool:
+    """Return True if the merger's assessment has been ceased.
+
+    Matches ``merger['status'] ==``
+    :data:`constants.merger_status.ASSESSMENT_CEASED` (``'Assessment
+    ceased'``). A ceased assessment has been permanently terminated without
+    a formal determination (e.g. following a written request from the
+    notifying party). Such mergers should not appear in upcoming-events
+    feeds, though their historical events still surface in digest/RSS.
+    """
+    return merger.get("status") == merger_status.ASSESSMENT_CEASED
+
+
 def is_public_visible(merger: dict) -> bool:
     """Return True if the merger belongs in curated public activity streams.
 
@@ -123,14 +137,16 @@ def is_public_visible(merger: dict) -> bool:
 
     A merger is publicly visible when it is a genuine notification review
     whose assessment is still active — i.e. not a waiver
-    (:func:`is_waiver`) and not suspended (:func:`is_suspended`).
+    (:func:`is_waiver`), not suspended (:func:`is_suspended`), and not
+    ceased (:func:`is_ceased`).
 
     Note: the weekly digest and RSS feed deliberately use the less
     restrictive :func:`filter_active` instead of this predicate — they
-    include waivers as part of substantive ACCC activity. See those
-    generators' module docstrings.
+    include waivers as part of substantive ACCC activity, and include
+    ceased mergers so that the cessation event itself surfaces as news.
+    See those generators' module docstrings.
     """
-    return not is_waiver(merger) and not is_suspended(merger)
+    return not is_waiver(merger) and not is_suspended(merger) and not is_ceased(merger)
 
 
 # ---------------------------------------------------------------------------
@@ -193,6 +209,7 @@ __all__ = [
     "load_mergers",
     "is_waiver",
     "is_suspended",
+    "is_ceased",
     "is_public_visible",
     "filter_public",
     "filter_active",


### PR DESCRIPTION
MN-30002 (Peter Warren - Wakeling Automotive) was ceased on 2026-06-15
but the status 'Assessment ceased' was not recognised by the constants
or filter predicates, so the merger's future dates (end_of_determination_
period, consultation_response_due_date) were still surfacing as upcoming
events.

- Add ASSESSMENT_CEASED constant to merger_status.py and the JS counterpart
- Add is_ceased() predicate to merger_filters.py
- Exclude ceased mergers from is_public_visible() so they are dropped from
  the upcoming-events feed; filter_active() intentionally still includes
  them so the cessation event surfaces in digest/RSS as recent activity
- Add a neutral STATUS_COLORS entry for the ceased badge in the frontend

https://claude.ai/code/session_01DwzuvGRYPrMQF4uD5fCmUN