### PR TITLE
Add human-readable slugs to industry detail pages

### DIFF
--- a/merger-tracker/frontend/public/sitemap.xml
+++ b/merger-tracker/frontend/public/sitemap.xml
@@ -66,4951 +66,4951 @@
 
   <!-- Individual Industry Detail Pages (full ANZSIC tree) -->
   <url>
-    <loc>https://mergers.fyi/industries/01</loc>
+    <loc>https://mergers.fyi/industries/01/agriculture</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/011</loc>
+    <loc>https://mergers.fyi/industries/011/nursery-and-floriculture-production</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0111</loc>
+    <loc>https://mergers.fyi/industries/0111/nursery-production-under-cover</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0112</loc>
+    <loc>https://mergers.fyi/industries/0112/nursery-production-outdoors</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0113</loc>
+    <loc>https://mergers.fyi/industries/0113/turf-growing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0114</loc>
+    <loc>https://mergers.fyi/industries/0114/floriculture-production-under-cover</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0115</loc>
+    <loc>https://mergers.fyi/industries/0115/floriculture-production-outdoors</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/012</loc>
+    <loc>https://mergers.fyi/industries/012/mushroom-and-vegetable-growing</loc>
     <lastmod>2026-06-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0121</loc>
+    <loc>https://mergers.fyi/industries/0121/mushroom-growing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0122</loc>
+    <loc>https://mergers.fyi/industries/0122/vegetable-growing-under-cover</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0123</loc>
+    <loc>https://mergers.fyi/industries/0123/vegetable-growing-outdoors</loc>
     <lastmod>2026-06-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/013</loc>
+    <loc>https://mergers.fyi/industries/013/fruit-and-tree-nut-growing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0131</loc>
+    <loc>https://mergers.fyi/industries/0131/grape-growing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0132</loc>
+    <loc>https://mergers.fyi/industries/0132/kiwifruit-growing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0133</loc>
+    <loc>https://mergers.fyi/industries/0133/berry-fruit-growing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0134</loc>
+    <loc>https://mergers.fyi/industries/0134/apple-and-pear-growing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0135</loc>
+    <loc>https://mergers.fyi/industries/0135/stone-fruit-growing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0136</loc>
+    <loc>https://mergers.fyi/industries/0136/citrus-fruit-growing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0137</loc>
+    <loc>https://mergers.fyi/industries/0137/olive-growing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0139</loc>
+    <loc>https://mergers.fyi/industries/0139/other-fruit-and-tree-nut-growing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/014</loc>
+    <loc>https://mergers.fyi/industries/014/sheep-beef-cattle-and-grain-farming</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0141</loc>
+    <loc>https://mergers.fyi/industries/0141/sheep-farming-specialised</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0142</loc>
+    <loc>https://mergers.fyi/industries/0142/beef-cattle-farming-specialised</loc>
     <lastmod>2026-04-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0143</loc>
+    <loc>https://mergers.fyi/industries/0143/beef-cattle-feedlots-specialised</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0144</loc>
+    <loc>https://mergers.fyi/industries/0144/sheep-beef-cattle-farming</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0145</loc>
+    <loc>https://mergers.fyi/industries/0145/grain-sheep-or-grain-beef-cattle-farming</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0146</loc>
+    <loc>https://mergers.fyi/industries/0146/rice-growing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0149</loc>
+    <loc>https://mergers.fyi/industries/0149/other-grain-growing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/015</loc>
+    <loc>https://mergers.fyi/industries/015/other-crop-growing</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0151</loc>
+    <loc>https://mergers.fyi/industries/0151/sugar-cane-growing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0152</loc>
+    <loc>https://mergers.fyi/industries/0152/cotton-growing</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0159</loc>
+    <loc>https://mergers.fyi/industries/0159/other-crop-growing-n-e-c</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/016</loc>
+    <loc>https://mergers.fyi/industries/016/dairy-cattle-farming</loc>
     <lastmod>2026-04-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0160</loc>
+    <loc>https://mergers.fyi/industries/0160/dairy-cattle-farming</loc>
     <lastmod>2026-04-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/017</loc>
+    <loc>https://mergers.fyi/industries/017/poultry-farming</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0171</loc>
+    <loc>https://mergers.fyi/industries/0171/poultry-farming-meat</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0172</loc>
+    <loc>https://mergers.fyi/industries/0172/poultry-farming-eggs</loc>
     <lastmod>2026-03-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/018</loc>
+    <loc>https://mergers.fyi/industries/018/deer-farming</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0180</loc>
+    <loc>https://mergers.fyi/industries/0180/deer-farming</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/019</loc>
+    <loc>https://mergers.fyi/industries/019/other-livestock-farming</loc>
     <lastmod>2026-03-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0191</loc>
+    <loc>https://mergers.fyi/industries/0191/horse-farming</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0192</loc>
+    <loc>https://mergers.fyi/industries/0192/pig-farming</loc>
     <lastmod>2026-03-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0193</loc>
+    <loc>https://mergers.fyi/industries/0193/beekeeping</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0199</loc>
+    <loc>https://mergers.fyi/industries/0199/other-livestock-farming-n-e-c</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/02</loc>
+    <loc>https://mergers.fyi/industries/02/aquaculture</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/020</loc>
+    <loc>https://mergers.fyi/industries/020/aquaculture</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0201</loc>
+    <loc>https://mergers.fyi/industries/0201/offshore-longline-and-rack-aquaculture</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0202</loc>
+    <loc>https://mergers.fyi/industries/0202/offshore-caged-aquaculture</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0203</loc>
+    <loc>https://mergers.fyi/industries/0203/onshore-aquaculture</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/03</loc>
+    <loc>https://mergers.fyi/industries/03/forestry-and-logging</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/030</loc>
+    <loc>https://mergers.fyi/industries/030/forestry-and-logging</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0301</loc>
+    <loc>https://mergers.fyi/industries/0301/forestry</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0302</loc>
+    <loc>https://mergers.fyi/industries/0302/logging</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/04</loc>
+    <loc>https://mergers.fyi/industries/04/fishing-hunting-and-trapping</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/041</loc>
+    <loc>https://mergers.fyi/industries/041/fishing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0411</loc>
+    <loc>https://mergers.fyi/industries/0411/rock-lobster-and-crab-potting</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0412</loc>
+    <loc>https://mergers.fyi/industries/0412/prawn-fishing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0413</loc>
+    <loc>https://mergers.fyi/industries/0413/line-fishing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0414</loc>
+    <loc>https://mergers.fyi/industries/0414/fish-trawling-seining-and-netting</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0419</loc>
+    <loc>https://mergers.fyi/industries/0419/other-fishing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/042</loc>
+    <loc>https://mergers.fyi/industries/042/hunting-and-trapping</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0420</loc>
+    <loc>https://mergers.fyi/industries/0420/hunting-and-trapping</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/05</loc>
+    <loc>https://mergers.fyi/industries/05/agriculture-forestry-and-fishing-support-services</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/051</loc>
+    <loc>https://mergers.fyi/industries/051/forestry-support-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0510</loc>
+    <loc>https://mergers.fyi/industries/0510/forestry-support-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/052</loc>
+    <loc>https://mergers.fyi/industries/052/agriculture-and-fishing-support-services</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0521</loc>
+    <loc>https://mergers.fyi/industries/0521/cotton-ginning</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0522</loc>
+    <loc>https://mergers.fyi/industries/0522/shearing-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0529</loc>
+    <loc>https://mergers.fyi/industries/0529/other-agriculture-and-fishing-support-services</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/06</loc>
+    <loc>https://mergers.fyi/industries/06/coal-mining</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/060</loc>
+    <loc>https://mergers.fyi/industries/060/coal-mining</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0600</loc>
+    <loc>https://mergers.fyi/industries/0600/coal-mining</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/07</loc>
+    <loc>https://mergers.fyi/industries/07/oil-and-gas-extraction</loc>
     <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/070</loc>
+    <loc>https://mergers.fyi/industries/070/oil-and-gas-extraction</loc>
     <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0700</loc>
+    <loc>https://mergers.fyi/industries/0700/oil-and-gas-extraction</loc>
     <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/08</loc>
+    <loc>https://mergers.fyi/industries/08/metal-ore-mining</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/080</loc>
+    <loc>https://mergers.fyi/industries/080/metal-ore-mining</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0801</loc>
+    <loc>https://mergers.fyi/industries/0801/iron-ore-mining</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0802</loc>
+    <loc>https://mergers.fyi/industries/0802/bauxite-mining</loc>
     <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0803</loc>
+    <loc>https://mergers.fyi/industries/0803/copper-ore-mining</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0804</loc>
+    <loc>https://mergers.fyi/industries/0804/gold-ore-mining</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0805</loc>
+    <loc>https://mergers.fyi/industries/0805/mineral-sand-mining</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0806</loc>
+    <loc>https://mergers.fyi/industries/0806/nickel-ore-mining</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0807</loc>
+    <loc>https://mergers.fyi/industries/0807/silver-lead-zinc-ore-mining</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0809</loc>
+    <loc>https://mergers.fyi/industries/0809/other-metal-ore-mining</loc>
     <lastmod>2026-05-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/09</loc>
+    <loc>https://mergers.fyi/industries/09/non-metallic-mineral-mining-and-quarrying</loc>
     <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/091</loc>
+    <loc>https://mergers.fyi/industries/091/construction-material-mining</loc>
     <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0911</loc>
+    <loc>https://mergers.fyi/industries/0911/gravel-and-sand-quarrying</loc>
     <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0919</loc>
+    <loc>https://mergers.fyi/industries/0919/other-construction-material-mining</loc>
     <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/099</loc>
+    <loc>https://mergers.fyi/industries/099/other-non-metallic-mineral-mining-and-quarrying</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/0990</loc>
+    <loc>https://mergers.fyi/industries/0990/other-non-metallic-mineral-mining-and-quarrying</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/10</loc>
+    <loc>https://mergers.fyi/industries/10/exploration-and-other-mining-support-services</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/101</loc>
+    <loc>https://mergers.fyi/industries/101/exploration</loc>
     <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1011</loc>
+    <loc>https://mergers.fyi/industries/1011/petroleum-exploration</loc>
     <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1012</loc>
+    <loc>https://mergers.fyi/industries/1012/mineral-exploration</loc>
     <lastmod>2026-03-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/109</loc>
+    <loc>https://mergers.fyi/industries/109/other-mining-support-services</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1090</loc>
+    <loc>https://mergers.fyi/industries/1090/other-mining-support-services</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/11</loc>
+    <loc>https://mergers.fyi/industries/11/food-product-manufacturing</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/111</loc>
+    <loc>https://mergers.fyi/industries/111/meat-and-meat-product-manufacturing</loc>
     <lastmod>2026-06-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1111</loc>
+    <loc>https://mergers.fyi/industries/1111/meat-processing</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1112</loc>
+    <loc>https://mergers.fyi/industries/1112/poultry-processing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1113</loc>
+    <loc>https://mergers.fyi/industries/1113/cured-meat-and-smallgoods-manufacturing</loc>
     <lastmod>2026-06-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/112</loc>
+    <loc>https://mergers.fyi/industries/112/seafood-processing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1120</loc>
+    <loc>https://mergers.fyi/industries/1120/seafood-processing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/113</loc>
+    <loc>https://mergers.fyi/industries/113/dairy-product-manufacturing</loc>
     <lastmod>2026-01-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1131</loc>
+    <loc>https://mergers.fyi/industries/1131/milk-and-cream-processing</loc>
     <lastmod>2026-01-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1132</loc>
+    <loc>https://mergers.fyi/industries/1132/ice-cream-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1133</loc>
+    <loc>https://mergers.fyi/industries/1133/cheese-and-other-dairy-product-manufacturing</loc>
     <lastmod>2026-01-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/114</loc>
+    <loc>https://mergers.fyi/industries/114/fruit-and-vegetable-processing</loc>
     <lastmod>2026-06-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1140</loc>
+    <loc>https://mergers.fyi/industries/1140/fruit-and-vegetable-processing</loc>
     <lastmod>2026-06-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/115</loc>
+    <loc>https://mergers.fyi/industries/115/oil-and-fat-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1150</loc>
+    <loc>https://mergers.fyi/industries/1150/oil-and-fat-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/116</loc>
+    <loc>https://mergers.fyi/industries/116/grain-mill-and-cereal-product-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1161</loc>
+    <loc>https://mergers.fyi/industries/1161/grain-mill-product-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1162</loc>
+    <loc>https://mergers.fyi/industries/1162/cereal-pasta-and-baking-mix-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/117</loc>
+    <loc>https://mergers.fyi/industries/117/bakery-product-manufacturing</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1171</loc>
+    <loc>https://mergers.fyi/industries/1171/bread-manufacturing-factory-based</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1172</loc>
+    <loc>https://mergers.fyi/industries/1172/cake-and-pastry-manufacturing-factory-based</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1173</loc>
+    <loc>https://mergers.fyi/industries/1173/biscuit-manufacturing-factory-based</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1174</loc>
+    <loc>https://mergers.fyi/industries/1174/bakery-product-manufacturing-non-factory-based</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/118</loc>
+    <loc>https://mergers.fyi/industries/118/sugar-and-confectionery-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1181</loc>
+    <loc>https://mergers.fyi/industries/1181/sugar-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1182</loc>
+    <loc>https://mergers.fyi/industries/1182/confectionery-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/119</loc>
+    <loc>https://mergers.fyi/industries/119/other-food-product-manufacturing</loc>
     <lastmod>2026-06-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1191</loc>
+    <loc>https://mergers.fyi/industries/1191/potato-corn-and-other-crisp-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1192</loc>
+    <loc>https://mergers.fyi/industries/1192/prepared-animal-and-bird-feed-manufacturing</loc>
     <lastmod>2026-06-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1199</loc>
+    <loc>https://mergers.fyi/industries/1199/other-food-product-manufacturing-n-e-c</loc>
     <lastmod>2026-04-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/12</loc>
+    <loc>https://mergers.fyi/industries/12/beverage-and-tobacco-product-manufacturing</loc>
     <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/121</loc>
+    <loc>https://mergers.fyi/industries/121/beverage-manufacturing</loc>
     <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1211</loc>
+    <loc>https://mergers.fyi/industries/1211/soft-drink-cordial-and-syrup-manufacturing</loc>
     <lastmod>2025-11-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1212</loc>
+    <loc>https://mergers.fyi/industries/1212/beer-manufacturing</loc>
     <lastmod>2025-11-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1213</loc>
+    <loc>https://mergers.fyi/industries/1213/spirit-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1214</loc>
+    <loc>https://mergers.fyi/industries/1214/wine-and-other-alcoholic-beverage-manufacturing</loc>
     <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/122</loc>
+    <loc>https://mergers.fyi/industries/122/cigarette-and-tobacco-product-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1220</loc>
+    <loc>https://mergers.fyi/industries/1220/cigarette-and-tobacco-product-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/13</loc>
+    <loc>https://mergers.fyi/industries/13/textile-leather-clothing-and-footwear-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/131</loc>
+    <loc>https://mergers.fyi/industries/131/textile-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1311</loc>
+    <loc>https://mergers.fyi/industries/1311/wool-scouring</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1312</loc>
+    <loc>https://mergers.fyi/industries/1312/natural-textile-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1313</loc>
+    <loc>https://mergers.fyi/industries/1313/synthetic-textile-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/132</loc>
+    <loc>https://mergers.fyi/industries/132/leather-tanning-fur-dressing-and-leather-product-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1320</loc>
+    <loc>https://mergers.fyi/industries/1320/leather-tanning-fur-dressing-and-leather-product-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/133</loc>
+    <loc>https://mergers.fyi/industries/133/textile-product-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1331</loc>
+    <loc>https://mergers.fyi/industries/1331/textile-floor-covering-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1332</loc>
+    <loc>https://mergers.fyi/industries/1332/rope-cordage-and-twine-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1333</loc>
+    <loc>https://mergers.fyi/industries/1333/cut-and-sewn-textile-product-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1334</loc>
+    <loc>https://mergers.fyi/industries/1334/textile-finishing-and-other-textile-product-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/134</loc>
+    <loc>https://mergers.fyi/industries/134/knitted-product-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1340</loc>
+    <loc>https://mergers.fyi/industries/1340/knitted-product-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/135</loc>
+    <loc>https://mergers.fyi/industries/135/clothing-and-footwear-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1351</loc>
+    <loc>https://mergers.fyi/industries/1351/clothing-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1352</loc>
+    <loc>https://mergers.fyi/industries/1352/footwear-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/14</loc>
+    <loc>https://mergers.fyi/industries/14/wood-product-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/141</loc>
+    <loc>https://mergers.fyi/industries/141/log-sawmilling-and-timber-dressing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1411</loc>
+    <loc>https://mergers.fyi/industries/1411/log-sawmilling</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1412</loc>
+    <loc>https://mergers.fyi/industries/1412/wood-chipping</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1413</loc>
+    <loc>https://mergers.fyi/industries/1413/timber-resawing-and-dressing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/149</loc>
+    <loc>https://mergers.fyi/industries/149/other-wood-product-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1491</loc>
+    <loc>https://mergers.fyi/industries/1491/prefabricated-wooden-building-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1492</loc>
+    <loc>https://mergers.fyi/industries/1492/wooden-structural-fitting-and-component-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1493</loc>
+    <loc>https://mergers.fyi/industries/1493/veneer-and-plywood-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1494</loc>
+    <loc>https://mergers.fyi/industries/1494/reconstituted-wood-product-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1499</loc>
+    <loc>https://mergers.fyi/industries/1499/other-wood-product-manufacturing-n-e-c</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/15</loc>
+    <loc>https://mergers.fyi/industries/15/pulp-paper-and-converted-paper-product-manufacturing</loc>
     <lastmod>2026-02-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/151</loc>
+    <loc>https://mergers.fyi/industries/151/pulp-paper-and-paperboard-manufacturing</loc>
     <lastmod>2026-02-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1510</loc>
+    <loc>https://mergers.fyi/industries/1510/pulp-paper-and-paperboard-manufacturing</loc>
     <lastmod>2026-02-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/152</loc>
+    <loc>https://mergers.fyi/industries/152/converted-paper-product-manufacturing</loc>
     <lastmod>2026-02-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1521</loc>
+    <loc>https://mergers.fyi/industries/1521/corrugated-paperboard-and-paperboard-container-manufacturing</loc>
     <lastmod>2026-02-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1522</loc>
+    <loc>https://mergers.fyi/industries/1522/paper-bag-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1523</loc>
+    <loc>https://mergers.fyi/industries/1523/paper-stationery-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1524</loc>
+    <loc>https://mergers.fyi/industries/1524/sanitary-paper-product-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1529</loc>
+    <loc>https://mergers.fyi/industries/1529/other-converted-paper-product-manufacturing</loc>
     <lastmod>2026-02-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/16</loc>
+    <loc>https://mergers.fyi/industries/16/printing-including-the-reproduction-of-recorded-media</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/161</loc>
+    <loc>https://mergers.fyi/industries/161/printing-and-printing-support-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1611</loc>
+    <loc>https://mergers.fyi/industries/1611/printing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1612</loc>
+    <loc>https://mergers.fyi/industries/1612/printing-support-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/162</loc>
+    <loc>https://mergers.fyi/industries/162/reproduction-of-recorded-media</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1620</loc>
+    <loc>https://mergers.fyi/industries/1620/reproduction-of-recorded-media</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/17</loc>
+    <loc>https://mergers.fyi/industries/17/petroleum-and-coal-product-manufacturing</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/170</loc>
+    <loc>https://mergers.fyi/industries/170/petroleum-and-coal-product-manufacturing</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1701</loc>
+    <loc>https://mergers.fyi/industries/1701/petroleum-refining-and-petroleum-fuel-manufacturing</loc>
     <lastmod>2026-06-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1709</loc>
+    <loc>https://mergers.fyi/industries/1709/other-petroleum-and-coal-product-manufacturing</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/18</loc>
+    <loc>https://mergers.fyi/industries/18/basic-chemical-and-chemical-product-manufacturing</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/181</loc>
+    <loc>https://mergers.fyi/industries/181/basic-chemical-manufacturing</loc>
     <lastmod>2026-03-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1811</loc>
+    <loc>https://mergers.fyi/industries/1811/industrial-gas-manufacturing</loc>
     <lastmod>2026-03-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1812</loc>
+    <loc>https://mergers.fyi/industries/1812/basic-organic-chemical-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1813</loc>
+    <loc>https://mergers.fyi/industries/1813/basic-inorganic-chemical-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/182</loc>
+    <loc>https://mergers.fyi/industries/182/basic-polymer-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1821</loc>
+    <loc>https://mergers.fyi/industries/1821/synthetic-resin-and-synthetic-rubber-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1829</loc>
+    <loc>https://mergers.fyi/industries/1829/other-basic-polymer-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/183</loc>
+    <loc>https://mergers.fyi/industries/183/fertiliser-and-pesticide-manufacturing</loc>
     <lastmod>2026-05-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1831</loc>
+    <loc>https://mergers.fyi/industries/1831/fertiliser-manufacturing</loc>
     <lastmod>2026-05-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1832</loc>
+    <loc>https://mergers.fyi/industries/1832/pesticide-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/184</loc>
+    <loc>https://mergers.fyi/industries/184/pharmaceutical-and-medicinal-product-manufacturing</loc>
     <lastmod>2026-06-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1841</loc>
+    <loc>https://mergers.fyi/industries/1841/human-pharmaceutical-and-medicinal-product-manufacturing</loc>
     <lastmod>2026-06-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1842</loc>
+    <loc>https://mergers.fyi/industries/1842/veterinary-pharmaceutical-and-medicinal-product-manufacturing</loc>
     <lastmod>2026-06-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/185</loc>
+    <loc>https://mergers.fyi/industries/185/cleaning-compound-and-toiletry-preparation-manufacturing</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1851</loc>
+    <loc>https://mergers.fyi/industries/1851/cleaning-compound-manufacturing</loc>
     <lastmod>2026-02-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1852</loc>
+    <loc>https://mergers.fyi/industries/1852/cosmetic-and-toiletry-preparation-manufacturing</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/189</loc>
+    <loc>https://mergers.fyi/industries/189/other-basic-chemical-product-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1891</loc>
+    <loc>https://mergers.fyi/industries/1891/photographic-chemical-product-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1892</loc>
+    <loc>https://mergers.fyi/industries/1892/explosive-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1899</loc>
+    <loc>https://mergers.fyi/industries/1899/other-basic-chemical-product-manufacturing-n-e-c</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/19</loc>
+    <loc>https://mergers.fyi/industries/19/polymer-product-and-rubber-product-manufacturing</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/191</loc>
+    <loc>https://mergers.fyi/industries/191/polymer-product-manufacturing</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1911</loc>
+    <loc>https://mergers.fyi/industries/1911/polymer-film-and-sheet-packaging-material-manufacturing</loc>
     <lastmod>2026-05-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1912</loc>
+    <loc>https://mergers.fyi/industries/1912/rigid-and-semi-rigid-polymer-product-manufacturing</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1913</loc>
+    <loc>https://mergers.fyi/industries/1913/polymer-foam-product-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1914</loc>
+    <loc>https://mergers.fyi/industries/1914/tyre-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1915</loc>
+    <loc>https://mergers.fyi/industries/1915/adhesive-manufacturing</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1916</loc>
+    <loc>https://mergers.fyi/industries/1916/paint-and-coatings-manufacturing</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1919</loc>
+    <loc>https://mergers.fyi/industries/1919/other-polymer-product-manufacturing</loc>
     <lastmod>2026-04-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/192</loc>
+    <loc>https://mergers.fyi/industries/192/natural-rubber-product-manufacturing</loc>
     <lastmod>2026-04-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/1920</loc>
+    <loc>https://mergers.fyi/industries/1920/natural-rubber-product-manufacturing</loc>
     <lastmod>2026-04-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/20</loc>
+    <loc>https://mergers.fyi/industries/20/non-metallic-mineral-product-manufacturing</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/201</loc>
+    <loc>https://mergers.fyi/industries/201/glass-and-glass-product-manufacturing</loc>
     <lastmod>2026-05-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2010</loc>
+    <loc>https://mergers.fyi/industries/2010/glass-and-glass-product-manufacturing</loc>
     <lastmod>2026-05-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/202</loc>
+    <loc>https://mergers.fyi/industries/202/ceramic-product-manufacturing</loc>
     <lastmod>2026-05-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2021</loc>
+    <loc>https://mergers.fyi/industries/2021/clay-brick-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2029</loc>
+    <loc>https://mergers.fyi/industries/2029/other-ceramic-product-manufacturing</loc>
     <lastmod>2026-05-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/203</loc>
+    <loc>https://mergers.fyi/industries/203/cement-lime-plaster-and-concrete-product-manufacturing</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2031</loc>
+    <loc>https://mergers.fyi/industries/2031/cement-and-lime-manufacturing</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2032</loc>
+    <loc>https://mergers.fyi/industries/2032/plaster-product-manufacturing</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2033</loc>
+    <loc>https://mergers.fyi/industries/2033/ready-mixed-concrete-manufacturing</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2034</loc>
+    <loc>https://mergers.fyi/industries/2034/concrete-product-manufacturing</loc>
     <lastmod>2026-04-02</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/209</loc>
+    <loc>https://mergers.fyi/industries/209/other-non-metallic-mineral-product-manufacturing</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2090</loc>
+    <loc>https://mergers.fyi/industries/2090/other-non-metallic-mineral-product-manufacturing</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/21</loc>
+    <loc>https://mergers.fyi/industries/21/primary-metal-and-metal-product-manufacturing</loc>
     <lastmod>2026-06-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/211</loc>
+    <loc>https://mergers.fyi/industries/211/basic-ferrous-metal-manufacturing</loc>
     <lastmod>2026-04-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2110</loc>
+    <loc>https://mergers.fyi/industries/2110/iron-smelting-and-steel-manufacturing</loc>
     <lastmod>2026-04-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/212</loc>
+    <loc>https://mergers.fyi/industries/212/basic-ferrous-metal-product-manufacturing</loc>
     <lastmod>2026-06-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2121</loc>
+    <loc>https://mergers.fyi/industries/2121/iron-and-steel-casting</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2122</loc>
+    <loc>https://mergers.fyi/industries/2122/steel-pipe-and-tube-manufacturing</loc>
     <lastmod>2026-06-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/213</loc>
+    <loc>https://mergers.fyi/industries/213/basic-non-ferrous-metal-manufacturing</loc>
     <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2131</loc>
+    <loc>https://mergers.fyi/industries/2131/alumina-production</loc>
     <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2132</loc>
+    <loc>https://mergers.fyi/industries/2132/aluminium-smelting</loc>
     <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2133</loc>
+    <loc>https://mergers.fyi/industries/2133/copper-silver-lead-and-zinc-smelting-and-refining</loc>
     <lastmod>2026-05-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2139</loc>
+    <loc>https://mergers.fyi/industries/2139/other-basic-non-ferrous-metal-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/214</loc>
+    <loc>https://mergers.fyi/industries/214/basic-non-ferrous-metal-product-manufacturing</loc>
     <lastmod>2026-03-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2141</loc>
+    <loc>https://mergers.fyi/industries/2141/non-ferrous-metal-casting</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2142</loc>
+    <loc>https://mergers.fyi/industries/2142/aluminium-rolling-drawing-extruding</loc>
     <lastmod>2026-03-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2149</loc>
+    <loc>https://mergers.fyi/industries/2149/other-basic-non-ferrous-metal-product-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/22</loc>
+    <loc>https://mergers.fyi/industries/22/fabricated-metal-product-manufacturing</loc>
     <lastmod>2026-05-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/221</loc>
+    <loc>https://mergers.fyi/industries/221/iron-and-steel-forging</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2210</loc>
+    <loc>https://mergers.fyi/industries/2210/iron-and-steel-forging</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/222</loc>
+    <loc>https://mergers.fyi/industries/222/structural-metal-product-manufacturing</loc>
     <lastmod>2026-04-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2221</loc>
+    <loc>https://mergers.fyi/industries/2221/structural-steel-fabricating</loc>
     <lastmod>2026-04-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2222</loc>
+    <loc>https://mergers.fyi/industries/2222/prefabricated-metal-building-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2223</loc>
+    <loc>https://mergers.fyi/industries/2223/architectural-aluminium-product-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2224</loc>
+    <loc>https://mergers.fyi/industries/2224/metal-roof-and-guttering-manufacturing-except-aluminium</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2229</loc>
+    <loc>https://mergers.fyi/industries/2229/other-structural-metal-product-manufacturing</loc>
     <lastmod>2026-04-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/223</loc>
+    <loc>https://mergers.fyi/industries/223/metal-container-manufacturing</loc>
     <lastmod>2026-05-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2231</loc>
+    <loc>https://mergers.fyi/industries/2231/boiler-tank-and-other-heavy-gauge-metal-container-manufacturing</loc>
     <lastmod>2026-05-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2239</loc>
+    <loc>https://mergers.fyi/industries/2239/other-metal-container-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/224</loc>
+    <loc>https://mergers.fyi/industries/224/sheet-metal-product-manufacturing-except-metal-structural-and-container-products</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2240</loc>
+    <loc>https://mergers.fyi/industries/2240/sheet-metal-product-manufacturing-except-metal-structural-and-container-products</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/229</loc>
+    <loc>https://mergers.fyi/industries/229/other-fabricated-metal-product-manufacturing</loc>
     <lastmod>2026-05-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2291</loc>
+    <loc>https://mergers.fyi/industries/2291/spring-and-wire-product-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2292</loc>
+    <loc>https://mergers.fyi/industries/2292/nut-bolt-screw-and-rivet-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2293</loc>
+    <loc>https://mergers.fyi/industries/2293/metal-coating-and-finishing</loc>
     <lastmod>2026-05-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2299</loc>
+    <loc>https://mergers.fyi/industries/2299/other-fabricated-metal-product-manufacturing-n-e-c</loc>
     <lastmod>2026-04-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/23</loc>
+    <loc>https://mergers.fyi/industries/23/transport-equipment-manufacturing</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/231</loc>
+    <loc>https://mergers.fyi/industries/231/motor-vehicle-and-motor-vehicle-part-manufacturing</loc>
     <lastmod>2026-04-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2311</loc>
+    <loc>https://mergers.fyi/industries/2311/motor-vehicle-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2312</loc>
+    <loc>https://mergers.fyi/industries/2312/motor-vehicle-body-and-trailer-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2313</loc>
+    <loc>https://mergers.fyi/industries/2313/automotive-electrical-component-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2319</loc>
+    <loc>https://mergers.fyi/industries/2319/other-motor-vehicle-parts-manufacturing</loc>
     <lastmod>2026-04-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/239</loc>
+    <loc>https://mergers.fyi/industries/239/other-transport-equipment-manufacturing</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2391</loc>
+    <loc>https://mergers.fyi/industries/2391/shipbuilding-and-repair-services</loc>
     <lastmod>2026-04-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2392</loc>
+    <loc>https://mergers.fyi/industries/2392/boatbuilding-and-repair-services</loc>
     <lastmod>2026-04-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2393</loc>
+    <loc>https://mergers.fyi/industries/2393/railway-rolling-stock-manufacturing-and-repair-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2394</loc>
+    <loc>https://mergers.fyi/industries/2394/aircraft-manufacturing-and-repair-services</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2399</loc>
+    <loc>https://mergers.fyi/industries/2399/other-transport-equipment-manufacturing-n-e-c</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/24</loc>
+    <loc>https://mergers.fyi/industries/24/machinery-and-equipment-manufacturing</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/241</loc>
+    <loc>https://mergers.fyi/industries/241/professional-and-scientific-equipment-manufacturing</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2411</loc>
+    <loc>https://mergers.fyi/industries/2411/photographic-optical-and-ophthalmic-equipment-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2412</loc>
+    <loc>https://mergers.fyi/industries/2412/medical-and-surgical-equipment-manufacturing</loc>
     <lastmod>2026-05-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2419</loc>
+    <loc>https://mergers.fyi/industries/2419/other-professional-and-scientific-equipment-manufacturing</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/242</loc>
+    <loc>https://mergers.fyi/industries/242/computer-and-electronic-equipment-manufacturing</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2421</loc>
+    <loc>https://mergers.fyi/industries/2421/computer-and-electronic-office-equipment-manufacturing</loc>
     <lastmod>2026-03-03</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2422</loc>
+    <loc>https://mergers.fyi/industries/2422/communications-equipment-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2429</loc>
+    <loc>https://mergers.fyi/industries/2429/other-electronic-equipment-manufacturing</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/243</loc>
+    <loc>https://mergers.fyi/industries/243/electrical-equipment-manufacturing</loc>
     <lastmod>2026-06-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2431</loc>
+    <loc>https://mergers.fyi/industries/2431/electric-cable-and-wire-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2432</loc>
+    <loc>https://mergers.fyi/industries/2432/electric-lighting-equipment-manufacturing</loc>
     <lastmod>2026-06-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2439</loc>
+    <loc>https://mergers.fyi/industries/2439/other-electrical-equipment-manufacturing</loc>
     <lastmod>2026-06-02</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/244</loc>
+    <loc>https://mergers.fyi/industries/244/domestic-appliance-manufacturing</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2441</loc>
+    <loc>https://mergers.fyi/industries/2441/whiteware-appliance-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2449</loc>
+    <loc>https://mergers.fyi/industries/2449/other-domestic-appliance-manufacturing</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/245</loc>
+    <loc>https://mergers.fyi/industries/245/pump-compressor-heating-and-ventilation-equipment-manufacturing</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2451</loc>
+    <loc>https://mergers.fyi/industries/2451/pump-and-compressor-manufacturing</loc>
     <lastmod>2026-03-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2452</loc>
+    <loc>https://mergers.fyi/industries/2452/fixed-space-heating-cooling-and-ventilation-equipment-manufacturing</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/246</loc>
+    <loc>https://mergers.fyi/industries/246/specialised-machinery-and-equipment-manufacturing</loc>
     <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2461</loc>
+    <loc>https://mergers.fyi/industries/2461/agricultural-machinery-and-equipment-manufacturing</loc>
     <lastmod>2026-04-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2462</loc>
+    <loc>https://mergers.fyi/industries/2462/mining-and-construction-machinery-manufacturing</loc>
     <lastmod>2026-05-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2463</loc>
+    <loc>https://mergers.fyi/industries/2463/machine-tool-and-parts-manufacturing</loc>
     <lastmod>2026-04-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2469</loc>
+    <loc>https://mergers.fyi/industries/2469/other-specialised-machinery-and-equipment-manufacturing</loc>
     <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/249</loc>
+    <loc>https://mergers.fyi/industries/249/other-machinery-and-equipment-manufacturing</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2491</loc>
+    <loc>https://mergers.fyi/industries/2491/lifting-and-material-handling-equipment-manufacturing</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2499</loc>
+    <loc>https://mergers.fyi/industries/2499/other-machinery-and-equipment-manufacturing-n-e-c</loc>
     <lastmod>2026-05-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/25</loc>
+    <loc>https://mergers.fyi/industries/25/furniture-and-other-manufacturing</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/251</loc>
+    <loc>https://mergers.fyi/industries/251/furniture-manufacturing</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2511</loc>
+    <loc>https://mergers.fyi/industries/2511/wooden-furniture-and-upholstered-seat-manufacturing</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2512</loc>
+    <loc>https://mergers.fyi/industries/2512/metal-furniture-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2513</loc>
+    <loc>https://mergers.fyi/industries/2513/mattress-manufacturing</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2519</loc>
+    <loc>https://mergers.fyi/industries/2519/other-furniture-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/259</loc>
+    <loc>https://mergers.fyi/industries/259/other-manufacturing</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2591</loc>
+    <loc>https://mergers.fyi/industries/2591/jewellery-and-silverware-manufacturing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2592</loc>
+    <loc>https://mergers.fyi/industries/2592/toy-sporting-and-recreational-product-manufacturing</loc>
     <lastmod>2026-03-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2599</loc>
+    <loc>https://mergers.fyi/industries/2599/other-manufacturing-n-e-c</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/26</loc>
+    <loc>https://mergers.fyi/industries/26/electricity-supply</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/261</loc>
+    <loc>https://mergers.fyi/industries/261/electricity-generation</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2611</loc>
+    <loc>https://mergers.fyi/industries/2611/fossil-fuel-electricity-generation</loc>
     <lastmod>2026-05-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2612</loc>
+    <loc>https://mergers.fyi/industries/2612/hydro-electricity-generation</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2619</loc>
+    <loc>https://mergers.fyi/industries/2619/other-electricity-generation</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/262</loc>
+    <loc>https://mergers.fyi/industries/262/electricity-transmission</loc>
     <lastmod>2026-06-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2620</loc>
+    <loc>https://mergers.fyi/industries/2620/electricity-transmission</loc>
     <lastmod>2026-06-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/263</loc>
+    <loc>https://mergers.fyi/industries/263/electricity-distribution</loc>
     <lastmod>2026-05-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2630</loc>
+    <loc>https://mergers.fyi/industries/2630/electricity-distribution</loc>
     <lastmod>2026-05-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/264</loc>
+    <loc>https://mergers.fyi/industries/264/on-selling-electricity-and-electricity-market-operation</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2640</loc>
+    <loc>https://mergers.fyi/industries/2640/on-selling-electricity-and-electricity-market-operation</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/27</loc>
+    <loc>https://mergers.fyi/industries/27/gas-supply</loc>
     <lastmod>2026-05-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/270</loc>
+    <loc>https://mergers.fyi/industries/270/gas-supply</loc>
     <lastmod>2026-05-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2700</loc>
+    <loc>https://mergers.fyi/industries/2700/gas-supply</loc>
     <lastmod>2026-05-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/28</loc>
+    <loc>https://mergers.fyi/industries/28/water-supply-sewerage-and-drainage-services</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/281</loc>
+    <loc>https://mergers.fyi/industries/281/water-supply-sewerage-and-drainage-services</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2811</loc>
+    <loc>https://mergers.fyi/industries/2811/water-supply</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2812</loc>
+    <loc>https://mergers.fyi/industries/2812/sewerage-and-drainage-services</loc>
     <lastmod>2026-05-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/29</loc>
+    <loc>https://mergers.fyi/industries/29/waste-collection-treatment-and-disposal-services</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/291</loc>
+    <loc>https://mergers.fyi/industries/291/waste-collection-services</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2911</loc>
+    <loc>https://mergers.fyi/industries/2911/solid-waste-collection-services</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2919</loc>
+    <loc>https://mergers.fyi/industries/2919/other-waste-collection-services</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/292</loc>
+    <loc>https://mergers.fyi/industries/292/waste-treatment-disposal-and-remediation-services</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2921</loc>
+    <loc>https://mergers.fyi/industries/2921/waste-treatment-and-disposal-services</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/2922</loc>
+    <loc>https://mergers.fyi/industries/2922/waste-remediation-and-materials-recovery-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/30</loc>
+    <loc>https://mergers.fyi/industries/30/building-construction</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/301</loc>
+    <loc>https://mergers.fyi/industries/301/residential-building-construction</loc>
     <lastmod>2026-04-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3011</loc>
+    <loc>https://mergers.fyi/industries/3011/house-construction</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3019</loc>
+    <loc>https://mergers.fyi/industries/3019/other-residential-building-construction</loc>
     <lastmod>2026-04-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/302</loc>
+    <loc>https://mergers.fyi/industries/302/non-residential-building-construction</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3020</loc>
+    <loc>https://mergers.fyi/industries/3020/non-residential-building-construction</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/31</loc>
+    <loc>https://mergers.fyi/industries/31/heavy-and-civil-engineering-construction</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/310</loc>
+    <loc>https://mergers.fyi/industries/310/heavy-and-civil-engineering-construction</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3101</loc>
+    <loc>https://mergers.fyi/industries/3101/road-and-bridge-construction</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3109</loc>
+    <loc>https://mergers.fyi/industries/3109/other-heavy-and-civil-engineering-construction</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/32</loc>
+    <loc>https://mergers.fyi/industries/32/construction-services</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/321</loc>
+    <loc>https://mergers.fyi/industries/321/land-development-and-site-preparation-services</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3211</loc>
+    <loc>https://mergers.fyi/industries/3211/land-development-and-subdivision</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3212</loc>
+    <loc>https://mergers.fyi/industries/3212/site-preparation-services</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/322</loc>
+    <loc>https://mergers.fyi/industries/322/building-structure-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3221</loc>
+    <loc>https://mergers.fyi/industries/3221/concreting-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3222</loc>
+    <loc>https://mergers.fyi/industries/3222/bricklaying-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3223</loc>
+    <loc>https://mergers.fyi/industries/3223/roofing-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3224</loc>
+    <loc>https://mergers.fyi/industries/3224/structural-steel-erection-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/323</loc>
+    <loc>https://mergers.fyi/industries/323/building-installation-services</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3231</loc>
+    <loc>https://mergers.fyi/industries/3231/plumbing-services</loc>
     <lastmod>2026-04-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3232</loc>
+    <loc>https://mergers.fyi/industries/3232/electrical-services</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3233</loc>
+    <loc>https://mergers.fyi/industries/3233/air-conditioning-and-heating-services</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3234</loc>
+    <loc>https://mergers.fyi/industries/3234/fire-and-security-alarm-installation-services</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3239</loc>
+    <loc>https://mergers.fyi/industries/3239/other-building-installation-services</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/324</loc>
+    <loc>https://mergers.fyi/industries/324/building-completion-services</loc>
     <lastmod>2026-04-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3241</loc>
+    <loc>https://mergers.fyi/industries/3241/plastering-and-ceiling-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3242</loc>
+    <loc>https://mergers.fyi/industries/3242/carpentry-services</loc>
     <lastmod>2026-04-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3243</loc>
+    <loc>https://mergers.fyi/industries/3243/tiling-and-carpeting-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3244</loc>
+    <loc>https://mergers.fyi/industries/3244/painting-and-decorating-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3245</loc>
+    <loc>https://mergers.fyi/industries/3245/glazing-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/329</loc>
+    <loc>https://mergers.fyi/industries/329/other-construction-services</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3291</loc>
+    <loc>https://mergers.fyi/industries/3291/landscape-construction-services</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3292</loc>
+    <loc>https://mergers.fyi/industries/3292/hire-of-construction-machinery-with-operator</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3299</loc>
+    <loc>https://mergers.fyi/industries/3299/other-construction-services-n-e-c</loc>
     <lastmod>2026-06-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/33</loc>
+    <loc>https://mergers.fyi/industries/33/basic-material-wholesaling</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/331</loc>
+    <loc>https://mergers.fyi/industries/331/agricultural-product-wholesaling</loc>
     <lastmod>2026-04-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3311</loc>
+    <loc>https://mergers.fyi/industries/3311/wool-wholesaling</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3312</loc>
+    <loc>https://mergers.fyi/industries/3312/cereal-grain-wholesaling</loc>
     <lastmod>2026-04-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3319</loc>
+    <loc>https://mergers.fyi/industries/3319/other-agricultural-product-wholesaling</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/332</loc>
+    <loc>https://mergers.fyi/industries/332/mineral-metal-and-chemical-wholesaling</loc>
     <lastmod>2026-06-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3321</loc>
+    <loc>https://mergers.fyi/industries/3321/petroleum-product-wholesaling</loc>
     <lastmod>2026-06-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3322</loc>
+    <loc>https://mergers.fyi/industries/3322/metal-and-mineral-wholesaling</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3323</loc>
+    <loc>https://mergers.fyi/industries/3323/industrial-and-agricultural-chemical-product-wholesaling</loc>
     <lastmod>2026-04-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/333</loc>
+    <loc>https://mergers.fyi/industries/333/timber-and-hardware-goods-wholesaling</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3331</loc>
+    <loc>https://mergers.fyi/industries/3331/timber-wholesaling</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3332</loc>
+    <loc>https://mergers.fyi/industries/3332/plumbing-goods-wholesaling</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3339</loc>
+    <loc>https://mergers.fyi/industries/3339/other-hardware-goods-wholesaling</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/34</loc>
+    <loc>https://mergers.fyi/industries/34/machinery-and-equipment-wholesaling</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/341</loc>
+    <loc>https://mergers.fyi/industries/341/specialised-industrial-machinery-and-equipment-wholesaling</loc>
     <lastmod>2026-04-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3411</loc>
+    <loc>https://mergers.fyi/industries/3411/agricultural-and-construction-machinery-wholesaling</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3419</loc>
+    <loc>https://mergers.fyi/industries/3419/other-specialised-industrial-machinery-and-equipment-wholesaling</loc>
     <lastmod>2026-04-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/349</loc>
+    <loc>https://mergers.fyi/industries/349/other-machinery-and-equipment-wholesaling</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3491</loc>
+    <loc>https://mergers.fyi/industries/3491/professional-and-scientific-goods-wholesaling</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3492</loc>
+    <loc>https://mergers.fyi/industries/3492/computer-and-computer-peripheral-wholesaling</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3493</loc>
+    <loc>https://mergers.fyi/industries/3493/telecommunication-goods-wholesaling</loc>
     <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3494</loc>
+    <loc>https://mergers.fyi/industries/3494/other-electrical-and-electronic-goods-wholesaling</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3499</loc>
+    <loc>https://mergers.fyi/industries/3499/other-machinery-and-equipment-wholesaling-n-e-c</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/35</loc>
+    <loc>https://mergers.fyi/industries/35/motor-vehicle-and-motor-vehicle-parts-wholesaling</loc>
     <lastmod>2026-04-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/350</loc>
+    <loc>https://mergers.fyi/industries/350/motor-vehicle-and-motor-vehicle-parts-wholesaling</loc>
     <lastmod>2026-04-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3501</loc>
+    <loc>https://mergers.fyi/industries/3501/car-wholesaling</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3502</loc>
+    <loc>https://mergers.fyi/industries/3502/commercial-vehicle-wholesaling</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3503</loc>
+    <loc>https://mergers.fyi/industries/3503/trailer-and-other-motor-vehicle-wholesaling</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3504</loc>
+    <loc>https://mergers.fyi/industries/3504/motor-vehicle-new-parts-wholesaling</loc>
     <lastmod>2026-04-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3505</loc>
+    <loc>https://mergers.fyi/industries/3505/motor-vehicle-dismantling-and-used-parts-wholesaling</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/36</loc>
+    <loc>https://mergers.fyi/industries/36/grocery-liquor-and-tobacco-product-wholesaling</loc>
     <lastmod>2026-06-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/360</loc>
+    <loc>https://mergers.fyi/industries/360/grocery-liquor-and-tobacco-product-wholesaling</loc>
     <lastmod>2026-06-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3601</loc>
+    <loc>https://mergers.fyi/industries/3601/general-line-grocery-wholesaling</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3602</loc>
+    <loc>https://mergers.fyi/industries/3602/meat-poultry-and-smallgoods-wholesaling</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3603</loc>
+    <loc>https://mergers.fyi/industries/3603/dairy-produce-wholesaling</loc>
     <lastmod>2026-01-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3604</loc>
+    <loc>https://mergers.fyi/industries/3604/fish-and-seafood-wholesaling</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3605</loc>
+    <loc>https://mergers.fyi/industries/3605/fruit-and-vegetable-wholesaling</loc>
     <lastmod>2026-06-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3606</loc>
+    <loc>https://mergers.fyi/industries/3606/liquor-and-tobacco-product-wholesaling</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3609</loc>
+    <loc>https://mergers.fyi/industries/3609/other-grocery-wholesaling</loc>
     <lastmod>2026-01-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/37</loc>
+    <loc>https://mergers.fyi/industries/37/other-goods-wholesaling</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/371</loc>
+    <loc>https://mergers.fyi/industries/371/textile-clothing-and-footwear-wholesaling</loc>
     <lastmod>2026-06-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3711</loc>
+    <loc>https://mergers.fyi/industries/3711/textile-product-wholesaling</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3712</loc>
+    <loc>https://mergers.fyi/industries/3712/clothing-and-footwear-wholesaling</loc>
     <lastmod>2026-06-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/372</loc>
+    <loc>https://mergers.fyi/industries/372/pharmaceutical-and-toiletry-goods-wholesaling</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3720</loc>
+    <loc>https://mergers.fyi/industries/3720/pharmaceutical-and-toiletry-goods-wholesaling</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/373</loc>
+    <loc>https://mergers.fyi/industries/373/furniture-floor-covering-and-other-goods-wholesaling</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3731</loc>
+    <loc>https://mergers.fyi/industries/3731/furniture-and-floor-covering-wholesaling</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3732</loc>
+    <loc>https://mergers.fyi/industries/3732/jewellery-and-watch-wholesaling</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3733</loc>
+    <loc>https://mergers.fyi/industries/3733/kitchen-and-diningware-wholesaling</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3734</loc>
+    <loc>https://mergers.fyi/industries/3734/toy-and-sporting-goods-wholesaling</loc>
     <lastmod>2026-04-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3735</loc>
+    <loc>https://mergers.fyi/industries/3735/book-and-magazine-wholesaling</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3736</loc>
+    <loc>https://mergers.fyi/industries/3736/paper-product-wholesaling</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3739</loc>
+    <loc>https://mergers.fyi/industries/3739/other-goods-wholesaling-n-e-c</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/38</loc>
+    <loc>https://mergers.fyi/industries/38/commission-based-wholesaling</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/380</loc>
+    <loc>https://mergers.fyi/industries/380/commission-based-wholesaling</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3800</loc>
+    <loc>https://mergers.fyi/industries/3800/commission-based-wholesaling</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/39</loc>
+    <loc>https://mergers.fyi/industries/39/motor-vehicle-and-motor-vehicle-parts-retailing</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/391</loc>
+    <loc>https://mergers.fyi/industries/391/motor-vehicle-retailing</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3911</loc>
+    <loc>https://mergers.fyi/industries/3911/car-retailing</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3912</loc>
+    <loc>https://mergers.fyi/industries/3912/motorcycle-retailing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3913</loc>
+    <loc>https://mergers.fyi/industries/3913/trailer-and-other-motor-vehicle-retailing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/392</loc>
+    <loc>https://mergers.fyi/industries/392/motor-vehicle-parts-and-tyre-retailing</loc>
     <lastmod>2026-06-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3921</loc>
+    <loc>https://mergers.fyi/industries/3921/motor-vehicle-parts-retailing</loc>
     <lastmod>2026-06-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/3922</loc>
+    <loc>https://mergers.fyi/industries/3922/tyre-retailing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/40</loc>
+    <loc>https://mergers.fyi/industries/40/fuel-retailing</loc>
     <lastmod>2026-06-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/400</loc>
+    <loc>https://mergers.fyi/industries/400/fuel-retailing</loc>
     <lastmod>2026-06-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4000</loc>
+    <loc>https://mergers.fyi/industries/4000/fuel-retailing</loc>
     <lastmod>2026-06-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/41</loc>
+    <loc>https://mergers.fyi/industries/41/food-retailing</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/411</loc>
+    <loc>https://mergers.fyi/industries/411/supermarket-and-grocery-stores</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4110</loc>
+    <loc>https://mergers.fyi/industries/4110/supermarket-and-grocery-stores</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/412</loc>
+    <loc>https://mergers.fyi/industries/412/specialised-food-retailing</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4121</loc>
+    <loc>https://mergers.fyi/industries/4121/fresh-meat-fish-and-poultry-retailing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4122</loc>
+    <loc>https://mergers.fyi/industries/4122/fruit-and-vegetable-retailing</loc>
     <lastmod>2026-05-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4123</loc>
+    <loc>https://mergers.fyi/industries/4123/liquor-retailing</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4129</loc>
+    <loc>https://mergers.fyi/industries/4129/other-specialised-food-retailing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/42</loc>
+    <loc>https://mergers.fyi/industries/42/other-store-based-retailing</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/421</loc>
+    <loc>https://mergers.fyi/industries/421/furniture-floor-coverings-houseware-and-textile-goods-retailing</loc>
     <lastmod>2026-05-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4211</loc>
+    <loc>https://mergers.fyi/industries/4211/furniture-retailing</loc>
     <lastmod>2026-05-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4212</loc>
+    <loc>https://mergers.fyi/industries/4212/floor-coverings-retailing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4213</loc>
+    <loc>https://mergers.fyi/industries/4213/houseware-retailing</loc>
     <lastmod>2026-05-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4214</loc>
+    <loc>https://mergers.fyi/industries/4214/manchester-and-other-textile-goods-retailing</loc>
     <lastmod>2026-04-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/422</loc>
+    <loc>https://mergers.fyi/industries/422/electrical-and-electronic-goods-retailing</loc>
     <lastmod>2026-04-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4221</loc>
+    <loc>https://mergers.fyi/industries/4221/electrical-electronic-and-gas-appliance-retailing</loc>
     <lastmod>2026-04-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4222</loc>
+    <loc>https://mergers.fyi/industries/4222/computer-and-computer-peripheral-retailing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4229</loc>
+    <loc>https://mergers.fyi/industries/4229/other-electrical-and-electronic-goods-retailing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/423</loc>
+    <loc>https://mergers.fyi/industries/423/hardware-building-and-garden-supplies-retailing</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4231</loc>
+    <loc>https://mergers.fyi/industries/4231/hardware-and-building-supplies-retailing</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4232</loc>
+    <loc>https://mergers.fyi/industries/4232/garden-supplies-retailing</loc>
     <lastmod>2026-06-02</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/424</loc>
+    <loc>https://mergers.fyi/industries/424/recreational-goods-retailing</loc>
     <lastmod>2026-04-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4241</loc>
+    <loc>https://mergers.fyi/industries/4241/sport-and-camping-equipment-retailing</loc>
     <lastmod>2026-04-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4242</loc>
+    <loc>https://mergers.fyi/industries/4242/entertainment-media-retailing</loc>
     <lastmod>2026-03-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4243</loc>
+    <loc>https://mergers.fyi/industries/4243/toy-and-game-retailing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4244</loc>
+    <loc>https://mergers.fyi/industries/4244/newspaper-and-book-retailing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4245</loc>
+    <loc>https://mergers.fyi/industries/4245/marine-equipment-retailing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/425</loc>
+    <loc>https://mergers.fyi/industries/425/clothing-footwear-and-personal-accessory-retailing</loc>
     <lastmod>2026-06-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4251</loc>
+    <loc>https://mergers.fyi/industries/4251/clothing-retailing</loc>
     <lastmod>2026-06-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4252</loc>
+    <loc>https://mergers.fyi/industries/4252/footwear-retailing</loc>
     <lastmod>2026-06-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4253</loc>
+    <loc>https://mergers.fyi/industries/4253/watch-and-jewellery-retailing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4259</loc>
+    <loc>https://mergers.fyi/industries/4259/other-personal-accessory-retailing</loc>
     <lastmod>2026-03-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/426</loc>
+    <loc>https://mergers.fyi/industries/426/department-stores</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4260</loc>
+    <loc>https://mergers.fyi/industries/4260/department-stores</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/427</loc>
+    <loc>https://mergers.fyi/industries/427/pharmaceutical-and-other-store-based-retailing</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4271</loc>
+    <loc>https://mergers.fyi/industries/4271/pharmaceutical-cosmetic-and-toiletry-goods-retailing</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4272</loc>
+    <loc>https://mergers.fyi/industries/4272/stationery-goods-retailing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4273</loc>
+    <loc>https://mergers.fyi/industries/4273/antique-and-used-goods-retailing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4274</loc>
+    <loc>https://mergers.fyi/industries/4274/flower-retailing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4279</loc>
+    <loc>https://mergers.fyi/industries/4279/other-store-based-retailing-n-e-c</loc>
     <lastmod>2026-05-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/43</loc>
+    <loc>https://mergers.fyi/industries/43/non-store-retailing-and-retail-commission-based-buying-and-or-selling</loc>
     <lastmod>2026-05-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/431</loc>
+    <loc>https://mergers.fyi/industries/431/non-store-retailing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4310</loc>
+    <loc>https://mergers.fyi/industries/4310/non-store-retailing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/432</loc>
+    <loc>https://mergers.fyi/industries/432/retail-commission-based-buying-and-or-selling</loc>
     <lastmod>2026-05-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4320</loc>
+    <loc>https://mergers.fyi/industries/4320/retail-commission-based-buying-and-or-selling</loc>
     <lastmod>2026-05-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/44</loc>
+    <loc>https://mergers.fyi/industries/44/accommodation</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/440</loc>
+    <loc>https://mergers.fyi/industries/440/accommodation</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4400</loc>
+    <loc>https://mergers.fyi/industries/4400/accommodation</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/45</loc>
+    <loc>https://mergers.fyi/industries/45/food-and-beverage-services</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/451</loc>
+    <loc>https://mergers.fyi/industries/451/cafes-restaurants-and-takeaway-food-services</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4511</loc>
+    <loc>https://mergers.fyi/industries/4511/cafes-and-restaurants</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4512</loc>
+    <loc>https://mergers.fyi/industries/4512/takeaway-food-services</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4513</loc>
+    <loc>https://mergers.fyi/industries/4513/catering-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/452</loc>
+    <loc>https://mergers.fyi/industries/452/pubs-taverns-and-bars</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4520</loc>
+    <loc>https://mergers.fyi/industries/4520/pubs-taverns-and-bars</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/453</loc>
+    <loc>https://mergers.fyi/industries/453/clubs-hospitality</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4530</loc>
+    <loc>https://mergers.fyi/industries/4530/clubs-hospitality</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/46</loc>
+    <loc>https://mergers.fyi/industries/46/road-transport</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/461</loc>
+    <loc>https://mergers.fyi/industries/461/road-freight-transport</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4610</loc>
+    <loc>https://mergers.fyi/industries/4610/road-freight-transport</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/462</loc>
+    <loc>https://mergers.fyi/industries/462/road-passenger-transport</loc>
     <lastmod>2026-06-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4621</loc>
+    <loc>https://mergers.fyi/industries/4621/interurban-and-rural-bus-transport</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4622</loc>
+    <loc>https://mergers.fyi/industries/4622/urban-bus-transport-including-tramway</loc>
     <lastmod>2026-05-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4623</loc>
+    <loc>https://mergers.fyi/industries/4623/taxi-and-other-road-transport</loc>
     <lastmod>2026-06-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/47</loc>
+    <loc>https://mergers.fyi/industries/47/rail-transport</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/471</loc>
+    <loc>https://mergers.fyi/industries/471/rail-freight-transport</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4710</loc>
+    <loc>https://mergers.fyi/industries/4710/rail-freight-transport</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/472</loc>
+    <loc>https://mergers.fyi/industries/472/rail-passenger-transport</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4720</loc>
+    <loc>https://mergers.fyi/industries/4720/rail-passenger-transport</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/48</loc>
+    <loc>https://mergers.fyi/industries/48/water-transport</loc>
     <lastmod>2026-03-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/481</loc>
+    <loc>https://mergers.fyi/industries/481/water-freight-transport</loc>
     <lastmod>2026-03-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4810</loc>
+    <loc>https://mergers.fyi/industries/4810/water-freight-transport</loc>
     <lastmod>2026-03-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/482</loc>
+    <loc>https://mergers.fyi/industries/482/water-passenger-transport</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4820</loc>
+    <loc>https://mergers.fyi/industries/4820/water-passenger-transport</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/49</loc>
+    <loc>https://mergers.fyi/industries/49/air-and-space-transport</loc>
     <lastmod>2026-05-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/490</loc>
+    <loc>https://mergers.fyi/industries/490/air-and-space-transport</loc>
     <lastmod>2026-05-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/4900</loc>
+    <loc>https://mergers.fyi/industries/4900/air-and-space-transport</loc>
     <lastmod>2026-05-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/50</loc>
+    <loc>https://mergers.fyi/industries/50/other-transport</loc>
     <lastmod>2026-05-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/501</loc>
+    <loc>https://mergers.fyi/industries/501/scenic-and-sightseeing-transport</loc>
     <lastmod>2026-05-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5010</loc>
+    <loc>https://mergers.fyi/industries/5010/scenic-and-sightseeing-transport</loc>
     <lastmod>2026-05-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/502</loc>
+    <loc>https://mergers.fyi/industries/502/pipeline-and-other-transport</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5021</loc>
+    <loc>https://mergers.fyi/industries/5021/pipeline-transport</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5029</loc>
+    <loc>https://mergers.fyi/industries/5029/other-transport-n-e-c</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/51</loc>
+    <loc>https://mergers.fyi/industries/51/postal-and-courier-pick-up-and-delivery-services</loc>
     <lastmod>2026-06-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/510</loc>
+    <loc>https://mergers.fyi/industries/510/postal-and-courier-pick-up-and-delivery-services</loc>
     <lastmod>2026-06-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5101</loc>
+    <loc>https://mergers.fyi/industries/5101/postal-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5102</loc>
+    <loc>https://mergers.fyi/industries/5102/courier-pick-up-and-delivery-services</loc>
     <lastmod>2026-06-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/52</loc>
+    <loc>https://mergers.fyi/industries/52/transport-support-services</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/521</loc>
+    <loc>https://mergers.fyi/industries/521/water-transport-support-services</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5211</loc>
+    <loc>https://mergers.fyi/industries/5211/stevedoring-services</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5212</loc>
+    <loc>https://mergers.fyi/industries/5212/port-and-water-transport-terminal-operations</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5219</loc>
+    <loc>https://mergers.fyi/industries/5219/other-water-transport-support-services</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/522</loc>
+    <loc>https://mergers.fyi/industries/522/airport-operations-and-other-air-transport-support-services</loc>
     <lastmod>2026-06-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5220</loc>
+    <loc>https://mergers.fyi/industries/5220/airport-operations-and-other-air-transport-support-services</loc>
     <lastmod>2026-06-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/529</loc>
+    <loc>https://mergers.fyi/industries/529/other-transport-support-services</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5291</loc>
+    <loc>https://mergers.fyi/industries/5291/customs-agency-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5292</loc>
+    <loc>https://mergers.fyi/industries/5292/freight-forwarding-services</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5299</loc>
+    <loc>https://mergers.fyi/industries/5299/other-transport-support-services-n-e-c</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/53</loc>
+    <loc>https://mergers.fyi/industries/53/warehousing-and-storage-services</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/530</loc>
+    <loc>https://mergers.fyi/industries/530/warehousing-and-storage-services</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5301</loc>
+    <loc>https://mergers.fyi/industries/5301/grain-storage-services</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5309</loc>
+    <loc>https://mergers.fyi/industries/5309/other-warehousing-and-storage-services</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/54</loc>
+    <loc>https://mergers.fyi/industries/54/publishing-except-internet-and-music-publishing</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/541</loc>
+    <loc>https://mergers.fyi/industries/541/newspaper-periodical-book-and-directory-publishing</loc>
     <lastmod>2026-06-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5411</loc>
+    <loc>https://mergers.fyi/industries/5411/newspaper-publishing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5412</loc>
+    <loc>https://mergers.fyi/industries/5412/magazine-and-other-periodical-publishing</loc>
     <lastmod>2026-06-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5413</loc>
+    <loc>https://mergers.fyi/industries/5413/book-publishing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5414</loc>
+    <loc>https://mergers.fyi/industries/5414/directory-and-mailing-list-publishing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5419</loc>
+    <loc>https://mergers.fyi/industries/5419/other-publishing-except-software-music-and-internet</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/542</loc>
+    <loc>https://mergers.fyi/industries/542/software-publishing</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5420</loc>
+    <loc>https://mergers.fyi/industries/5420/software-publishing</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/55</loc>
+    <loc>https://mergers.fyi/industries/55/motion-picture-and-sound-recording-activities</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/551</loc>
+    <loc>https://mergers.fyi/industries/551/motion-picture-and-video-activities</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5511</loc>
+    <loc>https://mergers.fyi/industries/5511/motion-picture-and-video-production</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5512</loc>
+    <loc>https://mergers.fyi/industries/5512/motion-picture-and-video-distribution</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5513</loc>
+    <loc>https://mergers.fyi/industries/5513/motion-picture-exhibition</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5514</loc>
+    <loc>https://mergers.fyi/industries/5514/post-production-services-and-other-motion-picture-and-video-activities</loc>
     <lastmod>2026-06-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/552</loc>
+    <loc>https://mergers.fyi/industries/552/sound-recording-and-music-publishing</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5521</loc>
+    <loc>https://mergers.fyi/industries/5521/music-publishing</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5522</loc>
+    <loc>https://mergers.fyi/industries/5522/music-and-other-sound-recording-activities</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/56</loc>
+    <loc>https://mergers.fyi/industries/56/broadcasting-except-internet</loc>
     <lastmod>2026-06-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/561</loc>
+    <loc>https://mergers.fyi/industries/561/radio-broadcasting</loc>
     <lastmod>2026-02-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5610</loc>
+    <loc>https://mergers.fyi/industries/5610/radio-broadcasting</loc>
     <lastmod>2026-02-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/562</loc>
+    <loc>https://mergers.fyi/industries/562/television-broadcasting</loc>
     <lastmod>2026-06-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5621</loc>
+    <loc>https://mergers.fyi/industries/5621/free-to-air-television-broadcasting</loc>
     <lastmod>2026-06-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5622</loc>
+    <loc>https://mergers.fyi/industries/5622/cable-and-other-subscription-broadcasting</loc>
     <lastmod>2026-06-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/57</loc>
+    <loc>https://mergers.fyi/industries/57/internet-publishing-and-broadcasting</loc>
     <lastmod>2026-05-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/570</loc>
+    <loc>https://mergers.fyi/industries/570/internet-publishing-and-broadcasting</loc>
     <lastmod>2026-05-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5700</loc>
+    <loc>https://mergers.fyi/industries/5700/internet-publishing-and-broadcasting</loc>
     <lastmod>2026-05-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/58</loc>
+    <loc>https://mergers.fyi/industries/58/telecommunications-services</loc>
     <lastmod>2026-05-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/580</loc>
+    <loc>https://mergers.fyi/industries/580/telecommunications-services</loc>
     <lastmod>2026-05-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5801</loc>
+    <loc>https://mergers.fyi/industries/5801/wired-telecommunications-network-operation</loc>
     <lastmod>2026-03-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5802</loc>
+    <loc>https://mergers.fyi/industries/5802/other-telecommunications-network-operation</loc>
     <lastmod>2026-05-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5809</loc>
+    <loc>https://mergers.fyi/industries/5809/other-telecommunications-services</loc>
     <lastmod>2026-04-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/59</loc>
+    <loc>https://mergers.fyi/industries/59/internet-service-providers-web-search-portals-and-data-processing-services</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/591</loc>
+    <loc>https://mergers.fyi/industries/591/internet-service-providers-and-web-search-portals</loc>
     <lastmod>2026-02-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5910</loc>
+    <loc>https://mergers.fyi/industries/5910/internet-service-providers-and-web-search-portals</loc>
     <lastmod>2026-02-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/592</loc>
+    <loc>https://mergers.fyi/industries/592/data-processing-web-hosting-and-electronic-information-storage-services</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5921</loc>
+    <loc>https://mergers.fyi/industries/5921/data-processing-and-web-hosting-services</loc>
     <lastmod>2026-06-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/5922</loc>
+    <loc>https://mergers.fyi/industries/5922/electronic-information-storage-services</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/60</loc>
+    <loc>https://mergers.fyi/industries/60/library-and-other-information-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/601</loc>
+    <loc>https://mergers.fyi/industries/601/libraries-and-archives</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6010</loc>
+    <loc>https://mergers.fyi/industries/6010/libraries-and-archives</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/602</loc>
+    <loc>https://mergers.fyi/industries/602/other-information-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6020</loc>
+    <loc>https://mergers.fyi/industries/6020/other-information-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/62</loc>
+    <loc>https://mergers.fyi/industries/62/finance</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/621</loc>
+    <loc>https://mergers.fyi/industries/621/central-banking</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6210</loc>
+    <loc>https://mergers.fyi/industries/6210/central-banking</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/622</loc>
+    <loc>https://mergers.fyi/industries/622/depository-financial-intermediation</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6221</loc>
+    <loc>https://mergers.fyi/industries/6221/banking</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6222</loc>
+    <loc>https://mergers.fyi/industries/6222/building-society-operation</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6223</loc>
+    <loc>https://mergers.fyi/industries/6223/credit-union-operation</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6229</loc>
+    <loc>https://mergers.fyi/industries/6229/other-depository-financial-intermediation</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/623</loc>
+    <loc>https://mergers.fyi/industries/623/non-depository-financing</loc>
     <lastmod>2026-06-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6230</loc>
+    <loc>https://mergers.fyi/industries/6230/non-depository-financing</loc>
     <lastmod>2026-06-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/624</loc>
+    <loc>https://mergers.fyi/industries/624/financial-asset-investing</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6240</loc>
+    <loc>https://mergers.fyi/industries/6240/financial-asset-investing</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/63</loc>
+    <loc>https://mergers.fyi/industries/63/insurance-and-superannuation-funds</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/631</loc>
+    <loc>https://mergers.fyi/industries/631/life-insurance</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6310</loc>
+    <loc>https://mergers.fyi/industries/6310/life-insurance</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/632</loc>
+    <loc>https://mergers.fyi/industries/632/health-and-general-insurance</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6321</loc>
+    <loc>https://mergers.fyi/industries/6321/health-insurance</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6322</loc>
+    <loc>https://mergers.fyi/industries/6322/general-insurance</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/633</loc>
+    <loc>https://mergers.fyi/industries/633/superannuation-funds</loc>
     <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6330</loc>
+    <loc>https://mergers.fyi/industries/6330/superannuation-funds</loc>
     <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/64</loc>
+    <loc>https://mergers.fyi/industries/64/auxiliary-finance-and-insurance-services</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/641</loc>
+    <loc>https://mergers.fyi/industries/641/auxiliary-finance-and-investment-services</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6411</loc>
+    <loc>https://mergers.fyi/industries/6411/financial-asset-broking-services</loc>
     <lastmod>2026-05-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6419</loc>
+    <loc>https://mergers.fyi/industries/6419/other-auxiliary-finance-and-investment-services</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/642</loc>
+    <loc>https://mergers.fyi/industries/642/auxiliary-insurance-services</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6420</loc>
+    <loc>https://mergers.fyi/industries/6420/auxiliary-insurance-services</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/66</loc>
+    <loc>https://mergers.fyi/industries/66/rental-and-hiring-services-except-real-estate</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/661</loc>
+    <loc>https://mergers.fyi/industries/661/motor-vehicle-and-transport-equipment-rental-and-hiring</loc>
     <lastmod>2026-05-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6611</loc>
+    <loc>https://mergers.fyi/industries/6611/passenger-car-rental-and-hiring</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6619</loc>
+    <loc>https://mergers.fyi/industries/6619/other-motor-vehicle-and-transport-equipment-rental-and-hiring</loc>
     <lastmod>2026-05-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/662</loc>
+    <loc>https://mergers.fyi/industries/662/farm-animal-and-bloodstock-leasing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6620</loc>
+    <loc>https://mergers.fyi/industries/6620/farm-animal-and-bloodstock-leasing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/663</loc>
+    <loc>https://mergers.fyi/industries/663/other-goods-and-equipment-rental-and-hiring</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6631</loc>
+    <loc>https://mergers.fyi/industries/6631/heavy-machinery-and-scaffolding-rental-and-hiring</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6632</loc>
+    <loc>https://mergers.fyi/industries/6632/video-and-other-electronic-media-rental-and-hiring</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6639</loc>
+    <loc>https://mergers.fyi/industries/6639/other-goods-and-equipment-rental-and-hiring-n-e-c</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/664</loc>
+    <loc>https://mergers.fyi/industries/664/non-financial-intangible-assets-except-copyrights-leasing</loc>
     <lastmod>2026-06-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6640</loc>
+    <loc>https://mergers.fyi/industries/6640/non-financial-intangible-assets-except-copyrights-leasing</loc>
     <lastmod>2026-06-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/67</loc>
+    <loc>https://mergers.fyi/industries/67/property-operators-and-real-estate-services</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/671</loc>
+    <loc>https://mergers.fyi/industries/671/property-operators</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6711</loc>
+    <loc>https://mergers.fyi/industries/6711/residential-property-operators</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6712</loc>
+    <loc>https://mergers.fyi/industries/6712/non-residential-property-operators</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/672</loc>
+    <loc>https://mergers.fyi/industries/672/real-estate-services</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6720</loc>
+    <loc>https://mergers.fyi/industries/6720/real-estate-services</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/69</loc>
+    <loc>https://mergers.fyi/industries/69/professional-scientific-and-technical-services-except-computer-system-design-and</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/691</loc>
+    <loc>https://mergers.fyi/industries/691/scientific-research-services</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6910</loc>
+    <loc>https://mergers.fyi/industries/6910/scientific-research-services</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/692</loc>
+    <loc>https://mergers.fyi/industries/692/architectural-engineering-and-technical-services</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6921</loc>
+    <loc>https://mergers.fyi/industries/6921/architectural-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6922</loc>
+    <loc>https://mergers.fyi/industries/6922/surveying-and-mapping-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6923</loc>
+    <loc>https://mergers.fyi/industries/6923/engineering-design-and-engineering-consulting-services</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6924</loc>
+    <loc>https://mergers.fyi/industries/6924/other-specialised-design-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6925</loc>
+    <loc>https://mergers.fyi/industries/6925/scientific-testing-and-analysis-services</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/693</loc>
+    <loc>https://mergers.fyi/industries/693/legal-and-accounting-services</loc>
     <lastmod>2026-06-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6931</loc>
+    <loc>https://mergers.fyi/industries/6931/legal-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6932</loc>
+    <loc>https://mergers.fyi/industries/6932/accounting-services</loc>
     <lastmod>2026-06-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/694</loc>
+    <loc>https://mergers.fyi/industries/694/advertising-services</loc>
     <lastmod>2026-06-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6940</loc>
+    <loc>https://mergers.fyi/industries/6940/advertising-services</loc>
     <lastmod>2026-06-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/695</loc>
+    <loc>https://mergers.fyi/industries/695/market-research-and-statistical-services</loc>
     <lastmod>2026-02-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6950</loc>
+    <loc>https://mergers.fyi/industries/6950/market-research-and-statistical-services</loc>
     <lastmod>2026-02-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/696</loc>
+    <loc>https://mergers.fyi/industries/696/management-and-related-consulting-services</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6961</loc>
+    <loc>https://mergers.fyi/industries/6961/corporate-head-office-management-services</loc>
     <lastmod>2026-06-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6962</loc>
+    <loc>https://mergers.fyi/industries/6962/management-advice-and-related-consulting-services</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/697</loc>
+    <loc>https://mergers.fyi/industries/697/veterinary-services</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6970</loc>
+    <loc>https://mergers.fyi/industries/6970/veterinary-services</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/699</loc>
+    <loc>https://mergers.fyi/industries/699/other-professional-scientific-and-technical-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6991</loc>
+    <loc>https://mergers.fyi/industries/6991/professional-photographic-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/6999</loc>
+    <loc>https://mergers.fyi/industries/6999/other-professional-scientific-and-technical-services-n-e-c</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/70</loc>
+    <loc>https://mergers.fyi/industries/70/computer-system-design-and-related-services</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/700</loc>
+    <loc>https://mergers.fyi/industries/700/computer-system-design-and-related-services</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/7000</loc>
+    <loc>https://mergers.fyi/industries/7000/computer-system-design-and-related-services</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/72</loc>
+    <loc>https://mergers.fyi/industries/72/administrative-services</loc>
     <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/721</loc>
+    <loc>https://mergers.fyi/industries/721/employment-services</loc>
     <lastmod>2026-05-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/7211</loc>
+    <loc>https://mergers.fyi/industries/7211/employment-placement-and-recruitment-services</loc>
     <lastmod>2026-05-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/7212</loc>
+    <loc>https://mergers.fyi/industries/7212/labour-supply-services</loc>
     <lastmod>2026-05-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/722</loc>
+    <loc>https://mergers.fyi/industries/722/travel-agency-and-tour-arrangement-services</loc>
     <lastmod>2026-05-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/7220</loc>
+    <loc>https://mergers.fyi/industries/7220/travel-agency-and-tour-arrangement-services</loc>
     <lastmod>2026-05-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/729</loc>
+    <loc>https://mergers.fyi/industries/729/other-administrative-services</loc>
     <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/7291</loc>
+    <loc>https://mergers.fyi/industries/7291/office-administrative-services</loc>
     <lastmod>2026-01-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/7292</loc>
+    <loc>https://mergers.fyi/industries/7292/document-preparation-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/7293</loc>
+    <loc>https://mergers.fyi/industries/7293/credit-reporting-and-debt-collection-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/7294</loc>
+    <loc>https://mergers.fyi/industries/7294/call-centre-operation</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/7299</loc>
+    <loc>https://mergers.fyi/industries/7299/other-administrative-services-n-e-c</loc>
     <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/73</loc>
+    <loc>https://mergers.fyi/industries/73/building-cleaning-pest-control-and-other-support-services</loc>
     <lastmod>2026-03-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/731</loc>
+    <loc>https://mergers.fyi/industries/731/building-cleaning-pest-control-and-gardening-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/7311</loc>
+    <loc>https://mergers.fyi/industries/7311/building-and-other-industrial-cleaning-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/7312</loc>
+    <loc>https://mergers.fyi/industries/7312/building-pest-control-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/7313</loc>
+    <loc>https://mergers.fyi/industries/7313/gardening-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/732</loc>
+    <loc>https://mergers.fyi/industries/732/packaging-services</loc>
     <lastmod>2026-03-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/7320</loc>
+    <loc>https://mergers.fyi/industries/7320/packaging-services</loc>
     <lastmod>2026-03-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/75</loc>
+    <loc>https://mergers.fyi/industries/75/public-administration</loc>
     <lastmod>2026-04-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/751</loc>
+    <loc>https://mergers.fyi/industries/751/central-government-administration</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/7510</loc>
+    <loc>https://mergers.fyi/industries/7510/central-government-administration</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/752</loc>
+    <loc>https://mergers.fyi/industries/752/state-government-administration</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/7520</loc>
+    <loc>https://mergers.fyi/industries/7520/state-government-administration</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/753</loc>
+    <loc>https://mergers.fyi/industries/753/local-government-administration</loc>
     <lastmod>2026-04-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/7530</loc>
+    <loc>https://mergers.fyi/industries/7530/local-government-administration</loc>
     <lastmod>2026-04-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/754</loc>
+    <loc>https://mergers.fyi/industries/754/justice</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/7540</loc>
+    <loc>https://mergers.fyi/industries/7540/justice</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/755</loc>
+    <loc>https://mergers.fyi/industries/755/government-representation</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/7551</loc>
+    <loc>https://mergers.fyi/industries/7551/domestic-government-representation</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/7552</loc>
+    <loc>https://mergers.fyi/industries/7552/foreign-government-representation</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/76</loc>
+    <loc>https://mergers.fyi/industries/76/defence</loc>
     <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/760</loc>
+    <loc>https://mergers.fyi/industries/760/defence</loc>
     <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/7600</loc>
+    <loc>https://mergers.fyi/industries/7600/defence</loc>
     <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/77</loc>
+    <loc>https://mergers.fyi/industries/77/public-order-safety-and-regulatory-services</loc>
     <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/771</loc>
+    <loc>https://mergers.fyi/industries/771/public-order-and-safety-services</loc>
     <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/7711</loc>
+    <loc>https://mergers.fyi/industries/7711/police-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/7712</loc>
+    <loc>https://mergers.fyi/industries/7712/investigation-and-security-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/7713</loc>
+    <loc>https://mergers.fyi/industries/7713/fire-protection-and-other-emergency-services</loc>
     <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/7714</loc>
+    <loc>https://mergers.fyi/industries/7714/correctional-and-detention-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/7719</loc>
+    <loc>https://mergers.fyi/industries/7719/other-public-order-and-safety-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/772</loc>
+    <loc>https://mergers.fyi/industries/772/regulatory-services</loc>
     <lastmod>2026-04-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/7720</loc>
+    <loc>https://mergers.fyi/industries/7720/regulatory-services</loc>
     <lastmod>2026-04-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/80</loc>
+    <loc>https://mergers.fyi/industries/80/preschool-and-school-education</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/801</loc>
+    <loc>https://mergers.fyi/industries/801/preschool-education</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8010</loc>
+    <loc>https://mergers.fyi/industries/8010/preschool-education</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/802</loc>
+    <loc>https://mergers.fyi/industries/802/school-education</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8021</loc>
+    <loc>https://mergers.fyi/industries/8021/primary-education</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8022</loc>
+    <loc>https://mergers.fyi/industries/8022/secondary-education</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8023</loc>
+    <loc>https://mergers.fyi/industries/8023/combined-primary-and-secondary-education</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8024</loc>
+    <loc>https://mergers.fyi/industries/8024/special-school-education</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/81</loc>
+    <loc>https://mergers.fyi/industries/81/tertiary-education</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/810</loc>
+    <loc>https://mergers.fyi/industries/810/tertiary-education</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8101</loc>
+    <loc>https://mergers.fyi/industries/8101/technical-and-vocational-education-and-training</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8102</loc>
+    <loc>https://mergers.fyi/industries/8102/higher-education</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/82</loc>
+    <loc>https://mergers.fyi/industries/82/adult-community-and-other-education</loc>
     <lastmod>2026-05-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/821</loc>
+    <loc>https://mergers.fyi/industries/821/adult-community-and-other-education</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8211</loc>
+    <loc>https://mergers.fyi/industries/8211/sports-and-physical-recreation-instruction</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8212</loc>
+    <loc>https://mergers.fyi/industries/8212/arts-education</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8219</loc>
+    <loc>https://mergers.fyi/industries/8219/adult-community-and-other-education-n-e-c</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/822</loc>
+    <loc>https://mergers.fyi/industries/822/educational-support-services</loc>
     <lastmod>2026-05-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8220</loc>
+    <loc>https://mergers.fyi/industries/8220/educational-support-services</loc>
     <lastmod>2026-05-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/84</loc>
+    <loc>https://mergers.fyi/industries/84/hospitals</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/840</loc>
+    <loc>https://mergers.fyi/industries/840/hospitals</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8401</loc>
+    <loc>https://mergers.fyi/industries/8401/hospitals-except-psychiatric-hospitals</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8402</loc>
+    <loc>https://mergers.fyi/industries/8402/psychiatric-hospitals</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/85</loc>
+    <loc>https://mergers.fyi/industries/85/medical-and-other-health-care-services</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/851</loc>
+    <loc>https://mergers.fyi/industries/851/medical-services</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8511</loc>
+    <loc>https://mergers.fyi/industries/8511/general-practice-medical-services</loc>
     <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8512</loc>
+    <loc>https://mergers.fyi/industries/8512/specialist-medical-services</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/852</loc>
+    <loc>https://mergers.fyi/industries/852/pathology-and-diagnostic-imaging-services</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8520</loc>
+    <loc>https://mergers.fyi/industries/8520/pathology-and-diagnostic-imaging-services</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/853</loc>
+    <loc>https://mergers.fyi/industries/853/allied-health-services</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8531</loc>
+    <loc>https://mergers.fyi/industries/8531/dental-services</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8532</loc>
+    <loc>https://mergers.fyi/industries/8532/optometry-and-optical-dispensing</loc>
     <lastmod>2026-03-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8533</loc>
+    <loc>https://mergers.fyi/industries/8533/physiotherapy-services</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8534</loc>
+    <loc>https://mergers.fyi/industries/8534/chiropractic-and-osteopathic-services</loc>
     <lastmod>2026-03-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8539</loc>
+    <loc>https://mergers.fyi/industries/8539/other-allied-health-services</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/859</loc>
+    <loc>https://mergers.fyi/industries/859/other-health-care-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8591</loc>
+    <loc>https://mergers.fyi/industries/8591/ambulance-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8599</loc>
+    <loc>https://mergers.fyi/industries/8599/other-health-care-services-n-e-c</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/86</loc>
+    <loc>https://mergers.fyi/industries/86/residential-care-services</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/860</loc>
+    <loc>https://mergers.fyi/industries/860/residential-care-services</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8601</loc>
+    <loc>https://mergers.fyi/industries/8601/aged-care-residential-services</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8609</loc>
+    <loc>https://mergers.fyi/industries/8609/other-residential-care-services</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/87</loc>
+    <loc>https://mergers.fyi/industries/87/social-assistance-services</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/871</loc>
+    <loc>https://mergers.fyi/industries/871/child-care-services</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8710</loc>
+    <loc>https://mergers.fyi/industries/8710/child-care-services</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/879</loc>
+    <loc>https://mergers.fyi/industries/879/other-social-assistance-services</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8790</loc>
+    <loc>https://mergers.fyi/industries/8790/other-social-assistance-services</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/89</loc>
+    <loc>https://mergers.fyi/industries/89/heritage-activities</loc>
     <lastmod>2026-04-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/891</loc>
+    <loc>https://mergers.fyi/industries/891/museum-operation</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8910</loc>
+    <loc>https://mergers.fyi/industries/8910/museum-operation</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/892</loc>
+    <loc>https://mergers.fyi/industries/892/parks-and-gardens-operations</loc>
     <lastmod>2026-04-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8921</loc>
+    <loc>https://mergers.fyi/industries/8921/zoological-and-botanical-gardens-operation</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/8922</loc>
+    <loc>https://mergers.fyi/industries/8922/nature-reserves-and-conservation-parks-operation</loc>
     <lastmod>2026-04-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/90</loc>
+    <loc>https://mergers.fyi/industries/90/creative-and-performing-arts-activities</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/900</loc>
+    <loc>https://mergers.fyi/industries/900/creative-and-performing-arts-activities</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9001</loc>
+    <loc>https://mergers.fyi/industries/9001/performing-arts-operation</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9002</loc>
+    <loc>https://mergers.fyi/industries/9002/creative-artists-musicians-writers-and-performers</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9003</loc>
+    <loc>https://mergers.fyi/industries/9003/performing-arts-venue-operation</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/91</loc>
+    <loc>https://mergers.fyi/industries/91/sports-and-recreation-activities</loc>
     <lastmod>2026-05-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/911</loc>
+    <loc>https://mergers.fyi/industries/911/sports-and-physical-recreation-activities</loc>
     <lastmod>2026-01-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9111</loc>
+    <loc>https://mergers.fyi/industries/9111/health-and-fitness-centres-and-gymnasia-operation</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9112</loc>
+    <loc>https://mergers.fyi/industries/9112/sports-and-physical-recreation-clubs-and-sports-professionals</loc>
     <lastmod>2026-01-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9113</loc>
+    <loc>https://mergers.fyi/industries/9113/sports-and-physical-recreation-venues-grounds-and-facilities-operation</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9114</loc>
+    <loc>https://mergers.fyi/industries/9114/sports-and-physical-recreation-administrative-service</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/912</loc>
+    <loc>https://mergers.fyi/industries/912/horse-and-dog-racing-activities</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9121</loc>
+    <loc>https://mergers.fyi/industries/9121/horse-and-dog-racing-administration-and-track-operation</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9129</loc>
+    <loc>https://mergers.fyi/industries/9129/other-horse-and-dog-racing-activities</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/913</loc>
+    <loc>https://mergers.fyi/industries/913/amusement-and-other-recreation-activities</loc>
     <lastmod>2026-05-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9131</loc>
+    <loc>https://mergers.fyi/industries/9131/amusement-parks-and-centres-operation</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9139</loc>
+    <loc>https://mergers.fyi/industries/9139/amusement-and-other-recreational-activities-n-e-c</loc>
     <lastmod>2026-05-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/92</loc>
+    <loc>https://mergers.fyi/industries/92/gambling-activities</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/920</loc>
+    <loc>https://mergers.fyi/industries/920/gambling-activities</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9201</loc>
+    <loc>https://mergers.fyi/industries/9201/casino-operation</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9202</loc>
+    <loc>https://mergers.fyi/industries/9202/lottery-operation</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9209</loc>
+    <loc>https://mergers.fyi/industries/9209/other-gambling-activities</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/94</loc>
+    <loc>https://mergers.fyi/industries/94/repair-and-maintenance</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/941</loc>
+    <loc>https://mergers.fyi/industries/941/automotive-repair-and-maintenance</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9411</loc>
+    <loc>https://mergers.fyi/industries/9411/automotive-electrical-services</loc>
     <lastmod>2026-03-31</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9412</loc>
+    <loc>https://mergers.fyi/industries/9412/automotive-body-paint-and-interior-repair</loc>
     <lastmod>2026-05-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9419</loc>
+    <loc>https://mergers.fyi/industries/9419/other-automotive-repair-and-maintenance</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/942</loc>
+    <loc>https://mergers.fyi/industries/942/machinery-and-equipment-repair-and-maintenance</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9421</loc>
+    <loc>https://mergers.fyi/industries/9421/domestic-appliance-repair-and-maintenance</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9422</loc>
+    <loc>https://mergers.fyi/industries/9422/electronic-except-domestic-appliance-and-precision-equipment-repair-and-maintena</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9429</loc>
+    <loc>https://mergers.fyi/industries/9429/other-machinery-and-equipment-repair-and-maintenance</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/949</loc>
+    <loc>https://mergers.fyi/industries/949/other-repair-and-maintenance</loc>
     <lastmod>2026-04-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9491</loc>
+    <loc>https://mergers.fyi/industries/9491/clothing-and-footwear-repair</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9499</loc>
+    <loc>https://mergers.fyi/industries/9499/other-repair-and-maintenance-n-e-c</loc>
     <lastmod>2026-04-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/95</loc>
+    <loc>https://mergers.fyi/industries/95/personal-and-other-services</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/951</loc>
+    <loc>https://mergers.fyi/industries/951/personal-care-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9511</loc>
+    <loc>https://mergers.fyi/industries/9511/hairdressing-and-beauty-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9512</loc>
+    <loc>https://mergers.fyi/industries/9512/diet-and-weight-reduction-centre-operation</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/952</loc>
+    <loc>https://mergers.fyi/industries/952/funeral-crematorium-and-cemetery-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9520</loc>
+    <loc>https://mergers.fyi/industries/9520/funeral-crematorium-and-cemetery-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/953</loc>
+    <loc>https://mergers.fyi/industries/953/other-personal-services</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9531</loc>
+    <loc>https://mergers.fyi/industries/9531/laundry-and-dry-cleaning-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9532</loc>
+    <loc>https://mergers.fyi/industries/9532/photographic-film-processing</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9533</loc>
+    <loc>https://mergers.fyi/industries/9533/parking-services</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9534</loc>
+    <loc>https://mergers.fyi/industries/9534/brothel-keeping-and-prostitution-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9539</loc>
+    <loc>https://mergers.fyi/industries/9539/other-personal-services-n-e-c</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/954</loc>
+    <loc>https://mergers.fyi/industries/954/religious-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9540</loc>
+    <loc>https://mergers.fyi/industries/9540/religious-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/955</loc>
+    <loc>https://mergers.fyi/industries/955/civic-professional-and-other-interest-group-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9551</loc>
+    <loc>https://mergers.fyi/industries/9551/business-and-professional-association-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9552</loc>
+    <loc>https://mergers.fyi/industries/9552/labour-association-services</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9559</loc>
+    <loc>https://mergers.fyi/industries/9559/other-interest-group-services-n-e-c</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/96</loc>
+    <loc>https://mergers.fyi/industries/96/private-households-employing-staff-and-undifferentiated-goods-and-service-produc</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/960</loc>
+    <loc>https://mergers.fyi/industries/960/private-households-employing-staff-and-undifferentiated-goods-and-service-produc</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9601</loc>
+    <loc>https://mergers.fyi/industries/9601/private-households-employing-staff</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9602</loc>
+    <loc>https://mergers.fyi/industries/9602/undifferentiated-goods-producing-activities-of-private-households-for-own-use</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/9603</loc>
+    <loc>https://mergers.fyi/industries/9603/undifferentiated-service-producing-activities-of-private-households-for-own-use</loc>
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/A</loc>
+    <loc>https://mergers.fyi/industries/A/agriculture-forestry-and-fishing</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/B</loc>
+    <loc>https://mergers.fyi/industries/B/mining</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/C</loc>
+    <loc>https://mergers.fyi/industries/C/manufacturing</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/D</loc>
+    <loc>https://mergers.fyi/industries/D/electricity-gas-water-and-waste-services</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/E</loc>
+    <loc>https://mergers.fyi/industries/E/construction</loc>
     <lastmod>2026-06-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/F</loc>
+    <loc>https://mergers.fyi/industries/F/wholesale-trade</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/G</loc>
+    <loc>https://mergers.fyi/industries/G/retail-trade</loc>
     <lastmod>2026-06-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/H</loc>
+    <loc>https://mergers.fyi/industries/H/accommodation-and-food-services</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/I</loc>
+    <loc>https://mergers.fyi/industries/I/transport-postal-and-warehousing</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/J</loc>
+    <loc>https://mergers.fyi/industries/J/information-media-and-telecommunications</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/K</loc>
+    <loc>https://mergers.fyi/industries/K/financial-and-insurance-services</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/L</loc>
+    <loc>https://mergers.fyi/industries/L/rental-hiring-and-real-estate-services</loc>
     <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/M</loc>
+    <loc>https://mergers.fyi/industries/M/professional-scientific-and-technical-services</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/N</loc>
+    <loc>https://mergers.fyi/industries/N/administrative-and-support-services</loc>
     <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/O</loc>
+    <loc>https://mergers.fyi/industries/O/public-administration-and-safety</loc>
     <lastmod>2026-06-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/P</loc>
+    <loc>https://mergers.fyi/industries/P/education-and-training</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/Q</loc>
+    <loc>https://mergers.fyi/industries/Q/health-care-and-social-assistance</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/R</loc>
+    <loc>https://mergers.fyi/industries/R/arts-and-recreation-services</loc>
     <lastmod>2026-05-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://mergers.fyi/industries/S</loc>
+    <loc>https://mergers.fyi/industries/S/other-services</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>

--- a/merger-tracker/frontend/src/App.jsx
+++ b/merger-tracker/frontend/src/App.jsx
@@ -43,6 +43,7 @@ function AppContent() {
             <Route path="/timeline" element={<Timeline />} />
             <Route path="/industries" element={<Industries />} />
             <Route path="/industries/:code" element={<IndustryDetail />} />
+            <Route path="/industries/:code/:slug" element={<IndustryDetail />} />
             <Route path="/commentary" element={<Commentary />} />
             <Route path="/digest" element={<Digest />} />
             <Route path="/analysis" element={<Analysis />} />

--- a/merger-tracker/frontend/src/components/IndustryTreemap.jsx
+++ b/merger-tracker/frontend/src/components/IndustryTreemap.jsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { FaArrowRightLong } from 'react-icons/fa6';
+import { industryPath } from '../utils/slug';
 
 // A treemap-style heatmap of industries: cells packed by deal volume (flex-grow
 // proportional to the merger count) and shaded by intensity. Acts as the visual
@@ -44,7 +45,7 @@ function IndustryTreemap({
           return (
             <Link
               key={ind.code}
-              to={`/industries/${ind.code}`}
+              to={industryPath(ind.code, ind.name)}
               className={`group relative rounded-xl px-4 py-3 flex-col justify-between transition-colors ${cellTone(intensity)} ${
                 hideOnMobile ? 'hidden sm:flex' : 'flex'
               }`}

--- a/merger-tracker/frontend/src/pages/IndustryDetail.jsx
+++ b/merger-tracker/frontend/src/pages/IndustryDetail.jsx
@@ -8,6 +8,7 @@ import PhaseDurationComparison from '../components/PhaseDurationComparison';
 import SEO from '../components/SEO';
 import { API_ENDPOINTS } from '../config';
 import { useFetchData } from '../hooks/useFetchData';
+import { industryPath } from '../utils/slug';
 
 // ANZSIC level → human label for the page subtitle and breadcrumb.
 const LEVEL_LABELS = {
@@ -139,7 +140,7 @@ function IndustryDetail() {
       <SEO
         title={industryName}
         description={`${mergers.length} merger${mergers.length !== 1 ? 's' : ''} in the ${industryName} industry${levelLabel ? ` (ANZSIC ${levelLabel.toLowerCase()} ${decodedCode})` : ''} reviewed by the ACCC.`}
-        url={`/industries/${encodeURIComponent(decodedCode)}`}
+        url={industryPath(decodedCode, industryName)}
       />
       <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8 animate-fade-in">
         {/* Breadcrumb: Industries → division → … → current node */}
@@ -154,7 +155,7 @@ function IndustryDetail() {
               <li key={a.code} className="flex items-center gap-x-1.5">
                 <FaChevronRight className="w-3 h-3 text-gray-300" aria-hidden="true" />
                 <Link
-                  to={`/industries/${encodeURIComponent(a.code)}`}
+                  to={industryPath(a.code, a.name)}
                   className="hover:text-primary transition-colors"
                 >
                   {a.name}
@@ -215,7 +216,7 @@ function IndustryDetail() {
               {children.map((child) => (
                 <li key={child.code}>
                   <Link
-                    to={`/industries/${encodeURIComponent(child.code)}`}
+                    to={industryPath(child.code, child.name)}
                     className="flex items-center justify-between gap-3 py-2.5 group"
                   >
                     <span className="text-sm text-gray-900 group-hover:text-primary transition-colors">

--- a/merger-tracker/frontend/src/pages/MergerDetail.jsx
+++ b/merger-tracker/frontend/src/pages/MergerDetail.jsx
@@ -17,7 +17,7 @@ import { useFetchData } from '../hooks/useFetchData';
 import { formatDate } from '../utils/dates';
 import { API_ENDPOINTS } from '../config';
 import { PROSE_MARKDOWN } from '../utils/classNames';
-import { slugify, mergerPath } from '../utils/slug';
+import { slugify, mergerPath, industryPath } from '../utils/slug';
 
 // Display text for each related-merger relationship. Keys match the
 // `relationship` values produced by the data pipeline (see
@@ -404,7 +404,7 @@ function MergerDetail() {
               {merger.anzsic_codes.map((code) => (
                 <Link
                   key={`anzsic-${code.code || code.name}`}
-                  to={code.code ? `/industries/${encodeURIComponent(code.code)}` : `/mergers?q=${encodeURIComponent(code.name)}`}
+                  to={code.code ? industryPath(code.code, code.name) : `/mergers?q=${encodeURIComponent(code.name)}`}
                   className="inline-flex items-center px-3 py-1.5 rounded-lg text-sm bg-gray-50 text-gray-600 border border-gray-100 hover:bg-primary/5 hover:text-primary hover:border-primary/20 transition-all"
                 >
                   {code.name}

--- a/merger-tracker/frontend/src/utils/slug.js
+++ b/merger-tracker/frontend/src/utils/slug.js
@@ -38,3 +38,19 @@ export function mergerPath(id, name) {
   const slug = slugify(name);
   return slug ? `/mergers/${id}/${slug}` : `/mergers/${id}`;
 }
+
+/**
+ * Build the canonical path for an industry detail page, including the readable
+ * slug when one can be derived from the industry name. Falls back to the bare
+ * `/industries/{code}` form. Like the merger slug, this is purely decorative —
+ * industry pages are always looked up by their ANZSIC `code`.
+ *
+ * @param {string} code - ANZSIC code (e.g. "0610")
+ * @param {string} [name] - industry name used to derive the slug
+ * @returns {string}
+ */
+export function industryPath(code, name) {
+  const encodedCode = encodeURIComponent(code);
+  const slug = slugify(name);
+  return slug ? `/industries/${encodedCode}/${slug}` : `/industries/${encodedCode}`;
+}

--- a/scripts/generate_sitemap.py
+++ b/scripts/generate_sitemap.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from xml.sax.saxutils import escape
 
 from merger_filters import load_mergers
-from slug import merger_path
+from slug import industry_path, merger_path
 from static_data import anzsic
 
 
@@ -128,8 +128,13 @@ def generate_sitemap(mergers):
     all_codes = set(anzsic.hierarchy()) | set(industry_latest)
     for code in sorted(all_codes):
         raw = industry_latest.get(code)
+        # Append the readable slug derived from the ANZSIC name, matching what
+        # the SPA renders and links to. Codes tagged outside the known tree have
+        # no node (and so no name) and fall back to the bare /industries/{code}.
+        node = anzsic.get(code)
+        path = industry_path(code, node.name if node else "")
         lines.append(url_entry(
-            loc=escape(f"{BASE_URL}/industries/{code}"),
+            loc=escape(f"{BASE_URL}{path}"),
             lastmod=_format_lastmod(raw) if raw else TODAY,
             changefreq="weekly",
             priority="0.5",

--- a/scripts/slug.py
+++ b/scripts/slug.py
@@ -39,3 +39,15 @@ def merger_path(merger_id: str, name: str) -> str:
     """
     slug = slugify(name)
     return f"/mergers/{merger_id}/{slug}" if slug else f"/mergers/{merger_id}"
+
+
+def industry_path(code: str, name: str) -> str:
+    """Build the canonical path for an industry detail page.
+
+    Includes the readable slug when one can be derived from the industry name,
+    otherwise falls back to the bare ``/industries/{code}`` form. Like the
+    merger slug, this is purely decorative — industry pages are always looked up
+    by their ANZSIC ``code``.
+    """
+    slug = slugify(name)
+    return f"/industries/{code}/{slug}" if slug else f"/industries/{code}"


### PR DESCRIPTION
Mirror the merger-page slug pattern for industry pages: industry URLs
now render as /industries/{code}/{slug} (e.g. /industries/0610/coal-mining)
instead of the bare /industries/{code}. The slug is decorative — pages are
still resolved by ANZSIC code, and the bare form continues to work.

- Add industryPath() helper alongside mergerPath() in both the JS
  (utils/slug.js) and Python (scripts/slug.py) copies, reusing the existing
  slugify()
- Add the optional /industries/:code/:slug route
- Switch every industry link (treemap, breadcrumb ancestors, sub-industry
  children, merger-detail ANZSIC tags) and the canonical SEO url to industryPath
- Emit slugged industry URLs in the sitemap, falling back to the bare form for
  codes tagged outside the known ANZSIC tree

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YAyLEapga3hb8NKtevsDSV