### PR TITLE
Fix digest email column widths so the summary gets the most space

### DIFF
--- a/scripts/send_weekly_email.py
+++ b/scripts/send_weekly_email.py
@@ -311,7 +311,7 @@ def col_header_row(cols: list[str], widths: list[str] | None = None) -> str:
             f'background:#f9fafb;border-bottom:1px solid #efefef;">'
             f"{esc(c)}</td>"
         )
-    return f"<tr>{cells}</tr>"
+    return f'<tr class="col-head">{cells}</tr>'
 
 
 def empty_row(message: str, color: dict, num_cols: int) -> str:
@@ -331,8 +331,8 @@ def name_cell(merger: dict, color: dict) -> str:
         else ""
     )
     return (
-        f'<td style="padding:11px 18px;vertical-align:top;'
-        f'word-break:break-word;overflow-wrap:break-word;">'
+        f'<td class="cell cell-merger" style="padding:11px 18px;'
+        f'vertical-align:top;overflow-wrap:break-word;">'
         f"{merger_link(merger, color)}{waiver}"
         f'<div style="color:#9ca3af;font-size:11px;margin-top:2px;">{mid}</div>'
         f"</td>"
@@ -341,8 +341,9 @@ def name_cell(merger: dict, color: dict) -> str:
 
 def date_cell(date_str: str) -> str:
     return (
-        f'<td style="padding:11px 18px;vertical-align:top;white-space:nowrap;'
-        f'font-size:13px;color:#4b5563;">{esc(format_date(date_str))}</td>'
+        f'<td class="cell cell-date" style="padding:11px 18px;vertical-align:top;'
+        f'white-space:nowrap;font-size:13px;color:#4b5563;">'
+        f"{esc(format_date(date_str))}</td>"
     )
 
 
@@ -357,8 +358,8 @@ def date_stack_cell(notified: str, due: str) -> str:
         'text-transform:uppercase;letter-spacing:0.04em;'
     )
     return (
-        f'<td style="padding:11px 18px;vertical-align:top;white-space:nowrap;'
-        f'font-size:13px;color:#4b5563;">'
+        f'<td class="cell cell-date" style="padding:11px 18px;vertical-align:top;'
+        f'white-space:nowrap;font-size:13px;color:#4b5563;">'
         f'<span style="{label}">Notified</span>{esc(format_date(notified))}'
         f'<span style="{label}margin-top:6px;">Due</span>'
         f"{esc(format_date(due))}"
@@ -373,7 +374,8 @@ def text_cell(text: str, bold_color: str | None = None) -> str:
         else "color:#4b5563;"
     )
     return (
-        f'<td style="padding:11px 18px;vertical-align:top;font-size:13px;'
+        f'<td class="cell cell-summary" style="padding:11px 18px;'
+        f'vertical-align:top;font-size:13px;'
         f'{style}line-height:1.5;">{esc(text)}</td>'
     )
 
@@ -402,7 +404,8 @@ def section_table(
         )
         layout = "table-layout:fixed;"
     return (
-        '<table width="100%" cellpadding="0" cellspacing="0" border="0" '
+        '<table class="sec-table" width="100%" cellpadding="0" cellspacing="0" '
+        'border="0" '
         'style="border-radius:10px;overflow:hidden;border:1px solid #e5e7eb;'
         f'{layout}margin-bottom:20px;">'
         f"{colgroup}{header_row}{col_row}{data_rows}"
@@ -662,6 +665,24 @@ def build_html_email(digest: dict) -> str:
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Weekly mergers digest for {esc(date_range)} | Australian Merger Tracker</title>
+  <style>
+    /* On narrow screens the fixed three-column layout can't fit: merger
+       names break mid-word and the date column overlaps the summary. Stack
+       the cells vertically instead so each gets the full width. */
+    @media only screen and (max-width:600px) {{
+      table.sec-table {{ table-layout:auto !important; }}
+      table.sec-table colgroup {{ display:none !important; }}
+      table.sec-table tr.col-head {{ display:none !important; }}
+      table.sec-table td.cell {{
+        display:block !important;
+        width:100% !important;
+        box-sizing:border-box !important;
+        white-space:normal !important;
+        padding:10px 18px 0 !important;
+      }}
+      table.sec-table td.cell-summary {{ padding-bottom:12px !important; }}
+    }}
+  </style>
 </head>
 <body style="margin:0;padding:0;background-color:#f1f5f9;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,Helvetica,sans-serif;">
 

--- a/scripts/send_weekly_email.py
+++ b/scripts/send_weekly_email.py
@@ -298,14 +298,19 @@ def section_header_row(title: str, color: dict, num_cols: int) -> str:
     )
 
 
-def col_header_row(*cols: str) -> str:
-    cells = "".join(
-        f'<td style="padding:8px 18px;font-size:11px;font-weight:600;'
-        f'color:#6b7280;text-transform:uppercase;letter-spacing:0.05em;'
-        f'background:#f9fafb;border-bottom:1px solid #efefef;">'
-        f"{esc(c)}</td>"
-        for c in cols
-    )
+def col_header_row(cols: list[str], widths: list[str] | None = None) -> str:
+    if widths is None:
+        widths = [""] * len(cols)
+    cells = ""
+    for c, w in zip(cols, widths):
+        width_attr = f' width="{w}"' if w else ""
+        cells += (
+            f'<td{width_attr} style="padding:8px 18px;'
+            f'font-size:11px;font-weight:600;'
+            f'color:#6b7280;text-transform:uppercase;letter-spacing:0.05em;'
+            f'background:#f9fafb;border-bottom:1px solid #efefef;">'
+            f"{esc(c)}</td>"
+        )
     return f"<tr>{cells}</tr>"
 
 
@@ -326,7 +331,8 @@ def name_cell(merger: dict, color: dict) -> str:
         else ""
     )
     return (
-        f'<td style="padding:11px 18px;vertical-align:top;min-width:180px;">'
+        f'<td style="padding:11px 18px;vertical-align:top;'
+        f'word-break:break-word;overflow-wrap:break-word;">'
         f"{merger_link(merger, color)}{waiver}"
         f'<div style="color:#9ca3af;font-size:11px;margin-top:2px;">{mid}</div>'
         f"</td>"
@@ -372,18 +378,48 @@ def text_cell(text: str, bold_color: str | None = None) -> str:
     )
 
 
-def section_table(header_row: str, col_row: str, data_rows: str) -> str:
+def section_table(
+    header_row: str,
+    col_row: str,
+    data_rows: str,
+    col_widths: list[str] | None = None,
+) -> str:
+    """Render a section table.
+
+    ``col_widths`` pins the column widths via a ``<colgroup>`` and
+    ``table-layout:fixed`` so the merger-name column can't stretch to fit
+    long names and starve the summary/determination column. Clients that
+    ignore ``colgroup`` fall back to the ``width`` hints on the column
+    header cells.
+    """
+    colgroup = ""
+    layout = ""
+    if col_widths:
+        colgroup = (
+            "<colgroup>"
+            + "".join(f'<col style="width:{w};">' for w in col_widths)
+            + "</colgroup>"
+        )
+        layout = "table-layout:fixed;"
     return (
         '<table width="100%" cellpadding="0" cellspacing="0" border="0" '
         'style="border-radius:10px;overflow:hidden;border:1px solid #e5e7eb;'
-        'margin-bottom:20px;">'
-        f"{header_row}{col_row}{data_rows}"
+        f'{layout}margin-bottom:20px;">'
+        f"{colgroup}{header_row}{col_row}{data_rows}"
         "</table>"
     )
 
 # ---------------------------------------------------------------------------
 # Section builders
 # ---------------------------------------------------------------------------
+
+# Column widths (Merger | Date | last column). Summary-heavy sections give
+# the bulk of the width to the description; determination/stage sections have
+# a short final column, so the merger name can take more room there.
+SUMMARY_COL_WIDTHS = ["26%", "18%", "56%"]
+DETERMINATION_COL_WIDTHS = ["46%", "20%", "34%"]
+CEASED_COL_WIDTHS = ["42%", "24%", "34%"]
+
 
 def _row_divider() -> str:
     return ' style="border-bottom:1px solid #f5f5f5;"'
@@ -393,7 +429,7 @@ def build_new_mergers(mergers: list) -> str:
     c = COLORS["new_merger"]
     num_cols = 3
     hdr = section_header_row("New mergers notified", c, num_cols)
-    cols = col_header_row("Merger", "Notified", "Summary")
+    cols = col_header_row(["Merger", "Notified", "Summary"], SUMMARY_COL_WIDTHS)
     if not mergers:
         rows = empty_row("No new mergers notified this week.", c, num_cols)
     else:
@@ -407,7 +443,7 @@ def build_new_mergers(mergers: list) -> str:
                 f"{text_cell(desc)}"
                 f"</tr>"
             )
-    return section_table(hdr, cols, rows)
+    return section_table(hdr, cols, rows, SUMMARY_COL_WIDTHS)
 
 
 def _cleared_phase(merger: dict) -> str:
@@ -450,7 +486,7 @@ def build_cleared(mergers: list) -> str:
     c = COLORS["cleared"]
     num_cols = 3
     hdr = section_header_row("Mergers approved", c, num_cols)
-    cols = col_header_row("Merger", "Date", "Determination")
+    cols = col_header_row(["Merger", "Date", "Determination"], DETERMINATION_COL_WIDTHS)
     if not mergers:
         rows = empty_row("No mergers approved this week.", c, num_cols)
     else:
@@ -472,14 +508,14 @@ def build_cleared(mergers: list) -> str:
                     f"{text_cell(det, c['dark'])}"
                     f"</tr>"
                 )
-    return section_table(hdr, cols, rows)
+    return section_table(hdr, cols, rows, DETERMINATION_COL_WIDTHS)
 
 
 def build_declined(mergers: list) -> str:
     c = COLORS["declined"]
     num_cols = 3
     hdr = section_header_row("Mergers declined", c, num_cols)
-    cols = col_header_row("Merger", "Date", "Determination")
+    cols = col_header_row(["Merger", "Date", "Determination"], DETERMINATION_COL_WIDTHS)
     if not mergers:
         rows = empty_row("No mergers declined this week.", c, num_cols)
     else:
@@ -498,14 +534,14 @@ def build_declined(mergers: list) -> str:
                 f"{text_cell(det, c['dark'])}"
                 f"</tr>"
             )
-    return section_table(hdr, cols, rows)
+    return section_table(hdr, cols, rows, DETERMINATION_COL_WIDTHS)
 
 
 def build_referred_to_phase_2(mergers: list) -> str:
     c = COLORS["phase_2_referral"]
     num_cols = 3
     hdr = section_header_row("Mergers referred to phase 2", c, num_cols)
-    cols = col_header_row("Merger", "Referral date", "Determination")
+    cols = col_header_row(["Merger", "Referral date", "Determination"], DETERMINATION_COL_WIDTHS)
     if not mergers:
         rows = empty_row("No mergers referred to phase 2 this week.", c, num_cols)
     else:
@@ -523,14 +559,14 @@ def build_referred_to_phase_2(mergers: list) -> str:
                 f"{text_cell(det, c['dark'])}"
                 f"</tr>"
             )
-    return section_table(hdr, cols, rows)
+    return section_table(hdr, cols, rows, DETERMINATION_COL_WIDTHS)
 
 
 def build_ceased(mergers: list) -> str:
     c = COLORS["ceased"]
     num_cols = 3
     hdr = section_header_row("Assessment ceased", c, num_cols)
-    cols = col_header_row("Merger", "Date ceased", "Stage")
+    cols = col_header_row(["Merger", "Date ceased", "Stage"], CEASED_COL_WIDTHS)
     rows = ""
     for m in mergers:
         rows += (
@@ -540,14 +576,14 @@ def build_ceased(mergers: list) -> str:
             f"{text_cell(m.get('stage') or 'N/A', c['dark'])}"
             f"</tr>"
         )
-    return section_table(hdr, cols, rows)
+    return section_table(hdr, cols, rows, CEASED_COL_WIDTHS)
 
 
 def build_phase_section(mergers: list, phase_key: str, title: str) -> str:
     c = COLORS[phase_key]
     num_cols = 3
     hdr = section_header_row(title, c, num_cols)
-    cols = col_header_row("Merger", "Dates", "Summary")
+    cols = col_header_row(["Merger", "Dates", "Summary"], SUMMARY_COL_WIDTHS)
     if not mergers:
         rows = empty_row(f"No ongoing {title.lower().split('–')[0].strip()} mergers.", c, num_cols)
     else:
@@ -561,7 +597,7 @@ def build_phase_section(mergers: list, phase_key: str, title: str) -> str:
                 f"{text_cell(desc)}"
                 f"</tr>"
             )
-    return section_table(hdr, cols, rows)
+    return section_table(hdr, cols, rows, SUMMARY_COL_WIDTHS)
 
 # ---------------------------------------------------------------------------
 # Full email builder


### PR DESCRIPTION
## Problem

In the weekly digest email, the section tables used **automatic** table layout with no column widths. The merger-name column stretched to fit long names (it even carried a `min-width:180px`), which squeezed the Summary into the right ~40% of the row and left a large empty gap before the date column. The recent date-stacking change (#540) couldn't fix this on its own.

## Changes

`scripts/send_weekly_email.py`:

- `section_table` now pins column widths via a `<colgroup>` with `table-layout:fixed`, with `width` hints on the column header cells as a fallback for clients that ignore `colgroup`.
- Dropped `min-width:180px` on the name cell in favour of `word-break`/`overflow-wrap` so long names wrap inside their column instead of forcing it wide.
- Three width profiles:
  - **Summary-heavy sections** (new mergers, ongoing phase 1/2): `26% / 18% / 56%` — description gets the majority of the width.
  - **Determination sections** (approved / declined / referred): `46% / 20% / 34%` — wider name column since the final column is short ("Approved", etc.).
  - **Ceased**: `42% / 24% / 34%`.

## Verification

Rendered the `DRY_RUN=true` email preview before and after. The Summary now spans the majority of each row across all section types, and long merger names wrap rather than starving the summary.

## Notes

- There's no automated test for `send_weekly_email.py`, so this was validated visually via the dry-run preview rather than a unit test.
- `colgroup` widths render well in Gmail/Apple Mail; Outlook's Word engine has imperfect `colgroup` support, which is why the `width` hints on the header cells are kept as a fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ho1t4WoTUPumn7eA3XkDW7)_