### PR TITLE
Strip _bhlid tracking param in clean_file

### DIFF
--- a/scripts/scrape.sh
+++ b/scripts/scrape.sh
@@ -83,6 +83,7 @@ clean_file() {
     s/("css_js_query_string":")[^"\n]+"/${1}STATIC"/g;
     s/ct=t%28[^"\\]*%29\\u0026//g;
     s/acccCrmDataPullChildSyncOnLoad=[^"\\]*\\u0026//g;
+    s/_bhlid=[^"\\]*\\u0026//g;
     s/[ \t]*\n[ \t]*<script>!function\(e\)\{var n="https:\/\/s\.go-mpulse\.net\/boomerang\/".*?\(window\);<\/script><\/head>/\n  <\/head>/s;
     s{(<meta name="dcterms\.modified"[^\n]*/>\n)(<meta name="dcterms\.created"[^\n]*/>\n)}{$2$1}g;
     s{(<link rel="canonical"[^\n]*/>\n)(<link rel="shortlink"[^\n]*/>\n)}{$2$1}g;


### PR DESCRIPTION
The _bhlid marketing click-tracking parameter appears intermittently in
the drupal-settings-json ajaxTrustedUrl/ajax URLs, flip-flopping between
?_bhlid=<hash>\u0026ajax_form=1 and ?ajax_form=1 across scrape runs and
producing recurring noisy diffs (e.g. WA-15023.html in a2b3662).

Add a strip rule mirroring the existing ct= and
acccCrmDataPullChildSyncOnLoad= \u0026-suffixed rules. Verified the rule
reproduces the cleaned committed state byte-for-byte.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01G56FjxtGMQT9s7E2nFDePy