### PR TITLE
Treat assessment-ceased events as determination events

### DIFF
--- a/data/output/mergers.json
+++ b/data/output/mergers.json
@@ -11119,6 +11119,7 @@
           "date": "2026-06-15T12:00:00Z",
           "title": "Consideration of Notification ceased \u2013 following written request from notifying party",
           "display_title": "Consideration of Notification ceased \u2013 following written request from notifying party",
+          "is_determination_event": true,
           "phase": null
         }
       ],
@@ -11130,6 +11131,7 @@
       "phase_2_determination_date": null,
       "public_benefits_determination": null,
       "public_benefits_determination_date": null,
+      "ceased_date": "2026-06-15T12:00:00Z",
       "competition_concerns_notice_date": "2026-07-08T12:00:00Z",
       "has_questionnaire": true,
       "similar_mergers": [

--- a/merger-tracker/frontend/public/data/mergers/MN-30002.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-30002.json
@@ -112,6 +112,7 @@
       "date": "2026-06-15T12:00:00Z",
       "title": "Consideration of Notification ceased \u2013 following written request from notifying party",
       "display_title": "Consideration of Notification ceased \u2013 following written request from notifying party",
+      "is_determination_event": true,
       "phase": null
     }
   ],
@@ -123,6 +124,7 @@
   "phase_2_determination_date": null,
   "public_benefits_determination": null,
   "public_benefits_determination_date": null,
+  "ceased_date": "2026-06-15T12:00:00Z",
   "competition_concerns_notice_date": "2026-07-08T12:00:00Z",
   "has_questionnaire": true,
   "similar_mergers": [

--- a/merger-tracker/frontend/public/data/stats.json
+++ b/merger-tracker/frontend/public/data/stats.json
@@ -120,6 +120,16 @@
   ],
   "recent_determinations": [
     {
+      "merger_id": "MN-30002",
+      "merger_name": "Peter Warren - Wakeling Automotive",
+      "determination": "Assessment ceased",
+      "determination_date": "2026-06-15T12:00:00Z",
+      "page_modified_datetime": "2026-06-16T08:57:08+10:00",
+      "determination_type": "ceased",
+      "is_waiver": false,
+      "stage": "Phase 2 - detailed assessment"
+    },
+    {
       "merger_id": "WA-50023",
       "merger_name": "Hillhouse - MGI Dobbyn Carafa",
       "determination": "Approved",
@@ -165,16 +175,6 @@
       "determination": "Approved",
       "determination_date": "2026-06-11T12:00:00Z",
       "page_modified_datetime": "2026-06-12T08:46:44+10:00",
-      "determination_type": "final",
-      "is_waiver": false,
-      "stage": "Phase 1 - initial assessment"
-    },
-    {
-      "merger_id": "MN-25018",
-      "merger_name": "Primary Wave - Kobalt",
-      "determination": "Approved",
-      "determination_date": "2026-06-11T12:00:00Z",
-      "page_modified_datetime": "2026-06-11T10:04:09+10:00",
       "determination_type": "final",
       "is_waiver": false,
       "stage": "Phase 1 - initial assessment"

--- a/merger-tracker/frontend/src/components/MergerTimeline.jsx
+++ b/merger-tracker/frontend/src/components/MergerTimeline.jsx
@@ -23,6 +23,7 @@ const OUTCOME_DOT = {
   [MERGER_STATUS.DECLINED]: 'bg-red-500',
   [MERGER_STATUS.NOT_APPROVED]: 'bg-red-500',
   [MERGER_STATUS.REFERRED_TO_PHASE_2]: 'bg-amber-500',
+  [MERGER_STATUS.ASSESSMENT_CEASED]: 'bg-purple-500',
 };
 
 // Position of `date` along the start -> end axis, clamped to [0, 100].
@@ -86,7 +87,11 @@ function MergerTimelineFallback({ merger, startStr }) {
  */
 function MergerTimeline({ merger }) {
   const startStr = merger.effective_notification_datetime || merger.original_notification_datetime;
-  const isComplete = Boolean(merger.determination_publication_date);
+  const isCeased = merger.status === MERGER_STATUS.ASSESSMENT_CEASED;
+  // For ceased mergers the cessation date stands in for the determination date.
+  const effectiveDeterminationDate = merger.determination_publication_date
+    || (isCeased ? merger.ceased_date : null);
+  const isComplete = Boolean(effectiveDeterminationDate);
 
   const start = startStr ? parseISO(startStr) : null;
 
@@ -114,9 +119,9 @@ function MergerTimeline({ merger }) {
     end = deadline;
     endLabel = 'Deadline';
   } else if (isComplete) {
-    endStr = merger.determination_publication_date;
+    endStr = effectiveDeterminationDate;
     end = parseISO(endStr);
-    endLabel = 'Determination';
+    endLabel = isCeased ? 'Ceased' : 'Determination';
     endIsOutcome = true;
   }
 
@@ -126,17 +131,17 @@ function MergerTimeline({ merger }) {
   }
 
   const startLabel = merger.is_waiver ? 'Waiver application' : 'Notified';
-  const outcomeDot = OUTCOME_DOT[merger.accc_determination] || 'bg-primary';
+  const outcomeDot = OUTCOME_DOT[merger.accc_determination] || OUTCOME_DOT[merger.status] || 'bg-primary';
 
-  const duration = calculateDuration(startStr, merger.determination_publication_date);
-  const businessDuration = calculateBusinessDays(startStr, merger.determination_publication_date);
+  const duration = calculateDuration(startStr, effectiveDeterminationDate);
+  const businessDuration = calculateBusinessDays(startStr, effectiveDeterminationDate);
   const daysRemaining = getDaysRemaining(deadlineStr);
   const businessDaysRemaining = getBusinessDaysRemaining(deadlineStr);
 
   // Mid-axis "determination" marker for decided mergers whose endpoint is the
   // deadline.
   const decisionPct = isComplete && hasDeadline
-    ? axisPct(parseISO(merger.determination_publication_date), start, end)
+    ? axisPct(parseISO(effectiveDeterminationDate), start, end)
     : null;
 
   // For mergers referred to Phase 2, mark the Phase 1 determination date with a
@@ -172,6 +177,7 @@ function MergerTimeline({ merger }) {
   // These are mutually exclusive.
   const midPct = decisionPct !== null ? decisionPct : todayPct;
   const midIsDetermination = decisionPct !== null;
+  const midLabel = midIsDetermination ? (isCeased ? 'Ceased' : 'Determination') : 'Today';
   // Shared positioning for the mid label and value so they stay aligned.
   const midStyle = midPct === null ? null : {
     width: MID_BOX,
@@ -227,7 +233,7 @@ function MergerTimeline({ merger }) {
             }`}
             style={midStyle}
           >
-            {midIsDetermination ? 'Determination' : 'Today'}
+            {midLabel}
           </span>
         )}
 
@@ -284,7 +290,7 @@ function MergerTimeline({ merger }) {
           >
             {midIsDetermination ? (
               <>
-                <span className={`block ${dateClass}`}>{formatDateMedium(merger.determination_publication_date)}</span>
+                <span className={`block ${dateClass}`}>{formatDateMedium(effectiveDeterminationDate)}</span>
                 {durationStr && (
                   <span className="block text-[11px] font-normal text-gray-500">{durationStr}</span>
                 )}

--- a/merger-tracker/frontend/src/components/RecentDeterminationsTable.jsx
+++ b/merger-tracker/frontend/src/components/RecentDeterminationsTable.jsx
@@ -5,6 +5,11 @@ import { isNewItem } from '../utils/lastVisit';
 import NewBadge from './NewBadge';
 import StatusBadge from './StatusBadge';
 import WaiverBadge from './WaiverBadge';
+import { MERGER_STATUS } from '../constants/mergerStatus';
+
+const DETERMINATION_LABELS = {
+  [MERGER_STATUS.ASSESSMENT_CEASED]: 'Ceased',
+};
 
 function RecentDeterminationsTable({ determinations }) {
   if (!determinations || determinations.length === 0) {
@@ -68,7 +73,10 @@ function RecentDeterminationsTable({ determinations }) {
                   </div>
                 </td>
                 <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm">
-                  <StatusBadge determination={item.determination} />
+                  <StatusBadge
+                    determination={item.determination}
+                    label={DETERMINATION_LABELS[item.determination]}
+                  />
                   <div className="text-xs text-gray-500 mt-1 pl-2.5">
                     {formatDate(item.determination_date)}
                   </div>

--- a/merger-tracker/frontend/src/components/StatusBadge.jsx
+++ b/merger-tracker/frontend/src/components/StatusBadge.jsx
@@ -1,6 +1,6 @@
 import { MERGER_STATUS, STATUS_COLORS, DEFAULT_STATUS_STYLE } from '../constants/mergerStatus';
 
-function StatusBadge({ status, determination }) {
+function StatusBadge({ status, determination, label }) {
   const getStatusStyle = () => {
     // Determinations take precedence over statuses; 'Declined' and 'Not approved'
     // share the same red palette (both map to the same STATUS_COLORS entry).
@@ -24,7 +24,7 @@ function StatusBadge({ status, determination }) {
     return DEFAULT_STATUS_STYLE;
   };
 
-  const displayText = determination || status;
+  const displayText = label || determination || status;
 
   const ariaLabel = determination
     ? `Determination: ${determination}`

--- a/merger-tracker/frontend/src/components/StatusBadge.jsx
+++ b/merger-tracker/frontend/src/components/StatusBadge.jsx
@@ -8,7 +8,8 @@ function StatusBadge({ status, determination }) {
       determination === MERGER_STATUS.APPROVED ||
       determination === MERGER_STATUS.DECLINED ||
       determination === MERGER_STATUS.NOT_APPROVED ||
-      determination === MERGER_STATUS.REFERRED_TO_PHASE_2
+      determination === MERGER_STATUS.REFERRED_TO_PHASE_2 ||
+      determination === MERGER_STATUS.ASSESSMENT_CEASED
     ) {
       return STATUS_COLORS[determination];
     }

--- a/scripts/static_data/enrichment.py
+++ b/scripts/static_data/enrichment.py
@@ -111,6 +111,14 @@ def enrich_merger(
     m['public_benefits_determination'] = pb_det
     m['public_benefits_determination_date'] = pb_det_date
 
+    # For ceased mergers, find the cessation event and treat it as a determination event.
+    if m.get('status') == merger_status.ASSESSMENT_CEASED:
+        for event in m.get('events', []):
+            if 'ceased' in event.get('title', '').lower():
+                m['ceased_date'] = event.get('date')
+                event['is_determination_event'] = True
+                break
+
     # Compute competition concerns notice date for Phase 2 mergers
     # The notice is due by BD 25 of Phase 2 (Phase 2 BD 1 = end_of_determination_period - 90 BDs)
     stage = m.get('stage', '')

--- a/scripts/static_data/outputs/stats.py
+++ b/scripts/static_data/outputs/stats.py
@@ -153,6 +153,20 @@ def generate(mergers: list) -> dict:
                 })
                 break
 
+        # Check for ceased assessments
+        ceased_date = m.get('ceased_date')
+        if m.get('status') == merger_status.ASSESSMENT_CEASED and ceased_date:
+            determination_events.append({
+                "merger_id": merger_id,
+                "merger_name": merger_name,
+                "determination": merger_status.ASSESSMENT_CEASED,
+                "determination_date": ceased_date,
+                "page_modified_datetime": page_modified,
+                "determination_type": "ceased",
+                "is_waiver": is_waiver,
+                "stage": m.get('stage'),
+            })
+
     # Sort by determination date descending, then by page modification time descending
     # This ensures determinations on the same day are sorted by the time they were added to the register
     determination_events.sort(

--- a/scripts/tests/test_static_data_outputs.py
+++ b/scripts/tests/test_static_data_outputs.py
@@ -151,6 +151,39 @@ class TestStatsGenerate:
         mining = next(i for i in payload['top_industries'] if i['name'] == 'Mining')
         assert mining['count'] == 2
 
+    def test_recent_determinations_includes_ceased_assessments(self):
+        mergers = _raw_fixture()
+        mergers.append({
+            'merger_id': 'MN-0006',
+            'merger_name': 'Lambda ceased',
+            'status': merger_status.ASSESSMENT_CEASED,
+            'accc_determination': None,
+            'stage': 'Phase 1 - preliminary assessment',
+            'effective_notification_datetime': '2026-01-10T09:00:00Z',
+            'determination_publication_date': None,
+            'end_of_determination_period': '2026-03-01T12:00:00Z',
+            'page_modified_datetime': '2026-02-15T12:30:00Z',
+            'anzsic_codes': [],
+            'acquirers': ['Lambda'],
+            'targets': ['Mu'],
+            'other_parties': [],
+            'url': 'https://example.com/MN-0006',
+            'events': [
+                {'title': 'Merger notified to ACCC', 'date': '2026-01-10T09:00:00Z'},
+                {'title': 'Consideration of Notification ceased', 'date': '2026-02-15T12:00:00Z'},
+            ],
+        })
+        enriched = [enrich_merger(m) for m in mergers]
+        payload = stats.generate(enriched)
+        ceased = [
+            d for d in payload['recent_determinations']
+            if d.get('determination_type') == 'ceased'
+        ]
+        assert any(d['merger_id'] == 'MN-0006' for d in ceased)
+        entry = next(d for d in ceased if d['merger_id'] == 'MN-0006')
+        assert entry['determination'] == merger_status.ASSESSMENT_CEASED
+        assert entry['determination_date'] == '2026-02-15T12:00:00Z'
+
     def test_recent_determinations_includes_phase_2_referrals(self):
         mergers = _raw_fixture()
         mergers.append({


### PR DESCRIPTION
## Summary

- Ceased mergers (e.g. MN-30002) now appear in the **recent determinations** list on the dashboard, with determination type `"ceased"` and the cessation event date
- The **merger detail timeline** now shows ceased mergers as complete at the cessation date, with a "Ceased" label and purple marker — rather than showing as still-running toward the original deadline
- The cessation event is flagged with `is_determination_event: true` so it's treated consistently as a determination throughout the pipeline

## Changes

**`scripts/static_data/enrichment.py`** — During enrichment, detect `Assessment ceased` status, find the cessation event (title contains "ceased"), store its date as `ceased_date`, and flag the event as `is_determination_event`.

**`scripts/static_data/outputs/stats.py`** — Add ceased mergers to the recent determinations collector using their `ceased_date`.

**`merger-tracker/frontend/src/components/MergerTimeline.jsx`** — Use `ceased_date` as the effective determination date for ceased mergers; show "Ceased" label and purple dot on the timeline; treat the merger as complete rather than ongoing.

**`scripts/tests/test_static_data_outputs.py`** — New test asserting ceased mergers appear correctly in `recent_determinations`.

## Test plan

- [x] MN-30002 appears in the recent determinations list on the dashboard
- [x] MN-30002 detail page timeline shows: Notified (Mar 5) → [Phase 2 referral dot: Jun 2] → Ceased marker (Jun 15) → Deadline (Oct 8), with fill bar up to the ceased marker
- [x] No "Today" marker shown for MN-30002 (it's complete)
- [x] All 27 pipeline tests pass

https://claude.ai/code/session_01UVArE5kJZhAT6f6cyvy5CZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVArE5kJZhAT6f6cyvy5CZ)_