### PR TITLE
Support suspended-then-refiled related mergers

### DIFF
--- a/.github/workflows/detect-related-mergers.yml
+++ b/.github/workflows/detect-related-mergers.yml
@@ -65,13 +65,14 @@ jobs:
             --limit 500 \
             --json number,state,title > existing_issues.json
 
-          # Extract "WA-XXXX/MN-XXXX" from each title.  Titles created by this
-          # workflow always contain that substring; anything else is skipped.
+          # Extract the "<ID>/<ID>" pair marker from each title.  Titles created
+          # by this workflow always contain that substring (e.g. WA-1234/MN-5678
+          # or MN-1234/MN-5678); anything else is skipped.
           jq -r '
             .[]
-            | select(.title | test("WA-[0-9]+/MN-[0-9]+"))
+            | select(.title | test("[A-Z]{2}-[0-9]+/[A-Z]{2}-[0-9]+"))
             | [
-                (.title | capture("(?<w>WA-[0-9]+)/(?<m>MN-[0-9]+)") | .w + "/" + .m),
+                (.title | capture("(?<a>[A-Z]{2}-[0-9]+)/(?<b>[A-Z]{2}-[0-9]+)") | .a + "/" + .b),
                 (.number | tostring),
                 .state
               ]

--- a/data/processed/related_mergers.json
+++ b/data/processed/related_mergers.json
@@ -1,12 +1,12 @@
 {
-  "_README": "Mergers that were effectively re-filed as a separate matter. Two pair shapes are accepted. Legacy: { \"waiver\": \"WA-...\", \"notification\": \"MN-...\" } for a waiver that was declined then re-filed as a notification (treated as type waiver_refiled). General: { \"from\": \"...\", \"to\": \"...\", \"type\": \"...\" } where type is \"waiver_refiled\" or \"suspended_refiled\" (a matter whose assessment was suspended and was re-filed later). Both directions are resolved automatically.",
+  "_README": "Mergers that were effectively re-filed as a separate matter. Each entry is { \"from\": \"...\", \"to\": \"...\", \"type\": \"...\" } where `from` is the earlier matter, `to` is what it was re-filed as, and `type` is one of: \"waiver_refiled\" (a WA waiver declined then re-filed as an MN notification) or \"suspended_refiled\" (a matter whose assessment was suspended and re-filed later). Both directions are resolved automatically.",
   "pairs": [
-    { "waiver": "WA-35003", "notification": "MN-85007" },
-    { "waiver": "WA-01087", "notification": "MN-20013" },
-    { "waiver": "WA-65003", "notification": "MN-40005" },
-    { "waiver": "WA-70003", "notification": "MN-40008" },
-    { "waiver": "WA-65011", "notification": "MN-05017" },
-    { "waiver": "WA-20010", "notification": "MN-90012" },
-    { "waiver": "WA-10008", "notification": "MN-40020" }
+    { "from": "WA-35003", "to": "MN-85007", "type": "waiver_refiled" },
+    { "from": "WA-01087", "to": "MN-20013", "type": "waiver_refiled" },
+    { "from": "WA-65003", "to": "MN-40005", "type": "waiver_refiled" },
+    { "from": "WA-70003", "to": "MN-40008", "type": "waiver_refiled" },
+    { "from": "WA-65011", "to": "MN-05017", "type": "waiver_refiled" },
+    { "from": "WA-20010", "to": "MN-90012", "type": "waiver_refiled" },
+    { "from": "WA-10008", "to": "MN-40020", "type": "waiver_refiled" }
   ]
 }

--- a/data/processed/related_mergers.json
+++ b/data/processed/related_mergers.json
@@ -1,5 +1,5 @@
 {
-  "_README": "Mergers that were initially filed as waiver applications, declined, then re-filed as formal notifications. Each entry maps the waiver ID to the notification ID. Both directions are resolved automatically.",
+  "_README": "Mergers that were effectively re-filed as a separate matter. Two pair shapes are accepted. Legacy: { \"waiver\": \"WA-...\", \"notification\": \"MN-...\" } for a waiver that was declined then re-filed as a notification (treated as type waiver_refiled). General: { \"from\": \"...\", \"to\": \"...\", \"type\": \"...\" } where type is \"waiver_refiled\" or \"suspended_refiled\" (a matter whose assessment was suspended and was re-filed later). Both directions are resolved automatically.",
   "pairs": [
     { "waiver": "WA-35003", "notification": "MN-85007" },
     { "waiver": "WA-01087", "notification": "MN-20013" },

--- a/merger-tracker/frontend/src/pages/MergerDetail.jsx
+++ b/merger-tracker/frontend/src/pages/MergerDetail.jsx
@@ -19,6 +19,16 @@ import { API_ENDPOINTS } from '../config';
 import { PROSE_MARKDOWN } from '../utils/classNames';
 import { slugify, mergerPath } from '../utils/slug';
 
+// Display text for each related-merger relationship. Keys match the
+// `relationship` values produced by the data pipeline (see
+// scripts/static_data/loaders.py).
+const RELATED_MERGER_LABELS = {
+  refiled_as: 'Waiver declined – subsequently notified',
+  refiled_from: 'Originally filed as a waiver application',
+  suspended_refiled_as: 'Assessment suspended – subsequently refiled',
+  suspended_refiled_from: 'Refiled after an earlier assessment was suspended',
+};
+
 function MergerDetail() {
   const { id, slug } = useParams();
   const navigate = useNavigate();
@@ -287,10 +297,8 @@ function MergerDetail() {
             </div>
             <div className="flex-1 min-w-0">
               <p className="text-sm font-medium text-gray-900">
-                {merger.related_merger.relationship === 'refiled_as'
-                  ? 'Waiver declined \u2013 subsequently notified'
-                  : 'Originally filed as a waiver application'
-                }
+                {RELATED_MERGER_LABELS[merger.related_merger.relationship]
+                  ?? RELATED_MERGER_LABELS.refiled_from}
               </p>
             </div>
           </Link>

--- a/scripts/detect_related_mergers.py
+++ b/scripts/detect_related_mergers.py
@@ -204,8 +204,8 @@ def score_pair(waiver: dict, notification: dict) -> tuple[float, dict]:
 def load_related_pairs(path: Path) -> set[tuple[str, str]]:
     """Return the set of (source, target) pairs already recorded.
 
-    Accepts both the legacy ``{"waiver", "notification"}`` shape and the
-    generalised ``{"from", "to", "type"}`` shape (see ``related_mergers.json``).
+    Each pair has the ``{"from", "to", "type"}`` shape (see
+    ``related_mergers.json``).
     """
     if not path.exists():
         return set()
@@ -213,8 +213,8 @@ def load_related_pairs(path: Path) -> set[tuple[str, str]]:
         data = json.load(fh)
     pairs: set[tuple[str, str]] = set()
     for p in data.get("pairs", []):
-        source = p.get("from") or p.get("waiver")
-        target = p.get("to") or p.get("notification")
+        source = p.get("from")
+        target = p.get("to")
         if source and target:
             pairs.add((source, target))
     return pairs
@@ -361,16 +361,7 @@ def edit_related_mergers_url(branch: str = "main") -> str:
 
 
 def json_line_for(candidate: dict) -> str:
-    """Render the exact line to paste into the `pairs` array of related_mergers.json.
-
-    Waiver pairs keep the original ``{waiver, notification}`` shape; everything
-    else uses the generalised ``{from, to, type}`` shape.
-    """
-    if candidate["type"] == WAIVER_REFILED:
-        return (
-            f'    {{ "waiver": "{candidate["source"]}", '
-            f'"notification": "{candidate["target"]}" }},'
-        )
+    """Render the exact line to paste into the `pairs` array of related_mergers.json."""
     return (
         f'    {{ "from": "{candidate["source"]}", '
         f'"to": "{candidate["target"]}", "type": "{candidate["type"]}" }},'

--- a/scripts/detect_related_mergers.py
+++ b/scripts/detect_related_mergers.py
@@ -1,26 +1,32 @@
 #!/usr/bin/env python3
 """
-Detect likely "related mergers" — waiver applications that were declined and
-then re-filed as formal notifications.
+Detect likely "related mergers" — an earlier application that was later
+re-filed as a separate matter.
 
 Background
 ----------
-`data/processed/related_mergers.json` manually maps each `WA-*` waiver ID to
-the `MN-*` notification ID that followed it after the waiver was declined.
+`data/processed/related_mergers.json` records pairs of merger IDs where one
+matter was effectively re-filed as another. Two patterns are covered:
+
+  * ``waiver_refiled`` — a `WA-*` waiver application was declined, then
+    re-filed as an `MN-*` notification; and
+  * ``suspended_refiled`` — a matter whose assessment was suspended is
+    re-filed later (often, but not necessarily, under a fresh `MN-*` ID).
+
 This script looks through the processed merger data for likely new pairs and
 reports any that aren't already recorded.
 
 Matching heuristic
 ------------------
-A candidate pair is (waiver, notification) where:
+Each pass pairs a "source" merger with a later "target" merger that share at
+least one acquirer or target identifier (ABN/etc.), or have very similar
+acquirer- and target-name strings, and where the target was filed after the
+source (soft check — missing dates don't disqualify a pair).
 
-  * the waiver has `merger_id` starting with `WA-` and
-    `accc_determination == "Not approved"`, and
-  * the notification has `merger_id` starting with `MN-`, and
-  * the two share at least one acquirer or target identifier (ABN/etc.), or
-    have very similar acquirer- and target-name strings, and
-  * the notification was filed after the waiver (soft check — missing dates
-    don't disqualify a pair).
+  * Waiver pass — source is a `WA-*` with `accc_determination == "Not
+    approved"`; target is any `MN-*`.
+  * Suspended pass — source is any merger with
+    `status == "Assessment suspended"`; target is any other merger.
 
 Each candidate gets a confidence score; only pairs above `--threshold`
 (default 0.70) are reported. Existing pairs listed in `related_mergers.json`
@@ -43,6 +49,8 @@ from datetime import datetime
 from difflib import SequenceMatcher
 from pathlib import Path
 
+from constants import merger_status
+
 SCRIPT_DIR = Path(__file__).parent
 REPO_ROOT = SCRIPT_DIR.parent
 DEFAULT_MERGERS = REPO_ROOT / "data" / "processed" / "mergers.json"
@@ -50,6 +58,10 @@ DEFAULT_RELATED = REPO_ROOT / "data" / "processed" / "related_mergers.json"
 
 DEFAULT_THRESHOLD = 0.70
 NAME_SIMILARITY_THRESHOLD = 0.75
+
+# Pair types recorded in related_mergers.json (see its `_README`).
+WAIVER_REFILED = "waiver_refiled"
+SUSPENDED_REFILED = "suspended_refiled"
 
 _REPO = "nwbort/accc-mergers"
 _MERGERS_FYI_BASE = "https://mergers.fyi/mergers"
@@ -190,39 +202,65 @@ def score_pair(waiver: dict, notification: dict) -> tuple[float, dict]:
 # ---------------------------------------------------------------------------
 
 def load_related_pairs(path: Path) -> set[tuple[str, str]]:
-    """Return the set of (waiver, notification) pairs already recorded."""
+    """Return the set of (source, target) pairs already recorded.
+
+    Accepts both the legacy ``{"waiver", "notification"}`` shape and the
+    generalised ``{"from", "to", "type"}`` shape (see ``related_mergers.json``).
+    """
     if not path.exists():
         return set()
     with path.open() as fh:
         data = json.load(fh)
+    pairs: set[tuple[str, str]] = set()
+    for p in data.get("pairs", []):
+        source = p.get("from") or p.get("waiver")
+        target = p.get("to") or p.get("notification")
+        if source and target:
+            pairs.add((source, target))
+    return pairs
+
+
+def _build_candidate(
+    source: dict, target: dict, pair_type: str, score: float, diag: dict
+) -> dict:
+    """Assemble a candidate dict shared by both detection passes."""
     return {
-        (p["waiver"], p["notification"])
-        for p in data.get("pairs", [])
-        if p.get("waiver") and p.get("notification")
+        "type": pair_type,
+        "source": source.get("merger_id"),
+        "target": target.get("merger_id"),
+        "source_name": source.get("merger_name", ""),
+        "target_name": target.get("merger_name", ""),
+        "source_filed": source.get("effective_notification_datetime"),
+        "target_filed": target.get("effective_notification_datetime"),
+        "source_determination": source.get("accc_determination"),
+        "source_status": source.get("status"),
+        "target_status": target.get("status"),
+        "score": round(score, 3),
+        "signals": diag,
     }
 
 
-def find_candidates(
+def find_waiver_candidates(
     mergers: list[dict],
     known_pairs: set[tuple[str, str]],
     threshold: float,
 ) -> list[dict]:
-    """Return a list of candidate pair dicts, sorted by score (descending)."""
-    known_waivers = {w for w, _ in known_pairs}
-    known_notifs = {n for _, n in known_pairs}
+    """Declined waiver (WA, "Not approved") → later notification (MN)."""
+    known_sources = {s for s, _ in known_pairs}
+    known_targets = {t for _, t in known_pairs}
 
     waivers = [
         m
         for m in mergers
         if m.get("merger_id", "").startswith("WA")
         and m.get("accc_determination") == "Not approved"
-        and m.get("merger_id") not in known_waivers
+        and m.get("merger_id") not in known_sources
     ]
     notifications = [
         m
         for m in mergers
         if m.get("merger_id", "").startswith("MN")
-        and m.get("merger_id") not in known_notifs
+        and m.get("merger_id") not in known_targets
     ]
 
     candidates: list[dict] = []
@@ -235,30 +273,77 @@ def find_candidates(
                 continue
             score, diag = score_pair(wa, mn)
             if score >= threshold:
-                candidates.append({
-                    "waiver": wa.get("merger_id"),
-                    "notification": mn.get("merger_id"),
-                    "waiver_name": wa.get("merger_name", ""),
-                    "notification_name": mn.get("merger_name", ""),
-                    "waiver_filed": wa.get("effective_notification_datetime"),
-                    "notification_filed": mn.get("effective_notification_datetime"),
-                    "waiver_determination": wa.get("accc_determination"),
-                    "notification_status": mn.get("status"),
-                    "score": round(score, 3),
-                    "signals": diag,
-                })
+                candidates.append(
+                    _build_candidate(wa, mn, WAIVER_REFILED, score, diag)
+                )
+    return candidates
 
-    # If a waiver matches multiple notifications, keep only the best per side.
+
+def find_suspended_candidates(
+    mergers: list[dict],
+    known_pairs: set[tuple[str, str]],
+    threshold: float,
+) -> list[dict]:
+    """Suspended merger (any ID) → a later, separately-filed merger.
+
+    Mirrors the waiver pass but keys off ``status == "Assessment suspended"``
+    rather than the WA/"Not approved" combination, and is deliberately
+    prefix-agnostic on both sides — a suspended matter may be refiled under a
+    fresh ``MN`` (or any other) identifier.
+    """
+    known_sources = {s for s, _ in known_pairs}
+    known_targets = {t for _, t in known_pairs}
+
+    suspended = [
+        m
+        for m in mergers
+        if m.get("status") == merger_status.ASSESSMENT_SUSPENDED
+        and m.get("merger_id")
+        and m.get("merger_id") not in known_sources
+    ]
+    others = [m for m in mergers if m.get("merger_id")]
+
+    candidates: list[dict] = []
+    for src in suspended:
+        src_id = src.get("merger_id")
+        src_date = parse_date(src.get("effective_notification_datetime"))
+        for tgt in others:
+            tgt_id = tgt.get("merger_id")
+            # Never link a merger to itself, and skip already-recorded refiles.
+            if tgt_id == src_id or tgt_id in known_targets:
+                continue
+            tgt_date = parse_date(tgt.get("effective_notification_datetime"))
+            # Soft ordering check: a refile should be filed after the suspension.
+            if src_date and tgt_date and tgt_date < src_date:
+                continue
+            score, diag = score_pair(src, tgt)
+            if score >= threshold:
+                candidates.append(
+                    _build_candidate(src, tgt, SUSPENDED_REFILED, score, diag)
+                )
+    return candidates
+
+
+def find_candidates(
+    mergers: list[dict],
+    known_pairs: set[tuple[str, str]],
+    threshold: float,
+) -> list[dict]:
+    """Return candidate pair dicts from every detection pass, best-scored first."""
+    candidates = find_waiver_candidates(mergers, known_pairs, threshold)
+    candidates += find_suspended_candidates(mergers, known_pairs, threshold)
+
+    # If one merger matches several partners, keep only the best per side.
     # Secondary keys keep the output stable across runs.
-    candidates.sort(key=lambda c: (-c["score"], c["waiver"], c["notification"]))
-    seen_waivers: set[str] = set()
-    seen_notifs: set[str] = set()
+    candidates.sort(key=lambda c: (-c["score"], c["source"], c["target"]))
+    seen_sources: set[str] = set()
+    seen_targets: set[str] = set()
     deduped: list[dict] = []
     for c in candidates:
-        if c["waiver"] in seen_waivers or c["notification"] in seen_notifs:
+        if c["source"] in seen_sources or c["target"] in seen_targets:
             continue
-        seen_waivers.add(c["waiver"])
-        seen_notifs.add(c["notification"])
+        seen_sources.add(c["source"])
+        seen_targets.add(c["target"])
         deduped.append(c)
     return deduped
 
@@ -276,10 +361,19 @@ def edit_related_mergers_url(branch: str = "main") -> str:
 
 
 def json_line_for(candidate: dict) -> str:
-    """Render the exact line to paste into the `pairs` array of related_mergers.json."""
+    """Render the exact line to paste into the `pairs` array of related_mergers.json.
+
+    Waiver pairs keep the original ``{waiver, notification}`` shape; everything
+    else uses the generalised ``{from, to, type}`` shape.
+    """
+    if candidate["type"] == WAIVER_REFILED:
+        return (
+            f'    {{ "waiver": "{candidate["source"]}", '
+            f'"notification": "{candidate["target"]}" }},'
+        )
     return (
-        f'    {{ "waiver": "{candidate["waiver"]}", '
-        f'"notification": "{candidate["notification"]}" }},'
+        f'    {{ "from": "{candidate["source"]}", '
+        f'"to": "{candidate["target"]}", "type": "{candidate["type"]}" }},'
     )
 
 
@@ -297,16 +391,16 @@ def _format_signals(signals: dict) -> str:
 
 def pair_id(candidate: dict) -> str:
     """Canonical, parseable identifier used in titles and for de-duplication."""
-    return f"{candidate['waiver']}/{candidate['notification']}"
+    return f"{candidate['source']}/{candidate['target']}"
 
 
 def build_issue_title(candidate: dict) -> str:
-    wa = candidate["waiver"]
-    mn = candidate["notification"]
-    # The `WA-XXXX/MN-XXXX` substring is the marker the workflow greps for
-    # to decide whether an issue already exists for this pair.
-    name = candidate.get("waiver_name") or candidate.get("notification_name") or ""
-    base = f"Related mergers: {wa}/{mn}"
+    src = candidate["source"]
+    tgt = candidate["target"]
+    # The `<ID>/<ID>` substring is the marker the workflow greps for to decide
+    # whether an issue already exists for this pair.
+    name = candidate.get("source_name") or candidate.get("target_name") or ""
+    base = f"Related mergers: {src}/{tgt}"
     if name:
         base = f"{base} — {name}"
     # GitHub issue title limit is 256 chars
@@ -315,30 +409,54 @@ def build_issue_title(candidate: dict) -> str:
     return base
 
 
+def _relationship_blurb(candidate: dict) -> str:
+    """One-line description of the relationship pattern for the issue body."""
+    if candidate["type"] == SUSPENDED_REFILED:
+        return (
+            "A \"related merger\" here is a matter whose assessment was "
+            "**suspended** and which appears to have been **re-filed** as a "
+            "separate matter (see the `_README` field in the JSON)."
+        )
+    return (
+        "A \"related merger\" is one that was initially filed as a **waiver** "
+        "application, declined, then re-filed as a formal **notification** "
+        "(see the `_README` field in the JSON)."
+    )
+
+
 def build_issue_body(candidate: dict, branch: str = "main") -> str:
-    wa = candidate["waiver"]
-    mn = candidate["notification"]
+    src = candidate["source"]
+    tgt = candidate["target"]
     edit_url = edit_related_mergers_url(branch)
     related_blob = f"https://github.com/{_REPO}/blob/{branch}/{_RELATED_PATH}"
 
+    if candidate["type"] == SUSPENDED_REFILED:
+        source_label = "Suspended matter"
+        source_detail = f"status: {candidate['source_status'] or 'unknown'}"
+        target_label = "Re-filed as"
+        target_detail = f"status: {candidate['target_status'] or 'unknown'}"
+    else:
+        source_label = "Waiver"
+        source_detail = (
+            f"determination: {candidate['source_determination'] or 'unknown'}"
+        )
+        target_label = "Notification"
+        target_detail = f"status: {candidate['target_status'] or 'unknown'}"
+
     lines = [
         f"<!-- pair-id: {pair_id(candidate)} -->",
-        f"The daily detector thinks **`{wa}`** and **`{mn}`** look like a "
+        f"The daily detector thinks **`{src}`** and **`{tgt}`** look like a "
         f"related-merger pair that isn't yet in "
         f"[`{_RELATED_PATH}`]({related_blob}).",
         "",
-        "A \"related merger\" is one that was initially filed as a **waiver** "
-        "application, declined, then re-filed as a formal **notification** "
-        "(see the `_README` field in the JSON).",
+        _relationship_blurb(candidate),
         "",
         "## The two mergers",
         "",
-        f"- **Waiver:** [{wa} — {candidate['waiver_name']}]({mergers_fyi_url(wa)}) "
-        f"· filed {candidate['waiver_filed'] or 'unknown'} · determination: "
-        f"{candidate['waiver_determination'] or 'unknown'}",
-        f"- **Notification:** [{mn} — {candidate['notification_name']}]({mergers_fyi_url(mn)}) "
-        f"· filed {candidate['notification_filed'] or 'unknown'} · status: "
-        f"{candidate['notification_status'] or 'unknown'}",
+        f"- **{source_label}:** [{src} — {candidate['source_name']}]({mergers_fyi_url(src)}) "
+        f"· filed {candidate['source_filed'] or 'unknown'} · {source_detail}",
+        f"- **{target_label}:** [{tgt} — {candidate['target_name']}]({mergers_fyi_url(tgt)}) "
+        f"· filed {candidate['target_filed'] or 'unknown'} · {target_detail}",
         "",
         f"**Match confidence:** {candidate['score']:.2f}  ",
         f"**Signals:** {_format_signals(candidate['signals'])}",
@@ -414,10 +532,10 @@ def main() -> int:
             print(f"Found {len(candidates)} candidate pair(s) above threshold {args.threshold}:")
             print()
             for c in candidates:
-                print(f"  {c['waiver']} ↔ {c['notification']}  (score {c['score']:.2f})")
-                print(f"    waiver       : {c['waiver_name']}")
-                print(f"    notification : {c['notification_name']}")
-                print(f"    signals      : {_format_signals(c['signals'])}")
+                print(f"  {c['source']} ↔ {c['target']}  (score {c['score']:.2f}, {c['type']})")
+                print(f"    source : {c['source_name']}")
+                print(f"    target : {c['target_name']}")
+                print(f"    signals: {_format_signals(c['signals'])}")
                 print()
 
     if args.issue_json:

--- a/scripts/generate_similar_mergers.py
+++ b/scripts/generate_similar_mergers.py
@@ -190,8 +190,8 @@ def _load_existing(path: Path) -> dict:
         return {}
 
 
-def _load_wn_partner_map(path: Path) -> dict[str, str]:
-    """Return {merger_id: direct_partner_id} for all waiver/notification pairs.
+def _load_related_partner_map(path: Path) -> dict[str, str]:
+    """Return {merger_id: direct_partner_id} for all related-merger pairs.
 
     Both directions are mapped so each merger knows its own direct partner.
     """
@@ -202,11 +202,11 @@ def _load_wn_partner_map(path: Path) -> dict[str, str]:
             data = json.load(f)
         result: dict[str, str] = {}
         for pair in data.get("pairs", []):
-            wa = pair.get("waiver", "")
-            mn = pair.get("notification", "")
-            if wa and mn:
-                result[wa] = mn
-                result[mn] = wa
+            source = pair.get("from", "")
+            target = pair.get("to", "")
+            if source and target:
+                result[source] = target
+                result[target] = source
         return result
     except (json.JSONDecodeError, IOError):
         return {}
@@ -235,7 +235,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--mergers", type=Path, default=DEFAULT_MERGERS)
     parser.add_argument("--related", type=Path, default=DEFAULT_RELATED,
-                        help="related_mergers.json path (waiver/notification pairs to exclude)")
+                        help="related_mergers.json path (related-merger pairs to exclude)")
     parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
     parser.add_argument("--all", action="store_true",
                         help="Recompute similar mergers for all mergers (full refresh)")
@@ -254,9 +254,9 @@ def main() -> int:
     all_mergers = _load_mergers(args.mergers)
     merger_index = {m.get("merger_id"): m for m in all_mergers if m.get("merger_id")}
 
-    # Waiver/notification pairs are already surfaced via related_merger; exclude each
+    # Related-merger pairs are already surfaced via related_merger; exclude each
     # merger's direct partner so we don't double-surface that link.
-    wn_partners = _load_wn_partner_map(args.related)
+    related_partners = _load_related_partner_map(args.related)
 
     existing = _load_existing(args.output)
 
@@ -282,11 +282,11 @@ def main() -> int:
         tid = target.get("merger_id", "")
         if not tid:
             continue
-        # Exclude the merger's direct waiver/notification partner — that relationship
+        # Exclude the merger's direct related-merger partner — that relationship
         # is already surfaced via the related_merger link above the page fold.
         exclude: set[str] = set()
-        if tid in wn_partners:
-            exclude.add(wn_partners[tid])
+        if tid in related_partners:
+            exclude.add(related_partners[tid])
 
         results = find_similar(
             target, all_mergers,

--- a/scripts/static_data/loaders.py
+++ b/scripts/static_data/loaders.py
@@ -28,11 +28,44 @@ def load_mergers() -> list:
     raise ValueError("Unexpected mergers.json format")
 
 
+# Relationship labels emitted for each pair type, as (source_label,
+# target_label). The source is the earlier matter (waiver / suspended); the
+# target is what it was re-filed as. The frontend maps these to display text.
+_RELATIONSHIP_LABELS = {
+    'waiver_refiled': ('refiled_as', 'refiled_from'),
+    'suspended_refiled': ('suspended_refiled_as', 'suspended_refiled_from'),
+}
+
+
+def build_relationship_map(data: dict) -> dict:
+    """Turn related-merger ``pairs`` into a per-merger relationship lookup.
+
+    Accepts both the legacy ``{"waiver", "notification"}`` shape (treated as
+    ``type: "waiver_refiled"``) and the generalised
+    ``{"from", "to", "type"}`` shape. Returns a dict keyed by merger_id mapping
+    to ``{'merger_id': ..., 'relationship': ...}``.
+    """
+    result = {}
+    for pair in data.get('pairs', []):
+        source = pair.get('from') or pair.get('waiver')
+        target = pair.get('to') or pair.get('notification')
+        if not source or not target:
+            continue
+        pair_type = pair.get('type', 'waiver_refiled')
+        source_rel, target_rel = _RELATIONSHIP_LABELS.get(
+            pair_type, _RELATIONSHIP_LABELS['waiver_refiled']
+        )
+        result[source] = {'merger_id': target, 'relationship': source_rel}
+        result[target] = {'merger_id': source, 'relationship': target_rel}
+    return result
+
+
 def load_related_mergers() -> dict:
     """Load related merger pairs from related_mergers.json.
 
     Returns a dict keyed by merger_id mapping to
-    ``{'merger_id': ..., 'relationship': 'refiled_as' | 'refiled_from'}``.
+    ``{'merger_id': ..., 'relationship': ...}``. See ``build_relationship_map``
+    for the supported pair shapes and relationship values.
     """
     if not RELATED_MERGERS_JSON.exists():
         return {}
@@ -40,14 +73,7 @@ def load_related_mergers() -> dict:
     try:
         with open(RELATED_MERGERS_JSON, 'r', encoding='utf-8') as f:
             data = json.load(f)
-
-        result = {}
-        for pair in data.get('pairs', []):
-            wa = pair['waiver']
-            mn = pair['notification']
-            result[wa] = {'merger_id': mn, 'relationship': 'refiled_as'}
-            result[mn] = {'merger_id': wa, 'relationship': 'refiled_from'}
-        return result
+        return build_relationship_map(data)
     except (json.JSONDecodeError, IOError, KeyError) as e:
         print(f"Warning: Could not load related_mergers.json: {e}")
         return {}

--- a/scripts/static_data/loaders.py
+++ b/scripts/static_data/loaders.py
@@ -40,15 +40,14 @@ _RELATIONSHIP_LABELS = {
 def build_relationship_map(data: dict) -> dict:
     """Turn related-merger ``pairs`` into a per-merger relationship lookup.
 
-    Accepts both the legacy ``{"waiver", "notification"}`` shape (treated as
-    ``type: "waiver_refiled"``) and the generalised
-    ``{"from", "to", "type"}`` shape. Returns a dict keyed by merger_id mapping
-    to ``{'merger_id': ..., 'relationship': ...}``.
+    Each pair has the shape ``{"from", "to", "type"}`` where ``from`` is the
+    earlier matter and ``to`` is what it was re-filed as. Returns a dict keyed
+    by merger_id mapping to ``{'merger_id': ..., 'relationship': ...}``.
     """
     result = {}
     for pair in data.get('pairs', []):
-        source = pair.get('from') or pair.get('waiver')
-        target = pair.get('to') or pair.get('notification')
+        source = pair.get('from')
+        target = pair.get('to')
         if not source or not target:
             continue
         pair_type = pair.get('type', 'waiver_refiled')

--- a/scripts/tests/test_related_mergers.py
+++ b/scripts/tests/test_related_mergers.py
@@ -1,0 +1,199 @@
+"""Tests for related-merger detection and linking.
+
+Covers two layers:
+  * ``static_data.loaders.build_relationship_map`` — turns recorded pairs into
+    the per-merger relationship lookup the frontend consumes, for both the
+    legacy ``{waiver, notification}`` shape and the generalised
+    ``{from, to, type}`` shape.
+  * ``detect_related_mergers`` — the daily candidate detector, including the
+    new "suspended assessment, re-filed later" pass.
+"""
+
+import json
+import os
+import sys
+import unittest.mock
+
+# Add scripts directory to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+# Mock heavy transitive imports before importing modules that need them
+sys.modules.setdefault('pdfplumber', unittest.mock.MagicMock())
+sys.modules.setdefault('markdownify', unittest.mock.MagicMock())
+sys.modules.setdefault('requests', unittest.mock.MagicMock())
+
+import detect_related_mergers as drm
+from constants import merger_status
+from static_data.loaders import build_relationship_map
+
+
+# ---------------------------------------------------------------------------
+# build_relationship_map
+# ---------------------------------------------------------------------------
+
+def test_legacy_pair_shape_maps_to_waiver_relationships():
+    data = {"pairs": [{"waiver": "WA-100", "notification": "MN-200"}]}
+    result = build_relationship_map(data)
+    assert result["WA-100"] == {"merger_id": "MN-200", "relationship": "refiled_as"}
+    assert result["MN-200"] == {"merger_id": "WA-100", "relationship": "refiled_from"}
+
+
+def test_typed_waiver_pair_shape_matches_legacy():
+    data = {"pairs": [{"from": "WA-100", "to": "MN-200", "type": "waiver_refiled"}]}
+    result = build_relationship_map(data)
+    assert result["WA-100"]["relationship"] == "refiled_as"
+    assert result["MN-200"]["relationship"] == "refiled_from"
+
+
+def test_suspended_pair_shape_maps_to_suspended_relationships():
+    data = {"pairs": [{"from": "MN-300", "to": "MN-400", "type": "suspended_refiled"}]}
+    result = build_relationship_map(data)
+    assert result["MN-300"] == {
+        "merger_id": "MN-400",
+        "relationship": "suspended_refiled_as",
+    }
+    assert result["MN-400"] == {
+        "merger_id": "MN-300",
+        "relationship": "suspended_refiled_from",
+    }
+
+
+def test_incomplete_pairs_are_skipped():
+    data = {"pairs": [{"from": "MN-300"}, {"to": "MN-400"}, {}]}
+    assert build_relationship_map(data) == {}
+
+
+def test_unknown_type_falls_back_to_waiver_labels():
+    data = {"pairs": [{"from": "MN-1", "to": "MN-2", "type": "future_thing"}]}
+    result = build_relationship_map(data)
+    assert result["MN-1"]["relationship"] == "refiled_as"
+
+
+# ---------------------------------------------------------------------------
+# detector: load_related_pairs (both schema shapes)
+# ---------------------------------------------------------------------------
+
+def test_load_related_pairs_accepts_both_shapes(tmp_path):
+    path = tmp_path / "related_mergers.json"
+    path.write_text(json.dumps({"pairs": [
+        {"waiver": "WA-100", "notification": "MN-200"},
+        {"from": "MN-300", "to": "MN-400", "type": "suspended_refiled"},
+        {"from": "MN-9"},  # incomplete — ignored
+    ]}))
+    assert drm.load_related_pairs(path) == {("WA-100", "MN-200"), ("MN-300", "MN-400")}
+
+
+def test_load_related_pairs_missing_file_returns_empty(tmp_path):
+    assert drm.load_related_pairs(tmp_path / "nope.json") == set()
+
+
+# ---------------------------------------------------------------------------
+# detector: candidate detection
+# ---------------------------------------------------------------------------
+
+def _entity(name, identifier):
+    return {"name": name, "identifier": identifier}
+
+
+def _mergers():
+    """A declined waiver/notification pair and a suspended/refile pair."""
+    return [
+        {
+            "merger_id": "WA-100",
+            "merger_name": "Alpha / Beta waiver",
+            "accc_determination": "Not approved",
+            "status": merger_status.ASSESSMENT_COMPLETED,
+            "effective_notification_datetime": "2025-01-01T00:00:00Z",
+            "acquirers": [_entity("Alpha Pty Ltd", "ABN-1")],
+            "targets": [_entity("Beta Pty Ltd", "ABN-2")],
+        },
+        {
+            "merger_id": "MN-200",
+            "merger_name": "Alpha / Beta notification",
+            "accc_determination": None,
+            "status": merger_status.UNDER_ASSESSMENT,
+            "effective_notification_datetime": "2025-03-01T00:00:00Z",
+            "acquirers": [_entity("Alpha Pty Ltd", "ABN-1")],
+            "targets": [_entity("Beta Pty Ltd", "ABN-2")],
+        },
+        {
+            "merger_id": "MN-300",
+            "merger_name": "Gamma / Delta",
+            "accc_determination": None,
+            "status": merger_status.ASSESSMENT_SUSPENDED,
+            "effective_notification_datetime": "2025-02-01T00:00:00Z",
+            "acquirers": [_entity("Gamma Pty Ltd", "ABN-3")],
+            "targets": [_entity("Delta Pty Ltd", "ABN-4")],
+        },
+        {
+            "merger_id": "MN-400",
+            "merger_name": "Gamma / Delta refiled",
+            "accc_determination": None,
+            "status": merger_status.UNDER_ASSESSMENT,
+            "effective_notification_datetime": "2025-05-01T00:00:00Z",
+            "acquirers": [_entity("Gamma Pty Ltd", "ABN-3")],
+            "targets": [_entity("Delta Pty Ltd", "ABN-4")],
+        },
+    ]
+
+
+def test_detects_waiver_pair():
+    cands = drm.find_candidates(_mergers(), known_pairs=set(), threshold=0.70)
+    waiver = next(c for c in cands if c["type"] == drm.WAIVER_REFILED)
+    assert (waiver["source"], waiver["target"]) == ("WA-100", "MN-200")
+    assert waiver["score"] == 1.0
+
+
+def test_detects_suspended_pair():
+    cands = drm.find_candidates(_mergers(), known_pairs=set(), threshold=0.70)
+    suspended = next(c for c in cands if c["type"] == drm.SUSPENDED_REFILED)
+    assert (suspended["source"], suspended["target"]) == ("MN-300", "MN-400")
+    assert suspended["score"] == 1.0
+
+
+def test_suspended_pass_never_links_a_merger_to_itself():
+    cands = drm.find_suspended_candidates(_mergers(), known_pairs=set(), threshold=0.70)
+    assert all(c["source"] != c["target"] for c in cands)
+
+
+def test_known_pairs_are_excluded():
+    cands = drm.find_candidates(
+        _mergers(), known_pairs={("MN-300", "MN-400")}, threshold=0.70
+    )
+    assert all(c["type"] != drm.SUSPENDED_REFILED for c in cands)
+
+
+def test_soft_date_ordering_rejects_earlier_refile():
+    mergers = _mergers()
+    # Move the refile to *before* the suspension — should no longer be paired.
+    for m in mergers:
+        if m["merger_id"] == "MN-400":
+            m["effective_notification_datetime"] = "2024-01-01T00:00:00Z"
+    cands = drm.find_suspended_candidates(mergers, known_pairs=set(), threshold=0.70)
+    assert cands == []
+
+
+# ---------------------------------------------------------------------------
+# detector: issue rendering
+# ---------------------------------------------------------------------------
+
+def test_json_line_waiver_uses_legacy_shape():
+    c = {"type": drm.WAIVER_REFILED, "source": "WA-100", "target": "MN-200"}
+    line = drm.json_line_for(c)
+    assert '"waiver": "WA-100"' in line and '"notification": "MN-200"' in line
+
+
+def test_json_line_suspended_uses_typed_shape():
+    c = {"type": drm.SUSPENDED_REFILED, "source": "MN-300", "target": "MN-400"}
+    line = drm.json_line_for(c)
+    assert '"from": "MN-300"' in line
+    assert '"to": "MN-400"' in line
+    assert '"type": "suspended_refiled"' in line
+
+
+def test_issue_body_describes_suspension_for_suspended_pair():
+    cands = drm.find_candidates(_mergers(), known_pairs=set(), threshold=0.70)
+    suspended = next(c for c in cands if c["type"] == drm.SUSPENDED_REFILED)
+    body = drm.build_issue_body(suspended)
+    assert "suspended" in body.lower()
+    assert drm.pair_id(suspended) == "MN-300/MN-400"

--- a/scripts/tests/test_related_mergers.py
+++ b/scripts/tests/test_related_mergers.py
@@ -2,9 +2,8 @@
 
 Covers two layers:
   * ``static_data.loaders.build_relationship_map`` — turns recorded pairs into
-    the per-merger relationship lookup the frontend consumes, for both the
-    legacy ``{waiver, notification}`` shape and the generalised
-    ``{from, to, type}`` shape.
+    the per-merger relationship lookup the frontend consumes, from the
+    ``{from, to, type}`` pair shape.
   * ``detect_related_mergers`` — the daily candidate detector, including the
     new "suspended assessment, re-filed later" pass.
 """
@@ -31,18 +30,24 @@ from static_data.loaders import build_relationship_map
 # build_relationship_map
 # ---------------------------------------------------------------------------
 
-def test_legacy_pair_shape_maps_to_waiver_relationships():
-    data = {"pairs": [{"waiver": "WA-100", "notification": "MN-200"}]}
+def test_waiver_pair_maps_to_waiver_relationships():
+    data = {"pairs": [{"from": "WA-100", "to": "MN-200", "type": "waiver_refiled"}]}
     result = build_relationship_map(data)
     assert result["WA-100"] == {"merger_id": "MN-200", "relationship": "refiled_as"}
     assert result["MN-200"] == {"merger_id": "WA-100", "relationship": "refiled_from"}
 
 
-def test_typed_waiver_pair_shape_matches_legacy():
-    data = {"pairs": [{"from": "WA-100", "to": "MN-200", "type": "waiver_refiled"}]}
+def test_pair_without_type_defaults_to_waiver_relationships():
+    data = {"pairs": [{"from": "WA-100", "to": "MN-200"}]}
     result = build_relationship_map(data)
     assert result["WA-100"]["relationship"] == "refiled_as"
     assert result["MN-200"]["relationship"] == "refiled_from"
+
+
+def test_legacy_pair_shape_is_ignored():
+    # The old {waiver, notification} shape is no longer supported.
+    data = {"pairs": [{"waiver": "WA-100", "notification": "MN-200"}]}
+    assert build_relationship_map(data) == {}
 
 
 def test_suspended_pair_shape_maps_to_suspended_relationships():
@@ -73,12 +78,13 @@ def test_unknown_type_falls_back_to_waiver_labels():
 # detector: load_related_pairs (both schema shapes)
 # ---------------------------------------------------------------------------
 
-def test_load_related_pairs_accepts_both_shapes(tmp_path):
+def test_load_related_pairs_parses_typed_shape(tmp_path):
     path = tmp_path / "related_mergers.json"
     path.write_text(json.dumps({"pairs": [
-        {"waiver": "WA-100", "notification": "MN-200"},
+        {"from": "WA-100", "to": "MN-200", "type": "waiver_refiled"},
         {"from": "MN-300", "to": "MN-400", "type": "suspended_refiled"},
         {"from": "MN-9"},  # incomplete — ignored
+        {"waiver": "WA-1", "notification": "MN-2"},  # legacy shape — ignored
     ]}))
     assert drm.load_related_pairs(path) == {("WA-100", "MN-200"), ("MN-300", "MN-400")}
 
@@ -177,10 +183,12 @@ def test_soft_date_ordering_rejects_earlier_refile():
 # detector: issue rendering
 # ---------------------------------------------------------------------------
 
-def test_json_line_waiver_uses_legacy_shape():
+def test_json_line_waiver_uses_typed_shape():
     c = {"type": drm.WAIVER_REFILED, "source": "WA-100", "target": "MN-200"}
     line = drm.json_line_for(c)
-    assert '"waiver": "WA-100"' in line and '"notification": "MN-200"' in line
+    assert '"from": "WA-100"' in line
+    assert '"to": "MN-200"' in line
+    assert '"type": "waiver_refiled"' in line
 
 
 def test_json_line_suspended_uses_typed_shape():


### PR DESCRIPTION
## Why

The "related mergers" feature was hard-wired end-to-end to one story: a **declined waiver (`WA-*`, "Not approved") that was refiled as a notification (`MN-*`)**. Intel suggests a merger whose assessment is **suspended** will be refiled later — likely an `MN → MN` link. That scenario had no path through any layer:

- **Schema** only had `waiver` / `notification` slots.
- **Loader** hard-coded `refiled_as` / `refiled_from` by ID side.
- **Detector** filtered the source to `WA-*` + `accc_determination == "Not approved"`, so a suspended matter (status `Assessment suspended`) would **never** be surfaced as a candidate.
- **UI** had two hard-coded labels and would mislabel a suspended pair as "Originally filed as a waiver application".
- **Workflow** dedup regex was `WA-…/MN-…`, so `MN → MN` suggestions wouldn't dedup.

## What changed

- **Schema** (`related_mergers.json`): standardised on a single typed shape `{ "from", "to", "type" }` where `type` is `waiver_refiled` or `suspended_refiled`. The legacy `{ "waiver", "notification" }` shape has been **removed** and the 7 existing pairs migrated to `waiver_refiled`.
- **Loader** (`loaders.py`): `build_relationship_map` emits labels by type (`refiled_as`/`refiled_from`, `suspended_refiled_as`/`suspended_refiled_from`), extracted into a pure, testable helper.
- **Detector** (`detect_related_mergers.py`): added a prefix-agnostic suspended pass keyed off `status == "Assessment suspended"`, reusing the existing party-identifier / name-similarity scoring and the same GitHub-issue suggestion flow (suspension-specific issue text; issue suggestions now always emit the typed JSON line). Self-links are excluded and the soft date-ordering check (refile after suspension) is applied. Both passes are de-duped per side.
- **Similar mergers** (`generate_similar_mergers.py`): reads the typed `from`/`to` pairs when excluding a merger's direct partner.
- **Workflow** (`detect-related-mergers.yml`): generalised the dedup regex from `WA-…/MN-…` to any `<ID>/<ID>` pair.
- **Frontend** (`MergerDetail.jsx`): relationship text now comes from a lookup map, with labels for the suspended directions:
  - suspended side → *"Assessment suspended – subsequently refiled"*
  - refiled side → *"Refiled after an earlier assessment was suspended"*

## CLI bundle (`data/output/cli/cli-bundle.json`) impact

The bundle is built from the enriched per-merger frontend files, so each merger object carries `related_merger: { merger_id, relationship, merger_name }`. **The object shape is unchanged.** The only consumer-facing change is that `related_merger.relationship` is now a 4-value enum — the two existing values plus `suspended_refiled_as` / `suspended_refiled_from`. No bundle content changes until a `suspended_refiled` pair is actually recorded (the 7 waiver pairs still resolve to `refiled_as` / `refiled_from`). A short note for downstream CLI consumers is included in the PR thread.

## Tests

`scripts/tests/test_related_mergers.py` covers the loader (typed shape, type default, legacy shape now ignored, incomplete entries) and the detector (waiver pass, suspended pass, no self-links, known-pair exclusion, soft date ordering, typed JSON-line rendering).

- Full suite: **516 passed**.
- Detector against current real data: **no new candidates** (no false positives introduced).

## Notes for review

- The refile ID prefix isn't confirmed, so the suspended pass is deliberately **prefix-agnostic** on both sides.
- UI wording is easy to tweak in the `RELATED_MERGER_LABELS` map if you'd prefer different phrasing.

https://claude.ai/code/session_01TK2aFiSXfRqmrChpyKe63r