### PR TITLE
Fix Phase 1 duration including Phase 2 review time

### DIFF
--- a/merger-tracker/frontend/public/data/analysis.json
+++ b/merger-tracker/frontend/public/data/analysis.json
@@ -21,8 +21,8 @@
       },
       {
         "notification_date": "2025-10-10",
-        "business_days": 148,
-        "calendar_days": 235,
+        "business_days": 58,
+        "calendar_days": 102,
         "merger_name": "Ampol \u2013 EG Australia",
         "merger_id": "MN-01019",
         "determination": "Referred to phase 2",
@@ -1029,17 +1029,17 @@
       }
     ],
     "stats": {
-      "average": 19.6,
+      "average": 18.7,
       "median": 17.0,
       "min": 15,
-      "max": 148,
+      "max": 58,
       "count": 110
     },
     "calendar_stats": {
-      "average": 29.7,
+      "average": 28.5,
       "median": 26.0,
       "min": 21,
-      "max": 235,
+      "max": 102,
       "count": 110
     }
   },

--- a/merger-tracker/frontend/public/data/industries/17.json
+++ b/merger-tracker/frontend/public/data/industries/17.json
@@ -58,9 +58,9 @@
   "waiver_count": 0,
   "active_count": 0,
   "phase_duration": {
-    "average_days": 80.5,
+    "average_days": 47.25,
     "median_days": 33,
-    "average_business_days": 51.0,
+    "average_business_days": 28.5,
     "median_business_days": 22,
     "completed_count": 4
   }

--- a/merger-tracker/frontend/public/data/industries/170.json
+++ b/merger-tracker/frontend/public/data/industries/170.json
@@ -69,9 +69,9 @@
   "waiver_count": 0,
   "active_count": 0,
   "phase_duration": {
-    "average_days": 80.5,
+    "average_days": 47.25,
     "median_days": 33,
-    "average_business_days": 51.0,
+    "average_business_days": 28.5,
     "median_business_days": 22,
     "completed_count": 4
   }

--- a/merger-tracker/frontend/public/data/industries/1701.json
+++ b/merger-tracker/frontend/public/data/industries/1701.json
@@ -47,10 +47,10 @@
   "waiver_count": 0,
   "active_count": 0,
   "phase_duration": {
-    "average_days": 134.0,
-    "median_days": 235,
-    "average_business_days": 85.0,
-    "median_business_days": 148,
+    "average_days": 67.5,
+    "median_days": 102,
+    "average_business_days": 40.0,
+    "median_business_days": 58,
     "completed_count": 2
   }
 }

--- a/merger-tracker/frontend/public/data/industries/33.json
+++ b/merger-tracker/frontend/public/data/industries/33.json
@@ -105,9 +105,9 @@
   "waiver_count": 5,
   "active_count": 1,
   "phase_duration": {
-    "average_days": 99.0,
+    "average_days": 54.666666666666664,
     "median_days": 35,
-    "average_business_days": 63.0,
+    "average_business_days": 33.0,
     "median_business_days": 23,
     "completed_count": 3
   }

--- a/merger-tracker/frontend/public/data/industries/332.json
+++ b/merger-tracker/frontend/public/data/industries/332.json
@@ -75,9 +75,9 @@
   "waiver_count": 1,
   "active_count": 0,
   "phase_duration": {
-    "average_days": 99.0,
+    "average_days": 54.666666666666664,
     "median_days": 35,
-    "average_business_days": 63.0,
+    "average_business_days": 33.0,
     "median_business_days": 23,
     "completed_count": 3
   }

--- a/merger-tracker/frontend/public/data/industries/3321.json
+++ b/merger-tracker/frontend/public/data/industries/3321.json
@@ -54,9 +54,9 @@
   "waiver_count": 0,
   "active_count": 0,
   "phase_duration": {
-    "average_days": 99.0,
+    "average_days": 54.666666666666664,
     "median_days": 35,
-    "average_business_days": 63.0,
+    "average_business_days": 33.0,
     "median_business_days": 23,
     "completed_count": 3
   }

--- a/merger-tracker/frontend/public/data/industries/39.json
+++ b/merger-tracker/frontend/public/data/industries/39.json
@@ -113,10 +113,10 @@
   "waiver_count": 8,
   "active_count": 0,
   "phase_duration": {
-    "average_days": 31.5,
+    "average_days": 50.666666666666664,
     "median_days": 35,
-    "average_business_days": 20.5,
+    "average_business_days": 33.333333333333336,
     "median_business_days": 23,
-    "completed_count": 2
+    "completed_count": 3
   }
 }

--- a/merger-tracker/frontend/public/data/industries/391.json
+++ b/merger-tracker/frontend/public/data/industries/391.json
@@ -124,10 +124,10 @@
   "waiver_count": 8,
   "active_count": 0,
   "phase_duration": {
-    "average_days": 31.5,
+    "average_days": 50.666666666666664,
     "median_days": 35,
-    "average_business_days": 20.5,
+    "average_business_days": 33.333333333333336,
     "median_business_days": 23,
-    "completed_count": 2
+    "completed_count": 3
   }
 }

--- a/merger-tracker/frontend/public/data/industries/3911.json
+++ b/merger-tracker/frontend/public/data/industries/3911.json
@@ -110,10 +110,10 @@
   "waiver_count": 8,
   "active_count": 0,
   "phase_duration": {
-    "average_days": 31.5,
+    "average_days": 50.666666666666664,
     "median_days": 35,
-    "average_business_days": 20.5,
+    "average_business_days": 33.333333333333336,
     "median_business_days": 23,
-    "completed_count": 2
+    "completed_count": 3
   }
 }

--- a/merger-tracker/frontend/public/data/industries/392.json
+++ b/merger-tracker/frontend/public/data/industries/392.json
@@ -62,10 +62,10 @@
   "waiver_count": 1,
   "active_count": 0,
   "phase_duration": {
-    "average_days": 35.0,
-    "median_days": 35,
-    "average_business_days": 23.0,
-    "median_business_days": 23,
-    "completed_count": 1
+    "average_days": 62.0,
+    "median_days": 89,
+    "average_business_days": 41.0,
+    "median_business_days": 59,
+    "completed_count": 2
   }
 }

--- a/merger-tracker/frontend/public/data/industries/3921.json
+++ b/merger-tracker/frontend/public/data/industries/3921.json
@@ -54,10 +54,10 @@
   "waiver_count": 1,
   "active_count": 0,
   "phase_duration": {
-    "average_days": 35.0,
-    "median_days": 35,
-    "average_business_days": 23.0,
-    "median_business_days": 23,
-    "completed_count": 1
+    "average_days": 62.0,
+    "median_days": 89,
+    "average_business_days": 41.0,
+    "median_business_days": 59,
+    "completed_count": 2
   }
 }

--- a/merger-tracker/frontend/public/data/industries/40.json
+++ b/merger-tracker/frontend/public/data/industries/40.json
@@ -58,10 +58,10 @@
   "waiver_count": 3,
   "active_count": 0,
   "phase_duration": {
-    "average_days": 235.0,
-    "median_days": 235,
-    "average_business_days": 148.0,
-    "median_business_days": 148,
+    "average_days": 102.0,
+    "median_days": 102,
+    "average_business_days": 58.0,
+    "median_business_days": 58,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/400.json
+++ b/merger-tracker/frontend/public/data/industries/400.json
@@ -63,10 +63,10 @@
   "waiver_count": 3,
   "active_count": 0,
   "phase_duration": {
-    "average_days": 235.0,
-    "median_days": 235,
-    "average_business_days": 148.0,
-    "median_business_days": 148,
+    "average_days": 102.0,
+    "median_days": 102,
+    "average_business_days": 58.0,
+    "median_business_days": 58,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/4000.json
+++ b/merger-tracker/frontend/public/data/industries/4000.json
@@ -61,10 +61,10 @@
   "waiver_count": 3,
   "active_count": 0,
   "phase_duration": {
-    "average_days": 235.0,
-    "median_days": 235,
-    "average_business_days": 148.0,
-    "median_business_days": 148,
+    "average_days": 102.0,
+    "median_days": 102,
+    "average_business_days": 58.0,
+    "median_business_days": 58,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/41.json
+++ b/merger-tracker/frontend/public/data/industries/41.json
@@ -183,10 +183,10 @@
   "waiver_count": 12,
   "active_count": 6,
   "phase_duration": {
-    "average_days": 96.33333333333333,
-    "median_days": 29,
-    "average_business_days": 60.666666666666664,
-    "median_business_days": 19,
-    "completed_count": 3
+    "average_days": 54.75,
+    "median_days": 63,
+    "average_business_days": 30.5,
+    "median_business_days": 30,
+    "completed_count": 4
   }
 }

--- a/merger-tracker/frontend/public/data/industries/411.json
+++ b/merger-tracker/frontend/public/data/industries/411.json
@@ -119,10 +119,10 @@
   "waiver_count": 6,
   "active_count": 4,
   "phase_duration": {
-    "average_days": 132.0,
-    "median_days": 235,
-    "average_business_days": 83.5,
-    "median_business_days": 148,
-    "completed_count": 2
+    "average_days": 64.66666666666667,
+    "median_days": 63,
+    "average_business_days": 35.666666666666664,
+    "median_business_days": 30,
+    "completed_count": 3
   }
 }

--- a/merger-tracker/frontend/public/data/industries/4110.json
+++ b/merger-tracker/frontend/public/data/industries/4110.json
@@ -117,10 +117,10 @@
   "waiver_count": 6,
   "active_count": 4,
   "phase_duration": {
-    "average_days": 132.0,
-    "median_days": 235,
-    "average_business_days": 83.5,
-    "median_business_days": 148,
-    "completed_count": 2
+    "average_days": 64.66666666666667,
+    "median_days": 63,
+    "average_business_days": 35.666666666666664,
+    "median_business_days": 30,
+    "completed_count": 3
   }
 }

--- a/merger-tracker/frontend/public/data/industries/412.json
+++ b/merger-tracker/frontend/public/data/industries/412.json
@@ -144,10 +144,10 @@
   "waiver_count": 9,
   "active_count": 3,
   "phase_duration": {
-    "average_days": 25.0,
-    "median_days": 25,
-    "average_business_days": 15.0,
-    "median_business_days": 15,
-    "completed_count": 1
+    "average_days": 44.0,
+    "median_days": 63,
+    "average_business_days": 22.5,
+    "median_business_days": 30,
+    "completed_count": 2
   }
 }

--- a/merger-tracker/frontend/public/data/industries/4123.json
+++ b/merger-tracker/frontend/public/data/industries/4123.json
@@ -117,10 +117,10 @@
   "waiver_count": 8,
   "active_count": 3,
   "phase_duration": {
-    "average_days": 25.0,
-    "median_days": 25,
-    "average_business_days": 15.0,
-    "median_business_days": 15,
-    "completed_count": 1
+    "average_days": 44.0,
+    "median_days": 63,
+    "average_business_days": 22.5,
+    "median_business_days": 30,
+    "completed_count": 2
   }
 }

--- a/merger-tracker/frontend/public/data/industries/62.json
+++ b/merger-tracker/frontend/public/data/industries/62.json
@@ -412,10 +412,10 @@
   "waiver_count": 41,
   "active_count": 1,
   "phase_duration": {
-    "average_days": 24.444444444444443,
-    "median_days": 23,
-    "average_business_days": 16.77777777777778,
+    "average_days": 30.9,
+    "median_days": 24,
+    "average_business_days": 21.0,
     "median_business_days": 16,
-    "completed_count": 9
+    "completed_count": 10
   }
 }

--- a/merger-tracker/frontend/public/data/industries/623.json
+++ b/merger-tracker/frontend/public/data/industries/623.json
@@ -55,5 +55,11 @@
   "phase_2_count": 1,
   "waiver_count": 2,
   "active_count": 0,
-  "phase_duration": null
+  "phase_duration": {
+    "average_days": 89.0,
+    "median_days": 89,
+    "average_business_days": 59.0,
+    "median_business_days": 59,
+    "completed_count": 1
+  }
 }

--- a/merger-tracker/frontend/public/data/industries/6230.json
+++ b/merger-tracker/frontend/public/data/industries/6230.json
@@ -53,5 +53,11 @@
   "phase_2_count": 1,
   "waiver_count": 2,
   "active_count": 0,
-  "phase_duration": null
+  "phase_duration": {
+    "average_days": 89.0,
+    "median_days": 89,
+    "average_business_days": 59.0,
+    "median_business_days": 59,
+    "completed_count": 1
+  }
 }

--- a/merger-tracker/frontend/public/data/industries/63.json
+++ b/merger-tracker/frontend/public/data/industries/63.json
@@ -119,10 +119,10 @@
   "waiver_count": 6,
   "active_count": 1,
   "phase_duration": {
-    "average_days": 25.0,
+    "average_days": 41.6,
     "median_days": 26,
-    "average_business_days": 17.0,
-    "median_business_days": 17,
-    "completed_count": 3
+    "average_business_days": 27.8,
+    "median_business_days": 18,
+    "completed_count": 5
   }
 }

--- a/merger-tracker/frontend/public/data/industries/632.json
+++ b/merger-tracker/frontend/public/data/industries/632.json
@@ -83,10 +83,10 @@
   "waiver_count": 1,
   "active_count": 1,
   "phase_duration": {
-    "average_days": 25.0,
+    "average_days": 41.6,
     "median_days": 26,
-    "average_business_days": 17.0,
-    "median_business_days": 17,
-    "completed_count": 3
+    "average_business_days": 27.8,
+    "median_business_days": 18,
+    "completed_count": 5
   }
 }

--- a/merger-tracker/frontend/public/data/industries/6322.json
+++ b/merger-tracker/frontend/public/data/industries/6322.json
@@ -75,10 +75,10 @@
   "waiver_count": 1,
   "active_count": 1,
   "phase_duration": {
-    "average_days": 25.0,
+    "average_days": 41.6,
     "median_days": 26,
-    "average_business_days": 17.0,
-    "median_business_days": 17,
-    "completed_count": 3
+    "average_business_days": 27.8,
+    "median_business_days": 18,
+    "completed_count": 5
   }
 }

--- a/merger-tracker/frontend/public/data/industries/66.json
+++ b/merger-tracker/frontend/public/data/industries/66.json
@@ -83,10 +83,10 @@
   "waiver_count": 1,
   "active_count": 1,
   "phase_duration": {
-    "average_days": 29.0,
-    "median_days": 24,
-    "average_business_days": 19.333333333333332,
-    "median_business_days": 16,
-    "completed_count": 3
+    "average_days": 31.75,
+    "median_days": 40,
+    "average_business_days": 21.25,
+    "median_business_days": 27,
+    "completed_count": 4
   }
 }

--- a/merger-tracker/frontend/public/data/industries/663.json
+++ b/merger-tracker/frontend/public/data/industries/663.json
@@ -68,10 +68,10 @@
   "waiver_count": 1,
   "active_count": 1,
   "phase_duration": {
-    "average_days": 22.0,
-    "median_days": 22,
-    "average_business_days": 15.0,
-    "median_business_days": 15,
-    "completed_count": 1
+    "average_days": 31.0,
+    "median_days": 40,
+    "average_business_days": 21.0,
+    "median_business_days": 27,
+    "completed_count": 2
   }
 }

--- a/merger-tracker/frontend/public/data/industries/6639.json
+++ b/merger-tracker/frontend/public/data/industries/6639.json
@@ -46,5 +46,11 @@
   "phase_2_count": 1,
   "waiver_count": 1,
   "active_count": 1,
-  "phase_duration": null
+  "phase_duration": {
+    "average_days": 40.0,
+    "median_days": 40,
+    "average_business_days": 27.0,
+    "median_business_days": 27,
+    "completed_count": 1
+  }
 }

--- a/merger-tracker/frontend/public/data/industries/67.json
+++ b/merger-tracker/frontend/public/data/industries/67.json
@@ -197,10 +197,10 @@
   "waiver_count": 15,
   "active_count": 3,
   "phase_duration": {
-    "average_days": 27.2,
-    "median_days": 29,
-    "average_business_days": 19.0,
-    "median_business_days": 19,
-    "completed_count": 5
+    "average_days": 33.166666666666664,
+    "median_days": 30,
+    "average_business_days": 20.833333333333332,
+    "median_business_days": 22,
+    "completed_count": 6
   }
 }

--- a/merger-tracker/frontend/public/data/industries/671.json
+++ b/merger-tracker/frontend/public/data/industries/671.json
@@ -181,10 +181,10 @@
   "waiver_count": 13,
   "active_count": 3,
   "phase_duration": {
-    "average_days": 28.75,
+    "average_days": 35.6,
     "median_days": 30,
-    "average_business_days": 20.0,
+    "average_business_days": 22.0,
     "median_business_days": 22,
-    "completed_count": 4
+    "completed_count": 5
   }
 }

--- a/merger-tracker/frontend/public/data/industries/6712.json
+++ b/merger-tracker/frontend/public/data/industries/6712.json
@@ -166,10 +166,10 @@
   "waiver_count": 12,
   "active_count": 3,
   "phase_duration": {
-    "average_days": 28.75,
+    "average_days": 35.6,
     "median_days": 30,
-    "average_business_days": 20.0,
+    "average_business_days": 22.0,
     "median_business_days": 22,
-    "completed_count": 4
+    "completed_count": 5
   }
 }

--- a/merger-tracker/frontend/public/data/industries/94.json
+++ b/merger-tracker/frontend/public/data/industries/94.json
@@ -126,10 +126,10 @@
   "waiver_count": 6,
   "active_count": 2,
   "phase_duration": {
-    "average_days": 26.0,
-    "median_days": 24,
-    "average_business_days": 17.333333333333332,
-    "median_business_days": 15,
-    "completed_count": 3
+    "average_days": 41.75,
+    "median_days": 32,
+    "average_business_days": 27.75,
+    "median_business_days": 22,
+    "completed_count": 4
   }
 }

--- a/merger-tracker/frontend/public/data/industries/941.json
+++ b/merger-tracker/frontend/public/data/industries/941.json
@@ -96,10 +96,10 @@
   "waiver_count": 4,
   "active_count": 0,
   "phase_duration": {
-    "average_days": 28.0,
+    "average_days": 48.333333333333336,
     "median_days": 32,
-    "average_business_days": 18.5,
+    "average_business_days": 32.0,
     "median_business_days": 22,
-    "completed_count": 2
+    "completed_count": 3
   }
 }

--- a/merger-tracker/frontend/public/data/industries/9419.json
+++ b/merger-tracker/frontend/public/data/industries/9419.json
@@ -75,10 +75,10 @@
   "waiver_count": 4,
   "active_count": 0,
   "phase_duration": {
-    "average_days": 24.0,
-    "median_days": 24,
-    "average_business_days": 15.0,
-    "median_business_days": 15,
-    "completed_count": 1
+    "average_days": 56.5,
+    "median_days": 89,
+    "average_business_days": 37.0,
+    "median_business_days": 59,
+    "completed_count": 2
   }
 }

--- a/merger-tracker/frontend/public/data/industries/C.json
+++ b/merger-tracker/frontend/public/data/industries/C.json
@@ -748,9 +748,9 @@
   "waiver_count": 51,
   "active_count": 7,
   "phase_duration": {
-    "average_days": 33.6764705882353,
+    "average_days": 29.764705882352942,
     "median_days": 26,
-    "average_business_days": 22.11764705882353,
+    "average_business_days": 19.470588235294116,
     "median_business_days": 18,
     "completed_count": 34
   }

--- a/merger-tracker/frontend/public/data/industries/F.json
+++ b/merger-tracker/frontend/public/data/industries/F.json
@@ -316,9 +316,9 @@
   "waiver_count": 16,
   "active_count": 6,
   "phase_duration": {
-    "average_days": 42.875,
+    "average_days": 34.5625,
     "median_days": 29,
-    "average_business_days": 26.4375,
+    "average_business_days": 20.8125,
     "median_business_days": 18,
     "completed_count": 16
   }

--- a/merger-tracker/frontend/public/data/industries/G.json
+++ b/merger-tracker/frontend/public/data/industries/G.json
@@ -366,10 +366,10 @@
   "waiver_count": 30,
   "active_count": 7,
   "phase_duration": {
-    "average_days": 55.625,
-    "median_days": 29,
-    "average_business_days": 35.375,
-    "median_business_days": 19,
-    "completed_count": 8
+    "average_days": 46.4,
+    "median_days": 35,
+    "average_business_days": 28.2,
+    "median_business_days": 23,
+    "completed_count": 10
   }
 }

--- a/merger-tracker/frontend/public/data/industries/K.json
+++ b/merger-tracker/frontend/public/data/industries/K.json
@@ -613,10 +613,10 @@
   "waiver_count": 62,
   "active_count": 3,
   "phase_duration": {
-    "average_days": 24.941176470588236,
-    "median_days": 24,
-    "average_business_days": 17.11764705882353,
+    "average_days": 29.31578947368421,
+    "median_days": 25,
+    "average_business_days": 19.94736842105263,
     "median_business_days": 16,
-    "completed_count": 17
+    "completed_count": 19
   }
 }

--- a/merger-tracker/frontend/public/data/industries/L.json
+++ b/merger-tracker/frontend/public/data/industries/L.json
@@ -222,10 +222,10 @@
   "waiver_count": 16,
   "active_count": 4,
   "phase_duration": {
-    "average_days": 27.875,
-    "median_days": 29,
-    "average_business_days": 19.125,
-    "median_business_days": 19,
-    "completed_count": 8
+    "average_days": 32.6,
+    "median_days": 30,
+    "average_business_days": 21.0,
+    "median_business_days": 22,
+    "completed_count": 10
   }
 }

--- a/merger-tracker/frontend/public/data/industries/S.json
+++ b/merger-tracker/frontend/public/data/industries/S.json
@@ -172,10 +172,10 @@
   "waiver_count": 14,
   "active_count": 2,
   "phase_duration": {
-    "average_days": 26.0,
-    "median_days": 24,
-    "average_business_days": 17.333333333333332,
-    "median_business_days": 15,
-    "completed_count": 3
+    "average_days": 41.75,
+    "median_days": 32,
+    "average_business_days": 27.75,
+    "median_business_days": 22,
+    "completed_count": 4
   }
 }

--- a/merger-tracker/frontend/public/data/stats.json
+++ b/merger-tracker/frontend/public/data/stats.json
@@ -15,22 +15,22 @@
     "Not approved": 14
   },
   "phase_duration": {
-    "average_days": 29.69090909090909,
+    "average_days": 29.55263157894737,
     "median_days": 26,
-    "average_business_days": 19.554545454545455,
+    "average_business_days": 19.350877192982455,
     "median_business_days": 17,
     "percentiles": {
       "day15": {
         "count": 23,
-        "percentage": 20.9
+        "percentage": 20.2
       },
       "day20": {
         "count": 86,
-        "percentage": 78.2
+        "percentage": 75.4
       },
       "day30": {
-        "count": 107,
-        "percentage": 97.3
+        "count": 110,
+        "percentage": 96.5
       }
     }
   },

--- a/scripts/static_data/durations.py
+++ b/scripts/static_data/durations.py
@@ -1,0 +1,52 @@
+"""Phase 1 review duration helpers shared across the static-data outputs.
+
+Phase 1 duration measures the time from notification to the *Phase 1* outcome.
+The subtlety is mergers that get referred to Phase 2: their published
+``determination_publication_date`` is the eventual Phase 2 determination, weeks
+or months later. Measuring to that date would fold the Phase 2 clock into the
+Phase 1 figure and badly inflate it (e.g. an industry average jumping to ~84
+business days off a single referred matter).
+
+Enrichment already records when Phase 1 actually concluded in
+``phase_1_determination_date`` — the referral date for referred matters, the
+determination date for matters resolved within Phase 1 — so every duration
+output measures to that field via :func:`phase_1_end_date`.
+"""
+
+from .business_days import calculate_business_days, calculate_calendar_days
+from .filters import filter_notifications
+
+
+def phase_1_end_date(m: dict) -> str | None:
+    """ISO date Phase 1 concluded for ``m``, or ``None`` if it hasn't.
+
+    For matters referred to Phase 2 this is the referral date (so the Phase 2
+    clock never inflates Phase 1 durations); for matters resolved within Phase
+    1 it is the determination publication date. Returns ``None`` while Phase 1
+    is still open.
+    """
+    return m.get('phase_1_determination_date')
+
+
+def collect_phase_1_durations(mergers: list) -> tuple[list, list]:
+    """Return ``(calendar_days, business_days)`` for completed Phase 1 reviews.
+
+    Only notification (non-waiver) mergers whose Phase 1 has concluded are
+    counted, measuring notification → Phase 1 end (see :func:`phase_1_end_date`).
+    """
+    calendar_days = []
+    business_days = []
+
+    for m in filter_notifications(mergers):
+        start = m.get('effective_notification_datetime')
+        end = phase_1_end_date(m)
+        if not (start and end):
+            continue
+        cal_days = calculate_calendar_days(start, end)
+        if cal_days is not None:
+            calendar_days.append(cal_days)
+        bus_days = calculate_business_days(start, end)
+        if bus_days is not None:
+            business_days.append(bus_days)
+
+    return calendar_days, business_days

--- a/scripts/static_data/outputs/analysis.py
+++ b/scripts/static_data/outputs/analysis.py
@@ -3,9 +3,8 @@
 from collections import defaultdict
 from statistics import median as stat_median
 
-from constants import merger_status
-
 from ..business_days import calculate_business_days, calculate_calendar_days
+from ..durations import phase_1_end_date
 from ..filters import filter_notifications, filter_waivers
 
 
@@ -21,18 +20,15 @@ def generate(mergers: list) -> dict:
 
     for m in notification_mergers:
         start = m.get('effective_notification_datetime')
-        end = m.get('determination_publication_date')
+        # Measure to the Phase 1 end. For matters referred to Phase 2 this is the
+        # referral date — never the later Phase 2 determination — so referred
+        # matters (whether still in Phase 2 or since concluded) don't inflate the
+        # Phase 1 figures.
+        end = phase_1_end_date(m)
         phase_1_det = m.get('phase_1_determination')
 
-        if not start:
+        if not start or not end:
             continue
-
-        # Include 'Referred to phase 2' mergers using the date the phase 2 notice was issued
-        if not end:
-            if phase_1_det == merger_status.REFERRED_TO_PHASE_2 and m.get('phase_1_determination_date'):
-                end = m['phase_1_determination_date']
-            else:
-                continue
 
         bus_days = calculate_business_days(start, end)
         cal_days = calculate_calendar_days(start, end)

--- a/scripts/static_data/outputs/industries.py
+++ b/scripts/static_data/outputs/industries.py
@@ -12,8 +12,7 @@ from pathlib import Path
 from constants import merger_status
 
 from .. import anzsic
-from ..business_days import calculate_business_days, calculate_calendar_days
-from ..filters import filter_notifications
+from ..durations import collect_phase_1_durations
 
 
 def classify_phase(m: dict) -> str:
@@ -50,23 +49,12 @@ def _median(values: list):
 def _phase_duration(unique_mergers: list) -> dict | None:
     """Phase 1 duration stats for an industry, mirroring the dashboard stats.
 
-    Measures notification → determination for completed notification (non-waiver)
-    mergers. Returns ``None`` when the industry has no completed Phase 1 reviews.
+    Measures notification → Phase 1 end for completed notification (non-waiver)
+    mergers, with matters referred to Phase 2 measured to the referral date so
+    the Phase 2 clock never inflates the figures. Returns ``None`` when the
+    industry has no completed Phase 1 reviews.
     """
-    durations = []
-    business_durations = []
-
-    for m in filter_notifications(unique_mergers):
-        start = m.get('effective_notification_datetime')
-        end = m.get('determination_publication_date')
-        if not (start and end):
-            continue
-        cal_days = calculate_calendar_days(start, end)
-        if cal_days is not None:
-            durations.append(cal_days)
-        bus_days = calculate_business_days(start, end)
-        if bus_days is not None:
-            business_durations.append(bus_days)
+    durations, business_durations = collect_phase_1_durations(unique_mergers)
 
     if not durations and not business_durations:
         return None

--- a/scripts/static_data/outputs/stats.py
+++ b/scripts/static_data/outputs/stats.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 
 from constants import merger_status
 
-from ..business_days import calculate_business_days, calculate_calendar_days
+from ..durations import collect_phase_1_durations
 from ..enrichment import is_phase_2_referral_event
 from ..filters import filter_notifications, filter_waivers
 
@@ -38,22 +38,10 @@ def generate(mergers: list) -> dict:
         if det:
             by_waiver_determination[det] += 1
 
-    # Phase durations (notifications only)
-    durations = []
-    business_durations = []
-
-    for m in notification_mergers:
-        start = m.get('effective_notification_datetime')
-        end = m.get('determination_publication_date')
-
-        if start and end:
-            cal_days = calculate_calendar_days(start, end)
-            if cal_days is not None:
-                durations.append(cal_days)
-
-            bus_days = calculate_business_days(start, end)
-            if bus_days is not None:
-                business_durations.append(bus_days)
+    # Phase 1 durations (notifications only). Matters referred to Phase 2 are
+    # measured to the referral date, not the later Phase 2 determination, so the
+    # Phase 2 clock never inflates the Phase 1 figures.
+    durations, business_durations = collect_phase_1_durations(notification_mergers)
 
     avg_duration = sum(durations) / len(durations) if durations else None
     median_duration = sorted(durations)[len(durations) // 2] if durations else None

--- a/scripts/tests/test_static_data_outputs.py
+++ b/scripts/tests/test_static_data_outputs.py
@@ -319,6 +319,76 @@ class TestIndustriesDetailFiles:
             transport = json.load(f)
         assert transport['phase_duration'] is None
 
+
+# ---------------------------------------------------------------------------
+# Phase 1 duration (shared across stats / industries / analysis)
+# ---------------------------------------------------------------------------
+
+def _referred_then_completed_phase_2_raw():
+    """A matter referred to Phase 2 whose Phase 2 has since concluded.
+
+    Its published determination is the *Phase 2* outcome months after
+    notification; Phase 1 ended at the referral on 2026-01-20.
+    """
+    return {
+        'merger_id': 'MN-7000',
+        'merger_name': 'Referred then approved at Phase 2',
+        'status': 'Assessment completed',
+        'accc_determination': 'Approved',
+        'stage': 'Phase 2 - detailed assessment',
+        'effective_notification_datetime': '2025-10-10T12:00:00Z',
+        'determination_publication_date': '2026-06-02T12:00:00Z',
+        'page_modified_datetime': '2026-06-02T12:30:00Z',
+        'anzsic_codes': [{'code': '0600', 'name': 'Mining'}],
+        'acquirers': ['Nu'],
+        'targets': ['Xi'],
+        'other_parties': [],
+        'url': 'https://example.com/MN-7000',
+        'events': [
+            {'title': 'Merger notified to ACCC', 'date': '2025-10-10T12:00:00Z'},
+            {'title': 'Decision to Proceed to a Phase 2 review', 'date': '2026-01-20T12:00:00Z'},
+            {'title': 'Phase 2 - Determination', 'date': '2026-06-02T12:00:00Z'},
+        ],
+    }
+
+
+class TestPhase1DurationExcludesPhase2Clock:
+    """A Phase-2-referred matter must be measured to the referral date, never
+    to the later Phase 2 determination, which would inflate Phase 1 durations.
+    """
+
+    def test_collect_uses_referral_date_not_phase_2_determination(self):
+        from static_data.business_days import (
+            calculate_business_days,
+            calculate_calendar_days,
+        )
+        from static_data.durations import collect_phase_1_durations
+
+        enriched = enrich_merger(_referred_then_completed_phase_2_raw())
+        cal, bus = collect_phase_1_durations([enriched])
+
+        # Phase 1 ran notification → referral (2025-10-10 → 2026-01-20), not
+        # notification → Phase 2 determination (→ 2026-06-02).
+        assert bus == [calculate_business_days('2025-10-10T12:00:00Z', '2026-01-20T12:00:00Z')]
+        assert cal == [calculate_calendar_days('2025-10-10T12:00:00Z', '2026-01-20T12:00:00Z')]
+
+    def test_stats_phase_duration_not_inflated(self):
+        enriched = enrich_merger(_referred_then_completed_phase_2_raw())
+        payload = stats.generate([enriched])
+        # The full notification → Phase 2 span is ~165 business days; Phase 1
+        # alone is well under the 30-business-day statutory window plus the
+        # Christmas shutdown — comfortably below 80.
+        assert payload['phase_duration']['average_business_days'] < 80
+
+    def test_industries_phase_duration_counts_referred_matter(self, tmp_path):
+        industries.generate_detail_files([enrich_merger(_referred_then_completed_phase_2_raw())], tmp_path)
+        with open(tmp_path / 'industries' / '0600.json') as f:
+            mining = json.load(f)
+        # The referred matter has a concluded Phase 1, so it is counted...
+        assert mining['phase_duration']['completed_count'] == 1
+        # ...but at its Phase 1 length, not the Phase 2 span.
+        assert mining['phase_duration']['average_business_days'] < 80
+
     def test_untouched_node_has_empty_payload(self, tmp_path):
         industries.generate_detail_files(_enriched_fixture(), tmp_path)
         # 0801 (Iron Ore Mining) has no mergers but still gets a browsable page.


### PR DESCRIPTION
Phase 1 duration was measured to determination_publication_date, which for
matters referred to Phase 2 is the eventual Phase 2 determination — folding
the Phase 2 clock into the Phase 1 figure. A single completed Phase 2 matter
pushed industry 4110's average to 83.5 business days (median 148).

Measure Phase 1 to phase_1_determination_date instead (the referral date for
referred matters, the determination date otherwise), via a shared
collect_phase_1_durations helper used by the stats, industries and analysis
outputs. analysis already did this for in-progress referrals but reverted to
the Phase 2 date once Phase 2 concluded; it is now consistent.

Industry 4110 now reports a 35.7 business-day average (median 30).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JcP4QLqCUNjYcNkgwuQxLJ