### PR TITLE
Match recently notified merger cards to recent determinations

### DIFF
--- a/merger-tracker/frontend/src/components/RecentMergersCards.jsx
+++ b/merger-tracker/frontend/src/components/RecentMergersCards.jsx
@@ -2,19 +2,8 @@ import { Link } from 'react-router-dom';
 import { mergerPath } from '../utils/slug';
 import { formatDate } from '../utils/dates';
 import { isNewItem } from '../utils/lastVisit';
-import StatusBadge from './StatusBadge';
-import NewBadge from './NewBadge';
-import WaiverBadge from './WaiverBadge';
+import { getCardStyle } from '../constants/cardStyles';
 import CardCollapseGrid from './CardCollapseGrid';
-
-// A clean white card outlined in primary (dark green). The status colour is
-// carried by the inline StatusBadge rather than the surface, so the section
-// stays calm even when every merger shares the same status.
-const CARD_STYLE = {
-  bg: 'bg-white border border-primary/40 hover:border-primary',
-  text: 'text-gray-900',
-  sub: 'text-gray-500',
-};
 
 function RecentMergersCards({ mergers }) {
   if (!mergers || mergers.length === 0) {
@@ -39,29 +28,43 @@ function RecentMergersCards({ mergers }) {
       <CardCollapseGrid
         items={mergers}
         getKey={(merger) => merger.merger_id}
-        getStyle={() => CARD_STYLE}
+        getStyle={(merger) =>
+          getCardStyle({
+            determination: merger.accc_determination,
+            status: merger.status,
+          })
+        }
         renderBody={(merger, style) => (
           <>
             <div className="flex items-start justify-between gap-2">
-              <StatusBadge
-                status={merger.status}
-                determination={merger.accc_determination}
-              />
-              {isNewItem(merger.merger_id) && <NewBadge />}
+              <span className="text-xs font-semibold uppercase tracking-wide">
+                {merger.accc_determination || merger.status}
+              </span>
+              {isNewItem(merger.merger_id) && (
+                <span className={`inline-flex items-center rounded-md px-2 py-0.5 text-xs font-semibold ${style.chip}`}>
+                  New
+                </span>
+              )}
             </div>
             <Link
               to={mergerPath(merger.merger_id, merger.merger_name)}
-              className={`mt-2 text-sm font-semibold leading-snug hover:text-primary after:absolute after:inset-0 ${style.text}`}
+              className={`mt-2 text-sm font-semibold leading-snug hover:underline after:absolute after:inset-0 ${style.text}`}
               aria-label={`View merger details for ${merger.merger_name}`}
             >
               {merger.merger_name}
             </Link>
             <div className={`mt-2 flex flex-wrap items-center gap-2 text-xs ${style.sub}`}>
+              <span>{merger.merger_id}</span>
+              <span aria-hidden="true">·</span>
               <span>
                 {merger.is_waiver ? 'Applied' : 'Notified'}{' '}
                 {formatDate(merger.effective_notification_datetime)}
               </span>
-              {merger.is_waiver && <WaiverBadge />}
+              {merger.is_waiver && (
+                <span className={`inline-flex items-center rounded-md px-2 py-0.5 font-medium ${style.chip}`}>
+                  Waiver
+                </span>
+              )}
             </div>
           </>
         )}

--- a/merger-tracker/frontend/src/components/RecentMergersCards.jsx
+++ b/merger-tracker/frontend/src/components/RecentMergersCards.jsx
@@ -2,8 +2,30 @@ import { Link } from 'react-router-dom';
 import { mergerPath } from '../utils/slug';
 import { formatDate } from '../utils/dates';
 import { isNewItem } from '../utils/lastVisit';
+import { MERGER_STATUS } from '../constants/mergerStatus';
 import { getCardStyle } from '../constants/cardStyles';
 import CardCollapseGrid from './CardCollapseGrid';
+
+// Mergers still under assessment stay calm: a white card with a green
+// (primary) border, the inline chips tinted green to sit on the white
+// surface. Anything with a determination (e.g. approved) falls through to
+// getCardStyle so it renders identically to the recent determinations cards.
+const UNDER_ASSESSMENT_STYLE = {
+  bg: 'bg-white border border-primary/40 hover:border-primary',
+  text: 'text-gray-900',
+  sub: 'text-gray-500',
+  chip: 'bg-primary/5 text-primary border border-primary/20',
+};
+
+function getMergerCardStyle(merger) {
+  if (!merger.accc_determination && merger.status === MERGER_STATUS.UNDER_ASSESSMENT) {
+    return UNDER_ASSESSMENT_STYLE;
+  }
+  return getCardStyle({
+    determination: merger.accc_determination,
+    status: merger.status,
+  });
+}
 
 function RecentMergersCards({ mergers }) {
   if (!mergers || mergers.length === 0) {
@@ -28,12 +50,7 @@ function RecentMergersCards({ mergers }) {
       <CardCollapseGrid
         items={mergers}
         getKey={(merger) => merger.merger_id}
-        getStyle={(merger) =>
-          getCardStyle({
-            determination: merger.accc_determination,
-            status: merger.status,
-          })
-        }
+        getStyle={getMergerCardStyle}
         renderBody={(merger, style) => (
           <>
             <div className="flex items-start justify-between gap-2">


### PR DESCRIPTION
Restyle the "Recently notified mergers" cards so their layout and colour
treatment mirror the "Recent determinations" cards:

- Solid-colour card surfaces via getCardStyle (determination takes
  precedence over status), so an approved merger renders identically to
  an approved determination, colour included.
- Status/determination shown as an uppercase label top-left, matching the
  "APPROVED" treatment, so "Under assessment" reads as "UNDER ASSESSMENT".
- Merger id added to the sub-line, in the same position as determinations.
- New/Waiver badges use the on-surface chip styles.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014AteiATP7XA9UhSySNX1yx