### PR TITLE
Add blue ring to new recent mergers and determinations cards

### DIFF
--- a/merger-tracker/frontend/src/components/CardCollapseGrid.jsx
+++ b/merger-tracker/frontend/src/components/CardCollapseGrid.jsx
@@ -30,7 +30,7 @@ function CardCollapseGrid({ items, getKey, getStyle, renderBody }) {
           return (
             <li
               key={getKey(item, index)}
-              className={`relative ${visibilityClass(index)} min-h-[7rem] flex-col justify-between rounded-xl p-4 transition-colors ${style.bg} ${style.text}`}
+              className={`relative ${visibilityClass(index)} min-h-[7rem] flex-col justify-between rounded-xl p-4 transition-colors ${style.bg} ${style.text} ${style.border || ''}`}
             >
               {renderBody(item, style)}
             </li>

--- a/merger-tracker/frontend/src/components/RecentDeterminationsCards.jsx
+++ b/merger-tracker/frontend/src/components/RecentDeterminationsCards.jsx
@@ -3,12 +3,19 @@ import { mergerPath } from '../utils/slug';
 import { formatDate } from '../utils/dates';
 import { isNewItem } from '../utils/lastVisit';
 import { MERGER_STATUS } from '../constants/mergerStatus';
-import { getCardStyle } from '../constants/cardStyles';
+import { getCardStyle, NEW_ITEM_BORDER } from '../constants/cardStyles';
 import CardCollapseGrid from './CardCollapseGrid';
 
 const DETERMINATION_LABELS = {
   [MERGER_STATUS.ASSESSMENT_CEASED]: 'Ceased',
 };
+
+function getDeterminationCardStyle(item) {
+  const base = getCardStyle({ determination: item.determination });
+  // Highlight recent determinations the visitor hasn't seen yet (those that
+  // also show a "New" badge) with a blue ring so they stand out.
+  return isNewItem(item.merger_id) ? { ...base, border: NEW_ITEM_BORDER } : base;
+}
 
 function RecentDeterminationsCards({ determinations }) {
   if (!determinations || determinations.length === 0) {
@@ -35,7 +42,7 @@ function RecentDeterminationsCards({ determinations }) {
         getKey={(item) =>
           `${item.merger_id}-${item.determination_date}-${item.determination_type}`
         }
-        getStyle={(item) => getCardStyle({ determination: item.determination })}
+        getStyle={getDeterminationCardStyle}
         renderBody={(item, style) => (
           <>
             <div className="flex items-start justify-between gap-2">

--- a/merger-tracker/frontend/src/components/RecentMergersCards.jsx
+++ b/merger-tracker/frontend/src/components/RecentMergersCards.jsx
@@ -3,7 +3,7 @@ import { mergerPath } from '../utils/slug';
 import { formatDate } from '../utils/dates';
 import { isNewItem } from '../utils/lastVisit';
 import { MERGER_STATUS } from '../constants/mergerStatus';
-import { getCardStyle } from '../constants/cardStyles';
+import { getCardStyle, NEW_ITEM_BORDER } from '../constants/cardStyles';
 import CardCollapseGrid from './CardCollapseGrid';
 
 // Mergers still under assessment stay calm: a white card with a green
@@ -18,13 +18,16 @@ const UNDER_ASSESSMENT_STYLE = {
 };
 
 function getMergerCardStyle(merger) {
-  if (!merger.accc_determination && merger.status === MERGER_STATUS.UNDER_ASSESSMENT) {
-    return UNDER_ASSESSMENT_STYLE;
-  }
-  return getCardStyle({
-    determination: merger.accc_determination,
-    status: merger.status,
-  });
+  const base =
+    !merger.accc_determination && merger.status === MERGER_STATUS.UNDER_ASSESSMENT
+      ? UNDER_ASSESSMENT_STYLE
+      : getCardStyle({
+          determination: merger.accc_determination,
+          status: merger.status,
+        });
+  // Highlight recently notified mergers the visitor hasn't seen yet (those that
+  // also show a "New" badge) with a blue ring so they stand out.
+  return isNewItem(merger.merger_id) ? { ...base, border: NEW_ITEM_BORDER } : base;
 }
 
 function RecentMergersCards({ mergers }) {

--- a/merger-tracker/frontend/src/constants/cardStyles.js
+++ b/merger-tracker/frontend/src/constants/cardStyles.js
@@ -34,6 +34,12 @@ export const CARD_STYLES = {
 
 export const DEFAULT_CARD_STYLE = { bg: 'bg-gray-500 hover:bg-gray-600', sub: 'text-gray-50/80', ...ON_DARK };
 
+// Blue ring applied to cards for items the visitor hasn't seen yet (those that
+// also show a "New" badge), so recent arrivals stand out from the grid. A ring
+// (rather than a border) avoids shifting the card's layout. Full class string
+// required so Tailwind's scanner keeps it at build time.
+export const NEW_ITEM_BORDER = 'ring-2 ring-blue-500';
+
 // Determination takes precedence over status, mirroring StatusBadge.
 export function getCardStyle({ determination, status } = {}) {
   return CARD_STYLES[determination] || CARD_STYLES[status] || DEFAULT_CARD_STYLE;


### PR DESCRIPTION
Recently notified mergers and recent determinations that the visitor
hasn't seen yet (those showing the "New" badge) now get a blue ring so
they stand out in the dashboard card grids.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SMTDyoUDLaXf8kCMCJ9XRq