### PR TITLE
Sort upcoming events within a day by type, phase, then name

### DIFF
--- a/merger-tracker/frontend/src/components/UpcomingEventsTimeline.jsx
+++ b/merger-tracker/frontend/src/components/UpcomingEventsTimeline.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { FaRegComments, FaGavel, FaTriangleExclamation } from 'react-icons/fa6';
 import { mergerPath } from '../utils/slug';
 import { formatWeekday, getCalendarDaysUntil } from '../utils/dates';
+import { PHASES } from '../constants/mergerStatus';
 
 // Each event type carries its own accent (icon tile + chip) so the kind of
 // deadline is recognisable at a glance, independent of the urgency colouring
@@ -36,6 +37,29 @@ const DEFAULT_EVENT_TYPE = {
 };
 
 const getEventType = (type) => EVENT_TYPES[type] || DEFAULT_EVENT_TYPE;
+
+// Within a single calendar day, surface the most consequential deadlines
+// first: determinations rank above concerns notices, which rank above
+// consultations; Phase 2 outranks Phase 1; ties fall back to the merger name
+// so the order is stable.
+const EVENT_TYPE_ORDER = {
+  determination_due: 0,
+  notice_of_competition_concerns: 1,
+  consultation_due: 2,
+};
+
+const phaseRank = (stage) => (stage && stage.includes(PHASES.PHASE_2) ? 0 : 1);
+
+function compareWithinDay(a, b) {
+  const typeDelta =
+    (EVENT_TYPE_ORDER[a.type] ?? 99) - (EVENT_TYPE_ORDER[b.type] ?? 99);
+  if (typeDelta !== 0) return typeDelta;
+
+  const phaseDelta = phaseRank(a.stage) - phaseRank(b.stage);
+  if (phaseDelta !== 0) return phaseDelta;
+
+  return a.merger_name.localeCompare(b.merger_name);
+}
 
 // Urgency drives the day marker: due today reads red, the next few days amber,
 // anything further out sits in the calm primary green.
@@ -72,7 +96,10 @@ function UpcomingEventsTimeline({ events }) {
     if (!events) return [];
     const byDay = new Map();
     [...events]
-      .sort((a, b) => a.date.localeCompare(b.date))
+      .sort((a, b) => {
+        const dayDelta = a.date.slice(0, 10).localeCompare(b.date.slice(0, 10));
+        return dayDelta !== 0 ? dayDelta : compareWithinDay(a, b);
+      })
       .forEach((event) => {
         const key = event.date.slice(0, 10);
         if (!byDay.has(key)) byDay.set(key, { date: event.date, events: [] });

--- a/merger-tracker/frontend/src/components/__tests__/UpcomingEventsTimeline.test.jsx
+++ b/merger-tracker/frontend/src/components/__tests__/UpcomingEventsTimeline.test.jsx
@@ -67,6 +67,52 @@ describe('UpcomingEventsTimeline', () => {
     expect(screen.getByText('Gamma – Delta')).toBeInTheDocument();
   });
 
+  it('orders events within a day: determinations first, Phase 2 above Phase 1, then name', () => {
+    renderTimeline([
+      makeEvent({
+        date: '2026-06-30T12:00:00Z',
+        merger_id: 'MN-1',
+        merger_name: 'Zeta – Consultation P1',
+        type: 'consultation_due',
+        stage: 'Phase 1 - initial assessment',
+      }),
+      makeEvent({
+        date: '2026-06-30T12:00:00Z',
+        merger_id: 'MN-2',
+        merger_name: 'Alpha – Determination P1',
+        type: 'determination_due',
+        stage: 'Phase 1 - initial assessment',
+      }),
+      makeEvent({
+        date: '2026-06-30T12:00:00Z',
+        merger_id: 'MN-3',
+        merger_name: 'Beta – Determination P2',
+        type: 'determination_due',
+        stage: 'Phase 2 - in-depth review',
+      }),
+      makeEvent({
+        date: '2026-06-30T12:00:00Z',
+        merger_id: 'MN-4',
+        merger_name: 'Aardvark – Determination P2',
+        type: 'determination_due',
+        stage: 'Phase 2 - in-depth review',
+      }),
+    ]);
+
+    const links = screen.getAllByRole('link');
+    const names = links.map((link) => within(link).getByText(/–/).textContent);
+
+    expect(names).toEqual([
+      // Phase 2 determinations first, broken by merger name…
+      'Aardvark – Determination P2',
+      'Beta – Determination P2',
+      // …then the Phase 1 determination…
+      'Alpha – Determination P1',
+      // …and consultations last.
+      'Zeta – Consultation P1',
+    ]);
+  });
+
   it('labels by calendar day, not elapsed 24-hour periods', () => {
     // Afternoon on the 28th: an event at noon UTC on the 29th is under 24h away
     // but is still the next calendar day, so it must read "Tomorrow", not "Today".


### PR DESCRIPTION
Group events by calendar day still orders days earliest-first, but within
a day events now sort with determinations above concerns notices above
consultations, Phase 2 above Phase 1, and ties broken by merger name.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019JtYSNXJdiNJeNVdPjPVnk