### PR TITLE
Compare Phase 1 duration against overall at every industry level

### DIFF
--- a/merger-tracker/frontend/src/components/PhaseDurationComparison.jsx
+++ b/merger-tracker/frontend/src/components/PhaseDurationComparison.jsx
@@ -1,11 +1,62 @@
 import { FaArrowUp, FaArrowDown } from 'react-icons/fa';
 
-// A single metric (Average or Median) rendered as a pair of horizontal bars:
-// this industry vs a comparison baseline (its parent in the ANZSIC hierarchy,
-// or all industries for top-level divisions). Bars are scaled to the larger of
-// the two so the comparison reads at a glance, with a delta chip spelling out
-// how much longer/shorter this industry runs.
-function MetricComparison({ label, current, comparison, comparisonName }) {
+// A single horizontal bar with its value to the right and a caption (plus an
+// optional delta chip) underneath.
+function Bar({ widthPct, value, barClass, valueClass, caption, delta }) {
+  return (
+    <>
+      <div className="flex items-center gap-3">
+        <div className="flex-1 bg-gray-100 rounded-full h-2 overflow-hidden">
+          <div
+            className={`${barClass} h-2 rounded-full transition-all duration-300`}
+            style={{ width: `${widthPct}%` }}
+          />
+        </div>
+        <span className={`text-sm tabular-nums w-7 text-right ${valueClass}`}>
+          {value}
+        </span>
+      </div>
+      <div className="flex items-center justify-between gap-2 mt-1">
+        <p className="text-[11px] text-gray-400 truncate">{caption}</p>
+        {delta}
+      </div>
+    </>
+  );
+}
+
+// Delta of this industry vs a baseline, as a small coloured chip. Positive
+// means this industry runs longer than the baseline.
+function DeltaChip({ current, comparison }) {
+  if (comparison == null) return null;
+  const delta = current - comparison;
+  if (delta === 0) {
+    return <span className="text-[11px] font-medium text-gray-400 shrink-0">Same</span>;
+  }
+  const longer = delta > 0;
+  const pct = comparison > 0 ? Math.round((delta / comparison) * 100) : null;
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-[11px] font-semibold shrink-0 ${
+        longer ? 'text-amber-600' : 'text-emerald-600'
+      }`}
+    >
+      {longer ? (
+        <FaArrowUp className="w-2.5 h-2.5" aria-hidden="true" />
+      ) : (
+        <FaArrowDown className="w-2.5 h-2.5" aria-hidden="true" />
+      )}
+      {Math.abs(delta)} days {longer ? 'longer' : 'shorter'}
+      {pct != null && pct !== 0 && <span className="text-gray-400">({Math.abs(pct)}%)</span>}
+    </span>
+  );
+}
+
+// A single metric (Average or Median) rendered as a stack of horizontal bars:
+// this industry on top, then one bar per comparison baseline (its parent in the
+// ANZSIC hierarchy and/or all industries). Bars are scaled to the largest value
+// so the comparison reads at a glance, and each baseline carries a delta chip
+// spelling out how much longer/shorter this industry runs.
+function MetricComparison({ label, current, comparisons }) {
   // No completed Phase 1 reviews here — nothing to plot.
   if (current == null) {
     return (
@@ -16,99 +67,68 @@ function MetricComparison({ label, current, comparison, comparisonName }) {
     );
   }
 
-  const hasComparison = comparison != null && comparisonName;
-  const max = Math.max(current, comparison ?? 0) || 1;
-  const currentWidth = (current / max) * 100;
-  const comparisonWidth = hasComparison ? (comparison / max) * 100 : 0;
+  const active = comparisons.filter((c) => c.value != null);
+  const max = Math.max(current, ...active.map((c) => c.value)) || 1;
 
-  // Delta vs the baseline: positive means this industry takes longer.
-  const delta = hasComparison ? current - comparison : null;
-  const pct = hasComparison && comparison > 0 ? Math.round((delta / comparison) * 100) : null;
-
-  let deltaChip = null;
-  if (hasComparison && delta !== 0) {
-    const longer = delta > 0;
-    deltaChip = (
-      <span
-        className={`inline-flex items-center gap-1 text-xs font-semibold ${
-          longer ? 'text-amber-600' : 'text-emerald-600'
-        }`}
-      >
-        {longer ? (
-          <FaArrowUp className="w-2.5 h-2.5" aria-hidden="true" />
-        ) : (
-          <FaArrowDown className="w-2.5 h-2.5" aria-hidden="true" />
-        )}
-        {Math.abs(delta)} days {longer ? 'longer' : 'shorter'}
-        {pct != null && pct !== 0 && <span className="text-gray-400">({Math.abs(pct)}%)</span>}
-      </span>
-    );
-  } else if (hasComparison) {
-    deltaChip = <span className="text-xs font-medium text-gray-400">Same as baseline</span>;
-  }
+  // Distinct shades so stacked baseline bars read apart from one another.
+  const barShades = ['bg-gray-400', 'bg-gray-300'];
 
   return (
     <div>
-      <div className="flex items-center justify-between gap-2 mb-2.5">
-        <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">{label}</p>
-        {deltaChip}
-      </div>
+      <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2.5">
+        {label}
+      </p>
 
       {/* This industry */}
-      <div className="flex items-center gap-3">
-        <div className="flex-1 bg-gray-100 rounded-full h-2 overflow-hidden">
-          <div
-            className="bg-primary h-2 rounded-full transition-all duration-300"
-            style={{ width: `${currentWidth}%` }}
+      <Bar
+        widthPct={(current / max) * 100}
+        value={current}
+        barClass="bg-primary"
+        valueClass="font-bold text-gray-900"
+        caption="This industry"
+      />
+
+      {/* One bar per baseline (parent industry, all industries). */}
+      {active.map((c, i) => (
+        <div key={c.name} className="mt-3">
+          <Bar
+            widthPct={(c.value / max) * 100}
+            value={c.value}
+            barClass={barShades[i] || 'bg-gray-300'}
+            valueClass="font-semibold text-gray-500"
+            caption={c.name}
+            delta={<DeltaChip current={current} comparison={c.value} />}
           />
         </div>
-        <span className="text-sm font-bold text-gray-900 tabular-nums w-7 text-right">
-          {current}
-        </span>
-      </div>
-      <p className="text-[11px] text-gray-400 mt-1">This industry</p>
-
-      {hasComparison && (
-        <>
-          {/* Comparison baseline (parent industry or all industries) */}
-          <div className="flex items-center gap-3 mt-3">
-            <div className="flex-1 bg-gray-100 rounded-full h-2 overflow-hidden">
-              <div
-                className="bg-gray-300 h-2 rounded-full transition-all duration-300"
-                style={{ width: `${comparisonWidth}%` }}
-              />
-            </div>
-            <span className="text-sm font-semibold text-gray-500 tabular-nums w-7 text-right">
-              {comparison}
-            </span>
-          </div>
-          <p className="text-[11px] text-gray-400 mt-1 truncate">{comparisonName}</p>
-        </>
-      )}
+      ))}
     </div>
   );
 }
 
 /**
- * Visual comparison of this industry's Phase 1 review durations against a
- * baseline — its parent in the ANZSIC hierarchy, or all industries for a
- * top-level division. Values are business days, rounded.
+ * Visual comparison of this industry's Phase 1 review durations against one or
+ * more baselines — its parent in the ANZSIC hierarchy and/or all industries.
+ * Values are business days, rounded.
  *
  * @param {object} props
  * @param {object|null} props.duration - this industry's `phase_duration`.
- * @param {object|null} props.comparisonDuration - baseline `phase_duration`.
- * @param {string|null} props.comparisonName - baseline label (e.g. parent name
- *   or "All industries").
+ * @param {Array<{name: string, duration: object|null}>} [props.comparisons] -
+ *   ordered baselines to plot beneath this industry (e.g. parent then overall).
  */
-function PhaseDurationComparison({ duration, comparisonDuration, comparisonName }) {
+function PhaseDurationComparison({ duration, comparisons = [] }) {
   const round = (v) => (v != null ? Math.round(v) : null);
 
   const currentAvg = round(duration?.average_business_days);
   const currentMedian = round(duration?.median_business_days);
-  const comparisonAvg = round(comparisonDuration?.average_business_days);
-  const comparisonMedian = round(comparisonDuration?.median_business_days);
 
-  const hasComparison = comparisonName && (comparisonAvg != null || comparisonMedian != null);
+  // Project the baselines onto each metric, dropping any without a usable value.
+  const toMetric = (key) =>
+    comparisons
+      .filter((c) => c.name)
+      .map((c) => ({ name: c.name, value: round(c.duration?.[key]) }));
+
+  const avgComparisons = toMetric('average_business_days');
+  const medianComparisons = toMetric('median_business_days');
 
   return (
     <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6">
@@ -123,14 +143,12 @@ function PhaseDurationComparison({ duration, comparisonDuration, comparisonName 
         <MetricComparison
           label="Average"
           current={currentAvg}
-          comparison={hasComparison ? comparisonAvg : null}
-          comparisonName={hasComparison ? comparisonName : null}
+          comparisons={avgComparisons}
         />
         <MetricComparison
           label="Median"
           current={currentMedian}
-          comparison={hasComparison ? comparisonMedian : null}
-          comparisonName={hasComparison ? comparisonName : null}
+          comparisons={medianComparisons}
         />
       </div>
     </div>

--- a/merger-tracker/frontend/src/pages/IndustryDetail.jsx
+++ b/merger-tracker/frontend/src/pages/IndustryDetail.jsx
@@ -47,12 +47,12 @@ function IndustryDetail() {
     parentCode ? { cacheKey: `industry-${parentCode}` } : {}
   );
 
-  // Top-level divisions have no parent, so compare against the overall
-  // all-industries figures instead (shared cache with the dashboard).
-  const needsOverall = !!data && !parentCode;
+  // Overall all-industries figures (shared cache with the dashboard). Fetched
+  // for every level so each industry can be compared against the market as a
+  // whole, not just against its immediate parent.
   const { data: statsData } = useFetchData(
-    needsOverall ? API_ENDPOINTS.stats : null,
-    needsOverall ? { cacheKey: 'dashboard-stats' } : {}
+    data ? API_ENDPOINTS.stats : null,
+    data ? { cacheKey: 'dashboard-stats' } : {}
   );
 
   const isNotFound = error === 'HTTP 404';
@@ -99,16 +99,19 @@ function IndustryDetail() {
   // surfaced visually via PhaseDurationComparison (vs the parent industry)
   // rather than as flat stat cards.
   const duration = data.phase_duration;
-  // Compare against the parent industry, or all industries for a top-level
-  // division (which has no parent).
-  const comparisonDuration = parentCode
-    ? parentData?.phase_duration || null
-    : statsData?.phase_duration || null;
-  const comparisonName = parentCode
-    ? data.parent?.name || null
-    : statsData
-      ? 'All industries'
-      : null;
+  // Baselines to compare this industry's durations against: its parent in the
+  // ANZSIC hierarchy (when it has one) and the overall all-industries figures.
+  // Divisions (no parent) show one baseline line; deeper levels show two.
+  const comparisons = [];
+  if (parentCode && parentData?.phase_duration) {
+    comparisons.push({
+      name: data.parent?.name || 'Parent industry',
+      duration: parentData.phase_duration,
+    });
+  }
+  if (statsData?.phase_duration) {
+    comparisons.push({ name: 'All industries', duration: statsData.phase_duration });
+  }
 
   const statCards = [
     { label: 'Total reviews', value: mergers.length },
@@ -183,8 +186,7 @@ function IndustryDetail() {
           <div className="mb-6">
             <PhaseDurationComparison
               duration={duration}
-              comparisonDuration={comparisonDuration}
-              comparisonName={comparisonName}
+              comparisons={comparisons}
             />
           </div>
         )}


### PR DESCRIPTION
Previously the duration comparison showed a single baseline: the parent
industry for deeper levels, or all industries only for top-level divisions.
Now every level is also compared against the overall all-industries figures,
so divisions show two bars (division + overall) and deeper levels show three
(this industry + parent + overall).

PhaseDurationComparison now takes an ordered `comparisons` array and stacks a
bar per baseline, each with its own delta chip.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Uiz2eNV9KbknVUnJAZwztN