### PR TITLE
Style upcoming events title as a section heading

### DIFF
--- a/merger-tracker/frontend/src/components/UpcomingEventsTimeline.jsx
+++ b/merger-tracker/frontend/src/components/UpcomingEventsTimeline.jsx
@@ -84,16 +84,14 @@ function UpcomingEventsTimeline({ events }) {
   if (days.length === 0) return <EmptyCard />;
 
   return (
-    <section
-      aria-labelledby="upcoming-events-heading"
-      className="bg-white rounded-2xl border border-gray-100 shadow-card overflow-hidden"
-    >
-      <div className="px-5 sm:px-6 py-4 border-b border-gray-50">
-        <h2 id="upcoming-events-heading" className="text-lg font-semibold text-gray-900">
-          Upcoming events
-        </h2>
-      </div>
-
+    <section aria-labelledby="upcoming-events-heading">
+      <h2
+        id="upcoming-events-heading"
+        className="text-lg font-semibold text-gray-900 mb-4"
+      >
+        Upcoming events
+      </h2>
+      <div className="bg-white rounded-2xl border border-gray-100 shadow-card overflow-hidden">
       <ol className="px-5 sm:px-6 py-5">
         {days.map((day, dayIndex) => {
           const daysRemaining = getCalendarDaysUntil(day.date);
@@ -168,6 +166,7 @@ function UpcomingEventsTimeline({ events }) {
           );
         })}
       </ol>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
Pull the Upcoming events title out of the card header so it sits above
the card as a plain section heading, matching the recent determinations
and recently notified mergers sections on the dashboard.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RD53MY7Nc2ehrG8AyVB81P