### PR TITLE
Add Phase 1 duration comparison vs parent industry

### DIFF
--- a/merger-tracker/frontend/src/components/PhaseDurationComparison.jsx
+++ b/merger-tracker/frontend/src/components/PhaseDurationComparison.jsx
@@ -1,0 +1,137 @@
+import { FaArrowUp, FaArrowDown } from 'react-icons/fa';
+
+// A single metric (Average or Median) rendered as a pair of horizontal bars:
+// this industry vs the parent in the ANZSIC hierarchy. Bars are scaled to the
+// larger of the two so the comparison reads at a glance, with a delta chip
+// spelling out how much longer/shorter this industry runs.
+function MetricComparison({ label, current, parent, parentName }) {
+  // No completed Phase 1 reviews here — nothing to plot.
+  if (current == null) {
+    return (
+      <div>
+        <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">{label}</p>
+        <p className="text-sm text-gray-400 mt-2">No completed Phase 1 reviews</p>
+      </div>
+    );
+  }
+
+  const hasParent = parent != null && parentName;
+  const max = Math.max(current, parent ?? 0) || 1;
+  const currentWidth = (current / max) * 100;
+  const parentWidth = hasParent ? (parent / max) * 100 : 0;
+
+  // Delta vs parent: positive means this industry takes longer.
+  const delta = hasParent ? current - parent : null;
+  const pct = hasParent && parent > 0 ? Math.round((delta / parent) * 100) : null;
+
+  let deltaChip = null;
+  if (hasParent && delta !== 0) {
+    const longer = delta > 0;
+    deltaChip = (
+      <span
+        className={`inline-flex items-center gap-1 text-xs font-semibold ${
+          longer ? 'text-amber-600' : 'text-emerald-600'
+        }`}
+      >
+        {longer ? (
+          <FaArrowUp className="w-2.5 h-2.5" aria-hidden="true" />
+        ) : (
+          <FaArrowDown className="w-2.5 h-2.5" aria-hidden="true" />
+        )}
+        {Math.abs(delta)} days {longer ? 'longer' : 'shorter'}
+        {pct != null && pct !== 0 && <span className="text-gray-400">({Math.abs(pct)}%)</span>}
+      </span>
+    );
+  } else if (hasParent) {
+    deltaChip = <span className="text-xs font-medium text-gray-400">Same as parent</span>;
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-2 mb-2.5">
+        <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">{label}</p>
+        {deltaChip}
+      </div>
+
+      {/* This industry */}
+      <div className="flex items-center gap-3">
+        <div className="flex-1 bg-gray-100 rounded-full h-2 overflow-hidden">
+          <div
+            className="bg-primary h-2 rounded-full transition-all duration-300"
+            style={{ width: `${currentWidth}%` }}
+          />
+        </div>
+        <span className="text-sm font-bold text-gray-900 tabular-nums w-7 text-right">
+          {current}
+        </span>
+      </div>
+      <p className="text-[11px] text-gray-400 mt-1">This industry</p>
+
+      {hasParent && (
+        <>
+          {/* Parent industry */}
+          <div className="flex items-center gap-3 mt-3">
+            <div className="flex-1 bg-gray-100 rounded-full h-2 overflow-hidden">
+              <div
+                className="bg-gray-300 h-2 rounded-full transition-all duration-300"
+                style={{ width: `${parentWidth}%` }}
+              />
+            </div>
+            <span className="text-sm font-semibold text-gray-500 tabular-nums w-7 text-right">
+              {parent}
+            </span>
+          </div>
+          <p className="text-[11px] text-gray-400 mt-1 truncate">{parentName}</p>
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Visual comparison of this industry's Phase 1 review durations against its
+ * parent in the ANZSIC hierarchy. Values are business days, rounded.
+ *
+ * @param {object} props
+ * @param {object|null} props.duration - this industry's `phase_duration`.
+ * @param {object|null} props.parentDuration - the parent's `phase_duration`.
+ * @param {string|null} props.parentName - parent display name (for labels).
+ */
+function PhaseDurationComparison({ duration, parentDuration, parentName }) {
+  const round = (v) => (v != null ? Math.round(v) : null);
+
+  const currentAvg = round(duration?.average_business_days);
+  const currentMedian = round(duration?.median_business_days);
+  const parentAvg = round(parentDuration?.average_business_days);
+  const parentMedian = round(parentDuration?.median_business_days);
+
+  const hasParent = parentName && (parentAvg != null || parentMedian != null);
+
+  return (
+    <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6">
+      <div className="flex items-baseline justify-between gap-3 mb-5">
+        <h2 className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+          Phase 1 duration
+        </h2>
+        <span className="text-[11px] text-gray-400">business days</span>
+      </div>
+
+      <div className="grid sm:grid-cols-2 gap-x-8 gap-y-6">
+        <MetricComparison
+          label="Average"
+          current={currentAvg}
+          parent={hasParent ? parentAvg : null}
+          parentName={hasParent ? parentName : null}
+        />
+        <MetricComparison
+          label="Median"
+          current={currentMedian}
+          parent={hasParent ? parentMedian : null}
+          parentName={hasParent ? parentName : null}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default PhaseDurationComparison;

--- a/merger-tracker/frontend/src/components/PhaseDurationComparison.jsx
+++ b/merger-tracker/frontend/src/components/PhaseDurationComparison.jsx
@@ -1,10 +1,11 @@
 import { FaArrowUp, FaArrowDown } from 'react-icons/fa';
 
 // A single metric (Average or Median) rendered as a pair of horizontal bars:
-// this industry vs the parent in the ANZSIC hierarchy. Bars are scaled to the
-// larger of the two so the comparison reads at a glance, with a delta chip
-// spelling out how much longer/shorter this industry runs.
-function MetricComparison({ label, current, parent, parentName }) {
+// this industry vs a comparison baseline (its parent in the ANZSIC hierarchy,
+// or all industries for top-level divisions). Bars are scaled to the larger of
+// the two so the comparison reads at a glance, with a delta chip spelling out
+// how much longer/shorter this industry runs.
+function MetricComparison({ label, current, comparison, comparisonName }) {
   // No completed Phase 1 reviews here — nothing to plot.
   if (current == null) {
     return (
@@ -15,17 +16,17 @@ function MetricComparison({ label, current, parent, parentName }) {
     );
   }
 
-  const hasParent = parent != null && parentName;
-  const max = Math.max(current, parent ?? 0) || 1;
+  const hasComparison = comparison != null && comparisonName;
+  const max = Math.max(current, comparison ?? 0) || 1;
   const currentWidth = (current / max) * 100;
-  const parentWidth = hasParent ? (parent / max) * 100 : 0;
+  const comparisonWidth = hasComparison ? (comparison / max) * 100 : 0;
 
-  // Delta vs parent: positive means this industry takes longer.
-  const delta = hasParent ? current - parent : null;
-  const pct = hasParent && parent > 0 ? Math.round((delta / parent) * 100) : null;
+  // Delta vs the baseline: positive means this industry takes longer.
+  const delta = hasComparison ? current - comparison : null;
+  const pct = hasComparison && comparison > 0 ? Math.round((delta / comparison) * 100) : null;
 
   let deltaChip = null;
-  if (hasParent && delta !== 0) {
+  if (hasComparison && delta !== 0) {
     const longer = delta > 0;
     deltaChip = (
       <span
@@ -42,8 +43,8 @@ function MetricComparison({ label, current, parent, parentName }) {
         {pct != null && pct !== 0 && <span className="text-gray-400">({Math.abs(pct)}%)</span>}
       </span>
     );
-  } else if (hasParent) {
-    deltaChip = <span className="text-xs font-medium text-gray-400">Same as parent</span>;
+  } else if (hasComparison) {
+    deltaChip = <span className="text-xs font-medium text-gray-400">Same as baseline</span>;
   }
 
   return (
@@ -67,21 +68,21 @@ function MetricComparison({ label, current, parent, parentName }) {
       </div>
       <p className="text-[11px] text-gray-400 mt-1">This industry</p>
 
-      {hasParent && (
+      {hasComparison && (
         <>
-          {/* Parent industry */}
+          {/* Comparison baseline (parent industry or all industries) */}
           <div className="flex items-center gap-3 mt-3">
             <div className="flex-1 bg-gray-100 rounded-full h-2 overflow-hidden">
               <div
                 className="bg-gray-300 h-2 rounded-full transition-all duration-300"
-                style={{ width: `${parentWidth}%` }}
+                style={{ width: `${comparisonWidth}%` }}
               />
             </div>
             <span className="text-sm font-semibold text-gray-500 tabular-nums w-7 text-right">
-              {parent}
+              {comparison}
             </span>
           </div>
-          <p className="text-[11px] text-gray-400 mt-1 truncate">{parentName}</p>
+          <p className="text-[11px] text-gray-400 mt-1 truncate">{comparisonName}</p>
         </>
       )}
     </div>
@@ -89,23 +90,25 @@ function MetricComparison({ label, current, parent, parentName }) {
 }
 
 /**
- * Visual comparison of this industry's Phase 1 review durations against its
- * parent in the ANZSIC hierarchy. Values are business days, rounded.
+ * Visual comparison of this industry's Phase 1 review durations against a
+ * baseline — its parent in the ANZSIC hierarchy, or all industries for a
+ * top-level division. Values are business days, rounded.
  *
  * @param {object} props
  * @param {object|null} props.duration - this industry's `phase_duration`.
- * @param {object|null} props.parentDuration - the parent's `phase_duration`.
- * @param {string|null} props.parentName - parent display name (for labels).
+ * @param {object|null} props.comparisonDuration - baseline `phase_duration`.
+ * @param {string|null} props.comparisonName - baseline label (e.g. parent name
+ *   or "All industries").
  */
-function PhaseDurationComparison({ duration, parentDuration, parentName }) {
+function PhaseDurationComparison({ duration, comparisonDuration, comparisonName }) {
   const round = (v) => (v != null ? Math.round(v) : null);
 
   const currentAvg = round(duration?.average_business_days);
   const currentMedian = round(duration?.median_business_days);
-  const parentAvg = round(parentDuration?.average_business_days);
-  const parentMedian = round(parentDuration?.median_business_days);
+  const comparisonAvg = round(comparisonDuration?.average_business_days);
+  const comparisonMedian = round(comparisonDuration?.median_business_days);
 
-  const hasParent = parentName && (parentAvg != null || parentMedian != null);
+  const hasComparison = comparisonName && (comparisonAvg != null || comparisonMedian != null);
 
   return (
     <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6">
@@ -120,14 +123,14 @@ function PhaseDurationComparison({ duration, parentDuration, parentName }) {
         <MetricComparison
           label="Average"
           current={currentAvg}
-          parent={hasParent ? parentAvg : null}
-          parentName={hasParent ? parentName : null}
+          comparison={hasComparison ? comparisonAvg : null}
+          comparisonName={hasComparison ? comparisonName : null}
         />
         <MetricComparison
           label="Median"
           current={currentMedian}
-          parent={hasParent ? parentMedian : null}
-          parentName={hasParent ? parentName : null}
+          comparison={hasComparison ? comparisonMedian : null}
+          comparisonName={hasComparison ? comparisonName : null}
         />
       </div>
     </div>

--- a/merger-tracker/frontend/src/pages/IndustryDetail.jsx
+++ b/merger-tracker/frontend/src/pages/IndustryDetail.jsx
@@ -47,6 +47,14 @@ function IndustryDetail() {
     parentCode ? { cacheKey: `industry-${parentCode}` } : {}
   );
 
+  // Top-level divisions have no parent, so compare against the overall
+  // all-industries figures instead (shared cache with the dashboard).
+  const needsOverall = !!data && !parentCode;
+  const { data: statsData } = useFetchData(
+    needsOverall ? API_ENDPOINTS.stats : null,
+    needsOverall ? { cacheKey: 'dashboard-stats' } : {}
+  );
+
   const isNotFound = error === 'HTTP 404';
 
   if (loading) return <LoadingSpinner />;
@@ -91,8 +99,16 @@ function IndustryDetail() {
   // surfaced visually via PhaseDurationComparison (vs the parent industry)
   // rather than as flat stat cards.
   const duration = data.phase_duration;
-  const parentDuration = parentData?.phase_duration || null;
-  const parentName = data.parent?.name || null;
+  // Compare against the parent industry, or all industries for a top-level
+  // division (which has no parent).
+  const comparisonDuration = parentCode
+    ? parentData?.phase_duration || null
+    : statsData?.phase_duration || null;
+  const comparisonName = parentCode
+    ? data.parent?.name || null
+    : statsData
+      ? 'All industries'
+      : null;
 
   const statCards = [
     { label: 'Total reviews', value: mergers.length },
@@ -167,8 +183,8 @@ function IndustryDetail() {
           <div className="mb-6">
             <PhaseDurationComparison
               duration={duration}
-              parentDuration={parentDuration}
-              parentName={parentName}
+              comparisonDuration={comparisonDuration}
+              comparisonName={comparisonName}
             />
           </div>
         )}

--- a/merger-tracker/frontend/src/pages/IndustryDetail.jsx
+++ b/merger-tracker/frontend/src/pages/IndustryDetail.jsx
@@ -3,6 +3,7 @@ import { FaChevronRight } from 'react-icons/fa';
 import LoadingSpinner from '../components/LoadingSpinner';
 import ErrorCard from '../components/ErrorCard';
 import IndustryMergerGroups from '../components/IndustryMergerGroups';
+import PhaseDurationComparison from '../components/PhaseDurationComparison';
 import SEO from '../components/SEO';
 import { API_ENDPOINTS } from '../config';
 import { useFetchData } from '../hooks/useFetchData';
@@ -35,6 +36,16 @@ function IndustryDetail() {
     cacheKey: 'industries-list',
   });
   const industries = industriesData?.industries || null;
+
+  // Parent industry detail — fetched once the main payload reveals the parent
+  // code, so we can compare Phase 1 durations against the next level up. The
+  // hook pauses while the URL is falsy (no parent / not yet loaded). A failure
+  // here is non-fatal: the comparison simply falls back to this industry alone.
+  const parentCode = data?.parent?.code;
+  const { data: parentData } = useFetchData(
+    parentCode ? API_ENDPOINTS.industryDetail(parentCode) : null,
+    parentCode ? { cacheKey: `industry-${parentCode}` } : {}
+  );
 
   const isNotFound = error === 'HTTP 404';
 
@@ -76,28 +87,18 @@ function IndustryDetail() {
   ).length;
 
   // Phase 1 duration stats, mirroring the dashboard. May be absent when the
-  // industry has no completed Phase 1 reviews (e.g. waivers only).
+  // industry has no completed Phase 1 reviews (e.g. waivers only). These are
+  // surfaced visually via PhaseDurationComparison (vs the parent industry)
+  // rather than as flat stat cards.
   const duration = data.phase_duration;
-  const avgDuration = duration?.average_business_days != null
-    ? `${Math.round(duration.average_business_days)} business days`
-    : 'N/A';
-  const avgDurationSub = duration?.average_days != null
-    ? `${Math.round(duration.average_days)} calendar days`
-    : null;
-  const medianDuration = duration?.median_business_days != null
-    ? `${duration.median_business_days} business days`
-    : 'N/A';
-  const medianDurationSub = duration?.median_days != null
-    ? `${duration.median_days} calendar days`
-    : null;
+  const parentDuration = parentData?.phase_duration || null;
+  const parentName = data.parent?.name || null;
 
   const statCards = [
     { label: 'Total reviews', value: mergers.length },
     { label: 'Phase 2 reviews', value: phase2Count },
     { label: 'Waivers', value: waiverCount },
     { label: 'Under assessment', value: activeCount },
-    { label: 'Avg phase 1 duration', value: avgDuration, subtitle: avgDurationSub },
-    { label: 'Median phase 1 duration', value: medianDuration, subtitle: medianDurationSub },
   ];
 
   return (
@@ -146,7 +147,7 @@ function IndustryDetail() {
         </div>
 
         {mergers.length > 0 && (
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-4 mb-6">
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6">
             {statCards.map(({ label, value, subtitle }) => (
               <div key={label} className="bg-white p-5 rounded-2xl border border-gray-100 shadow-card">
                 <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">{label}</p>
@@ -158,6 +159,17 @@ function IndustryDetail() {
                 )}
               </div>
             ))}
+          </div>
+        )}
+
+        {/* Phase 1 duration, shown visually against the parent industry. */}
+        {mergers.length > 0 && duration?.average_business_days != null && (
+          <div className="mb-6">
+            <PhaseDurationComparison
+              duration={duration}
+              parentDuration={parentDuration}
+              parentName={parentName}
+            />
           </div>
         )}
 


### PR DESCRIPTION
On the industry detail page, replace the flat "Avg/Median phase 1
duration" stat cards with a visual comparison against the next level
up in the ANZSIC hierarchy. Each metric shows paired horizontal bars
(this industry vs parent) scaled to the larger value, plus a delta
chip spelling out how much longer/shorter reviews run.

The parent's phase_duration is fetched from its existing detail JSON
once the main payload reveals the parent code; the fetch is non-fatal
and falls back to showing this industry alone (e.g. for divisions with
no parent).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TWgjvu5WGDCHnzMeRUVHTG