### PR TITLE
fix: resolve react-hooks/exhaustive-deps eslint warning in IndustryDetail

### DIFF
--- a/merger-tracker/frontend/src/pages/IndustryDetail.jsx
+++ b/merger-tracker/frontend/src/pages/IndustryDetail.jsx
@@ -59,15 +59,15 @@ function IndustryDetail() {
   // Local free-text filter for the merger list on this page.
   const [mergerSearch, setMergerSearch] = useState('');
 
-  const allMergers = data?.mergers || [];
   const trimmedSearch = mergerSearch.trim().toLowerCase();
   const filteredMergers = useMemo(() => {
+    const allMergers = data?.mergers || [];
     if (!trimmedSearch) return allMergers;
     return allMergers.filter((m) =>
       (m.merger_name || '').toLowerCase().includes(trimmedSearch) ||
       (m.status || '').toLowerCase().includes(trimmedSearch)
     );
-  }, [allMergers, trimmedSearch]);
+  }, [data?.mergers, trimmedSearch]);
 
   const isNotFound = error === 'HTTP 404';
 


### PR DESCRIPTION
Move the allMergers initialization inside the useMemo callback and depend
on data?.mergers directly, so the logical expression no longer recreates
the dependency on every render.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Bd2vXVBxgJJaLU1wLANhs6