### PR TITLE
Strip dynamic acccCrmDataPullChildSyncOnLoad query param in clean_file

### DIFF
--- a/scripts/scrape.sh
+++ b/scripts/scrape.sh
@@ -82,6 +82,7 @@ clean_file() {
     s/(\?t)[^">\n]+/${1}STATIC/g;
     s/("css_js_query_string":")[^"\n]+"/${1}STATIC"/g;
     s/ct=t%28[^"\\]*%29\\u0026//g;
+    s/acccCrmDataPullChildSyncOnLoad=[^"\\]*\\u0026//g;
     s/[ \t]*\n[ \t]*<script>!function\(e\)\{var n="https:\/\/s\.go-mpulse\.net\/boomerang\/".*?\(window\);<\/script><\/head>/\n  <\/head>/s;
     s{(<meta name="dcterms\.modified"[^\n]*/>\n)(<meta name="dcterms\.created"[^\n]*/>\n)}{$2$1}g;
     s{(<link rel="canonical"[^\n]*/>\n)(<link rel="shortlink"[^\n]*/>\n)}{$2$1}g;


### PR DESCRIPTION
The acccCrmDataPullChildSyncOnLoad=1 query parameter intermittently
appears in the drupal-settings-json AjaxTrustedUrl/ajax URLs depending on
whether a CRM child sync was triggered on page load. It flips on and off
between scrapes, producing noisy git diffs (6 data commits over a few
days) with no meaningful content change.

Add a clean_file rule to strip it, mirroring the existing ct=t(...) rule
which neutralizes the same class of dynamic URL-encoded query param.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01M2hJFANf5fV9Q7MytsnHQ1