### PR TITLE
fix: keep attachment when ACCC drops an event's document link

### DIFF
--- a/data/processed/mergers.json
+++ b/data/processed/mergers.json
@@ -7915,7 +7915,7 @@
         "display_title": "ACCC decided notification is subject to Phase 2 review",
         "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/MN%2030003%20-%20UPDATED%20MicroStar_Konvoy%20-%20Phase%202%20notice%20-%201%20April%202026_1.pdf",
         "url_gh": "/mergers/MN-30003/MN 30003 - UPDATED MicroStar_Konvoy - Phase 2 notice - 1 April 2026_1.pdf",
-        "status": "removed"
+        "status": "live"
       },
       {
         "date": "2026-06-24T12:00:00Z",
@@ -7940,11 +7940,6 @@
         "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/MN-30003%20MicroStar%20Konvoy%20-%20Notice%20of%20Competition%20Concerns%20%28summary%29%20-%2013%20May%202026_0.pdf",
         "url_gh": "/mergers/MN-30003/MN-30003 MicroStar Konvoy - Notice of Competition Concerns (summary) - 13 May 2026_0.pdf",
         "status": "live"
-      },
-      {
-        "date": "2026-04-01T12:00:00Z",
-        "title": "ACCC decided notification is subject to Phase 2 review",
-        "display_title": "ACCC decided notification is subject to Phase 2 review"
       }
     ],
     "is_waiver": false

--- a/scripts/extract_mergers.py
+++ b/scripts/extract_mergers.py
@@ -522,8 +522,28 @@ def _merge_events(scraped_events, existing_merger_data, merger_id, frozen_events
                 merged_events.append(updated_event)
                 existing_urls_processed.add(url)
             else:
-                existing_event['status'] = 'removed'
-                merged_events.append(existing_event)
+                # The document link is gone from the scraped page. The ACCC
+                # sometimes drops an event's attachment but keeps the event
+                # itself as a plain (URL-less) timeline row. Without this match
+                # the existing event would be flagged 'removed' AND the URL-less
+                # row appended as a separate event, producing a duplicate that
+                # reappears on every scrape (e.g. MN-30003's "subject to Phase 2
+                # review"). Re-bind that timeline row to the existing event so we
+                # keep the attachment we previously captured.
+                replacement_row = next(
+                    (e for e in scraped_without_url
+                     if e.get('title') == existing_event.get('title')
+                     and _dates_within_one_day(
+                         e.get('date', ''), existing_event.get('date', ''))),
+                    None,
+                )
+                if replacement_row is not None:
+                    existing_event['status'] = 'live'
+                    merged_events.append(existing_event)
+                    scraped_without_url.remove(replacement_row)
+                else:
+                    existing_event['status'] = 'removed'
+                    merged_events.append(existing_event)
         else:
             matching_scraped = next(
                 (e for e in scraped_without_url if e['title'] == existing_event['title']),

--- a/scripts/tests/test_pipeline.py
+++ b/scripts/tests/test_pipeline.py
@@ -28,9 +28,74 @@ from extract_mergers import (
     detect_inferred_phase_2,
     _infer_determination_date_from_events,
     _extract_anzsic_codes,
+    _merge_events,
 )
 import extract_mergers
 from bs4 import BeautifulSoup
+
+
+# ---------------------------------------------------------------------------
+# _merge_events: attachment preservation when ACCC drops a document link
+# ---------------------------------------------------------------------------
+
+class TestMergeEventsAttachmentDropped:
+    """When the ACCC removes an event's document link but keeps the event as a
+    plain (URL-less) timeline row, the previously captured attachment must be
+    preserved on a single event rather than spawning a recurring duplicate.
+
+    This is the MN-30003 "subject to Phase 2 review" case: a dedup PR that just
+    deletes the URL-less copy is undone by the next scrape because the row keeps
+    reappearing. Re-binding it to the existing event fixes the loop at source.
+    """
+
+    TITLE = "ACCC decided notification is subject to Phase 2 review"
+
+    def _existing(self):
+        return {
+            "events": [
+                {
+                    "date": "2026-04-01T12:00:00Z",
+                    "title": self.TITLE,
+                    "display_title": self.TITLE,
+                    "url": "https://accc.gov.au/.../phase-2-notice.pdf",
+                    "url_gh": "/mergers/MN-30003/phase-2-notice.pdf",
+                    "status": "live",
+                },
+            ],
+        }
+
+    def test_urlless_row_rebinds_to_attachment_event(self):
+        # The page now shows the event only as a plain timeline row (no link).
+        scraped = [{"date": "2026-04-01T12:00:00Z", "title": self.TITLE}]
+        merged = _merge_events(scraped, self._existing(), "MN-30003", set())
+
+        assert len(merged) == 1, "no duplicate should be created"
+        ev = merged[0]
+        assert ev["url_gh"] == "/mergers/MN-30003/phase-2-notice.pdf"
+        assert ev["url"] == "https://accc.gov.au/.../phase-2-notice.pdf"
+        assert ev["status"] == "live", "event is still on the page, not removed"
+
+    def test_one_day_date_shift_still_rebinds(self):
+        scraped = [{"date": "2026-04-02T12:00:00Z", "title": self.TITLE}]
+        merged = _merge_events(scraped, self._existing(), "MN-30003", set())
+        assert len(merged) == 1
+        assert merged[0]["url_gh"] == "/mergers/MN-30003/phase-2-notice.pdf"
+        assert merged[0]["status"] == "live"
+
+    def test_event_truly_gone_is_marked_removed(self):
+        # No matching timeline row: the event really disappeared from the page.
+        scraped = [{"date": "2026-05-01T12:00:00Z", "title": "Some other event"}]
+        merged = _merge_events(scraped, self._existing(), "MN-30003", set())
+        statuses = {e["title"]: e.get("status") for e in merged}
+        assert statuses[self.TITLE] == "removed"
+
+    def test_different_title_row_not_consumed(self):
+        # A genuinely different URL-less event must remain a separate event and
+        # the attachment event is marked removed (its link is gone, no rebind).
+        scraped = [{"date": "2026-04-01T12:00:00Z", "title": "Merger notified to ACCC"}]
+        merged = _merge_events(scraped, self._existing(), "MN-30003", set())
+        titles = sorted(e["title"] for e in merged)
+        assert titles == sorted([self.TITLE, "Merger notified to ACCC"])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
When the ACCC removes the document link from an event but keeps the event
itself as a plain (URL-less) timeline row, _merge_events marked the existing
attachment-bearing event 'removed' and appended the URL-less row as a separate
event. That produced a duplicate the scraper re-created on every run, so the
duplicate-event dedup PR (which only deletes from mergers.json) was undone by
the very next "Update merger data" commit (MN-30003's "subject to Phase 2
review").

_merge_events now re-binds the URL-less timeline row to the existing event
(matching on title and a +/-1 day date), preserving the previously captured
attachment and keeping the event 'live' instead of spawning a duplicate. This
mirrors the existing determination-event de-dup at line ~704. Also corrects the
current MN-30003 data: single event, attachment kept, status live.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ATokYMyrJtahPhEuwaDghM