### PR TITLE
fix(tests): update industries index assertions to include new totals fields

### DIFF
--- a/scripts/tests/test_pipeline.py
+++ b/scripts/tests/test_pipeline.py
@@ -1401,12 +1401,16 @@ class TestGenerateIndustriesJson:
 
     def test_empty_mergers(self):
         result = generate_industries_json([])
-        assert result == {"industries": []}
+        assert result['industries'] == []
+        assert result['total_industries'] == 0
+        assert result['total_mergers'] == 0
 
     def test_no_anzsic_codes(self):
         mergers = [{'merger_id': 'MN-001'}]
         result = generate_industries_json(mergers)
-        assert result == {"industries": []}
+        assert result['industries'] == []
+        assert result['total_industries'] == 0
+        assert result['total_mergers'] == 0
 
     def test_multiple_codes_per_merger(self):
         mergers = [


### PR DESCRIPTION
generate_index now returns total_mergers and total_industries alongside
the industries list. The two affected tests were asserting the old exact
shape; update them to check each field individually.

Co-Authored-By: Claude <noreply@anthropic.com>