### PR TITLE
Catch one-day-apart duplicate events in detect_duplicates

### DIFF
--- a/scripts/detect_duplicates.py
+++ b/scripts/detect_duplicates.py
@@ -115,6 +115,26 @@ def parse_date(raw: str):
         return None
 
 
+def dates_within_one_day(date1: str, date2: str) -> bool:
+    """Return True if two YYYY-MM-DD strings are the same day or one day apart.
+
+    The ACCC sometimes re-publishes a document under a slightly different date:
+    an event that first appears dated 20 Jan can reappear dated 21 Jan when the
+    attachment is re-uploaded under a new version (e.g. MN-01019's Phase 2
+    review notice). Allowing a ±1 day tolerance in the LIKELY pass lets these
+    near-duplicate events be grouped. Mirrors the tolerance applied in
+    extract_mergers._dates_within_one_day for synthetic determination events.
+    """
+    if not date1 or not date2:
+        return False
+    try:
+        d1 = datetime.strptime(date1, "%Y-%m-%d").date()
+        d2 = datetime.strptime(date2, "%Y-%m-%d").date()
+    except ValueError:
+        return date1 == date2
+    return abs((d1 - d2).days) <= 1
+
+
 def find_duplicates(merger: dict) -> list[dict]:
     """
     Return a list of duplicate groups for one merger.
@@ -157,6 +177,8 @@ def find_duplicates(merger: dict) -> list[dict]:
     checked: set[tuple[int, int]] = set()
 
     for i in remaining:
+        if i in used:
+            continue
         ev_i = events[i]
         date_i = parse_date(ev_i.get("date", ""))
         title_i = ev_i.get("title", "")
@@ -164,7 +186,7 @@ def find_duplicates(merger: dict) -> list[dict]:
             continue
         group_indices = [i]
         for j in remaining:
-            if j == i or (min(i, j), max(i, j)) in checked:
+            if j == i or j in used or (min(i, j), max(i, j)) in checked:
                 continue
             ev_j = events[j]
             date_j = parse_date(ev_j.get("date", ""))
@@ -172,7 +194,7 @@ def find_duplicates(merger: dict) -> list[dict]:
             if not date_j or not title_j:
                 continue
             if (
-                date_i == date_j
+                dates_within_one_day(date_i, date_j)
                 and not titles_are_different_event_types(title_i, title_j)
                 and title_similarity(title_i, title_j) >= SIMILARITY_THRESHOLD
             ):

--- a/scripts/tests/test_detect_duplicates.py
+++ b/scripts/tests/test_detect_duplicates.py
@@ -1,0 +1,107 @@
+"""Tests for event-level duplicate detection (``detect_duplicates``).
+
+Focus on the LIKELY pass's ±1 day tolerance, which catches the case where the
+ACCC re-publishes a document under a new version and a slightly shifted date
+(e.g. MN-01019's Phase 2 review notice appearing on both 20 and 21 Jan).
+"""
+
+import os
+import sys
+
+# Add scripts directory to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from detect_duplicates import dates_within_one_day, find_duplicates
+
+
+def _kinds(groups):
+    return {g["kind"] for g in groups}
+
+
+def test_dates_within_one_day_tolerance():
+    assert dates_within_one_day("2026-01-20", "2026-01-20") is True
+    assert dates_within_one_day("2026-01-20", "2026-01-21") is True
+    assert dates_within_one_day("2026-01-21", "2026-01-20") is True
+    assert dates_within_one_day("2026-01-20", "2026-01-22") is False
+    assert dates_within_one_day("2026-01-20", "") is False
+    # Month boundary
+    assert dates_within_one_day("2026-01-31", "2026-02-01") is True
+
+
+def test_phase2_referral_reupload_one_day_apart_is_likely_duplicate():
+    """The Ampol case: same title, dates one day apart after a re-upload."""
+    merger = {
+        "merger_id": "MN-01019",
+        "events": [
+            {
+                "date": "2026-01-20T12:00:00Z",
+                "title": "ACCC decided notification is subject to Phase 2 review",
+                "url": "https://accc.gov.au/.../Phase 2 Notice - Redacted_4.pdf",
+                "status": "removed",
+            },
+            {
+                "date": "2026-01-21T12:00:00Z",
+                "title": "ACCC decided notification is subject to Phase 2 review",
+                "url": "https://accc.gov.au/.../Phase 2 Notice - Redacted_7.pdf",
+                "status": "live",
+            },
+        ],
+    }
+    groups = find_duplicates(merger)
+    assert len(groups) == 1
+    assert groups[0]["kind"] == "likely"
+    assert set(groups[0]["indices"]) == {0, 1}
+
+
+def test_exact_duplicate_still_certain():
+    """Identical (date, title) pairs are still reported as CERTAIN, not LIKELY."""
+    merger = {
+        "merger_id": "MN-1",
+        "events": [
+            {"date": "2026-01-20T12:00:00Z", "title": "Statement of Issues"},
+            {"date": "2026-01-20T12:00:00Z", "title": "Statement of Issues"},
+        ],
+    }
+    groups = find_duplicates(merger)
+    assert len(groups) == 1
+    assert groups[0]["kind"] == "certain"
+
+
+def test_different_event_types_one_day_apart_not_grouped():
+    """The tolerance must not group genuinely distinct documents."""
+    merger = {
+        "merger_id": "MN-2",
+        "events": [
+            {"date": "2026-01-20T12:00:00Z", "title": "Questionnaire - Acme - Beta"},
+            {"date": "2026-01-21T12:00:00Z", "title": "Remedy offer - Acme - Beta"},
+        ],
+    }
+    assert find_duplicates(merger) == []
+
+
+def test_two_days_apart_not_grouped():
+    """Beyond the ±1 day window, same-title events are left alone."""
+    merger = {
+        "merger_id": "MN-3",
+        "events": [
+            {"date": "2026-01-20T12:00:00Z", "title": "ACCC decided notification is subject to Phase 2 review"},
+            {"date": "2026-01-22T12:00:00Z", "title": "ACCC decided notification is subject to Phase 2 review"},
+        ],
+    }
+    assert find_duplicates(merger) == []
+
+
+def test_three_consecutive_days_no_overlapping_groups():
+    """Non-transitive tolerance must not emit overlapping groups that share an index."""
+    merger = {
+        "merger_id": "MN-4",
+        "events": [
+            {"date": "2026-01-20T12:00:00Z", "title": "ACCC decided notification is subject to Phase 2 review"},
+            {"date": "2026-01-21T12:00:00Z", "title": "ACCC decided notification is subject to Phase 2 review"},
+            {"date": "2026-01-22T12:00:00Z", "title": "ACCC decided notification is subject to Phase 2 review"},
+        ],
+    }
+    groups = find_duplicates(merger)
+    # 20-21 group, leaving 22 ungrouped (22 is >1 day from the anchor 20).
+    all_indices = [i for g in groups for i in g["indices"]]
+    assert len(all_indices) == len(set(all_indices)), "events appear in more than one group"

--- a/scripts/tests/test_resolver.py
+++ b/scripts/tests/test_resolver.py
@@ -225,10 +225,14 @@ class TestFindDuplicates:
         assert set(groups[0]['indices']) == {0, 1}
 
     def test_different_dates_not_duplicates(self):
+        # Dates more than one day apart are not grouped. (Same-title events
+        # within ±1 day ARE now grouped as likely duplicates — see
+        # test_detect_duplicates.py — to catch ACCC re-uploads that shift the
+        # date by a day.)
         merger = {
             'events': [
                 {'date': '2025-01-01T00:00:00Z', 'title': 'Notification'},
-                {'date': '2025-01-02T00:00:00Z', 'title': 'Notification'},
+                {'date': '2025-01-05T00:00:00Z', 'title': 'Notification'},
             ]
         }
         assert find_duplicates(merger) == []


### PR DESCRIPTION
The LIKELY pass compared event dates with strict equality, so when the
ACCC re-publishes a document under a new version with a date shifted by
a day (e.g. MN-01019's Phase 2 review notice appearing on both 20 and
21 Jan), the stale 'removed' event and its live replacement were never
grouped as duplicates.

Apply a +/-1 day tolerance to the LIKELY pass (mirroring
extract_mergers._dates_within_one_day, already used for synthetic
determination events), and guard against the non-transitive tolerance
emitting overlapping groups. The CERTAIN pass stays exact.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Nocss6LFRokdVvnFs2V1oV