### PR TITLE
Create a PR for related mergers instead of an issue

### DIFF
--- a/.github/workflows/detect-related-mergers.yml
+++ b/.github/workflows/detect-related-mergers.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  issues: write
+  contents: write        # needed to push the suggestion branch
+  pull-requests: write   # needed to create / update the suggestion PR
 
 jobs:
   detect:
@@ -27,116 +27,89 @@ jobs:
       - name: Run related-merger detection
         id: detect
         run: |
-          python3 scripts/detect_related_mergers.py \
-            --branch "${{ github.event.repository.default_branch }}" \
-            --issue-json issue_payload.json || true
-          COUNT=$(jq -r '.count' issue_payload.json)
-          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          if python3 scripts/detect_related_mergers.py --summary; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Write job summary
+        run: |
           {
             echo "### Related mergers detection"
             echo ""
-            if [ "$COUNT" -gt 0 ]; then
-              echo "Found **$COUNT** candidate pair(s)."
-              jq -r '.candidates[] | "- \(.pair_id) — confidence \(.score)"' issue_payload.json
-            else
-              echo "No candidate pairs found."
-            fi
+            python3 scripts/detect_related_mergers.py --summary || true
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Ensure label exists
+      # Switch to (or create/reset) the well-known suggestion branch so the
+      # commit lands on top of the current default-branch HEAD.
+      - name: Create or reset suggestion branch
+        id: branch
+        if: steps.detect.outputs.found == 'true'
+        run: |
+          BRANCH="fix/related-mergers"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git switch -C "$BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Apply suggested pairs
+        if: steps.detect.outputs.found == 'true'
+        run: |
+          python3 scripts/detect_related_mergers.py \
+            --apply-suggestions \
+            --pr-markdown pr_body.md || true
+
+      - name: Commit and push suggestion branch
+        id: commit
+        if: steps.detect.outputs.found == 'true'
+        run: |
+          BRANCH="${{ steps.branch.outputs.branch }}"
+          if git diff --quiet data/processed/related_mergers.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            git add data/processed/related_mergers.json
+            git commit -m "suggest: candidate related mergers detected on $(date -u +%Y-%m-%d)"
+            git push origin "$BRANCH" --force
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create or update pull request
+        if: steps.detect.outputs.found == 'true' && steps.commit.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh label create "related-mergers" \
-            --description "Suggested additions to data/processed/related_mergers.json" \
-            --color "1f6feb" \
-            --force
+          BRANCH="${{ steps.branch.outputs.branch }}"
+          TITLE="suggest: link related mergers ($(date -u +%Y-%m-%d))"
 
-      # List every issue the bot has ever opened for this purpose (open or
-      # closed). A closed issue is treated as a permanent decision — the bot
-      # will NOT re-raise the same pair on a later run.
-      - name: Gather existing related-mergers issues
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh issue list \
-            --label related-mergers \
-            --state all \
-            --limit 500 \
-            --json number,state,title > existing_issues.json
+          EXISTING=$(gh pr list \
+            --head "$BRANCH" \
+            --state open \
+            --json number \
+            --jq '.[0].number' 2>/dev/null || echo "")
 
-          # Extract the "<ID>/<ID>" pair marker from each title.  Titles created
-          # by this workflow always contain that substring (e.g. WA-1234/MN-5678
-          # or MN-1234/MN-5678); anything else is skipped.
-          jq -r '
-            .[]
-            | select(.title | test("[A-Z]{2}-[0-9]+/[A-Z]{2}-[0-9]+"))
-            | [
-                (.title | capture("(?<a>[A-Z]{2}-[0-9]+)/(?<b>[A-Z]{2}-[0-9]+)") | .a + "/" + .b),
-                (.number | tostring),
-                .state
-              ]
-            | @tsv
-          ' existing_issues.json > existing_pairs.tsv
-
-          echo "Existing related-mergers issues (pair, number, state):"
-          cat existing_pairs.tsv || true
-
-      # For each candidate pair, create an issue if (and only if) no issue
-      # for that pair already exists in any state.
-      - name: Create issues for new candidate pairs
-        if: steps.detect.outputs.count != '0'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          COUNT=$(jq -r '.count' issue_payload.json)
-          CREATED=0
-          SKIPPED=0
-          for i in $(seq 0 $((COUNT - 1))); do
-            PAIR=$(jq -r ".candidates[$i].pair_id" issue_payload.json)
-            if awk -F '\t' -v p="$PAIR" '$1 == p { found=1 } END { exit !found }' existing_pairs.tsv; then
-              STATE=$(awk -F '\t' -v p="$PAIR" '$1 == p { print $3; exit }' existing_pairs.tsv)
-              echo "Skipping $PAIR — existing issue ($STATE)."
-              SKIPPED=$((SKIPPED + 1))
-              continue
-            fi
-            TITLE=$(jq -r ".candidates[$i].title" issue_payload.json)
-            BODY=$(jq -r ".candidates[$i].body" issue_payload.json)
-            URL=$(gh issue create \
+          if [ -n "$EXISTING" ]; then
+            gh pr edit "$EXISTING" --title "$TITLE" --body-file pr_body.md
+            echo "Updated PR #$EXISTING"
+          else
+            gh pr create \
+              --head "$BRANCH" \
               --title "$TITLE" \
-              --body "$BODY" \
-              --label "related-mergers")
-            echo "Created issue for $PAIR: $URL"
-            CREATED=$((CREATED + 1))
-          done
-          {
-            echo ""
-            echo "**Issues created:** $CREATED"
-            echo "**Already-seen pairs skipped:** $SKIPPED"
-          } >> "$GITHUB_STEP_SUMMARY"
+              --body-file pr_body.md
+          fi
 
-      # Close open issues whose pair is no longer flagged by the detector.
-      # This handles the case where the user added the pair to
-      # related_mergers.json (detector now filters it out) or the underlying
-      # data changed.  Issues the user has already closed are left alone.
-      - name: Close open issues for pairs no longer flagged
+      - name: Close suggestion PR when nothing left to recommend
+        if: steps.detect.outputs.found == 'false'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          jq -r '.candidates[].pair_id' issue_payload.json > current_pairs.txt
-          jq -r '.recorded_pairs[]' issue_payload.json > recorded_pairs.txt
-
-          awk -F '\t' '$3 == "OPEN" { print $1 "\t" $2 }' existing_pairs.tsv | \
-          while IFS=$'\t' read -r pair num; do
-            [ -z "$pair" ] && continue
-            if grep -qxF "$pair" current_pairs.txt; then
-              continue   # still flagged — leave the issue open
-            fi
-            if grep -qxF "$pair" recorded_pairs.txt; then
-              MSG="Looks like \`$pair\` is now recorded in \`data/processed/related_mergers.json\` — thanks! Closing automatically."
-            else
-              MSG="The detector no longer flags \`$pair\` (the underlying data may have changed, or the pair was added to \`related_mergers.json\` and then removed). Closing automatically — re-open this issue if you want to act on it."
-            fi
-            echo "Closing #$num for $pair"
-            gh issue close "$num" --comment "$MSG" || true
+          gh pr list \
+            --head "fix/related-mergers" \
+            --state open \
+            --json number \
+            --jq '.[].number' | \
+          while read -r num; do
+            gh pr close "$num" \
+              --comment "All detected related-merger pairs have been recorded as of $(date -u +%Y-%m-%d). Closing automatically." \
+              || true
           done

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -90,7 +90,9 @@ Runs `detect_duplicates.py` to identify duplicate merger entries and reports any
 
 ### `detect-related-mergers.yml` — Daily related-merger check (02:30 UTC)
 
-Runs `detect_related_mergers.py` to suggest waiver→notification pairs.
+Runs `detect_related_mergers.py` to suggest re-filed merger pairs (declined
+waiver→notification, or suspended→re-filed), and opens (or updates) a pull
+request recommending additions to `data/processed/related_mergers.json`.
 
 ### `detect-related-parties.yml` — Daily related-party check (02:45 UTC)
 

--- a/scripts/detect_related_mergers.py
+++ b/scripts/detect_related_mergers.py
@@ -34,7 +34,8 @@ are filtered out.
 
 Usage
 -----
-  python scripts/detect_related_mergers.py [--threshold 0.70] [--json PATH]
+  python scripts/detect_related_mergers.py [--threshold 0.70] [--summary]
+  python scripts/detect_related_mergers.py --apply-suggestions --pr-markdown pr_body.md
 
 Exit code is 1 if new candidate pairs are found (useful in CI), 0 otherwise.
 """
@@ -349,23 +350,11 @@ def find_candidates(
 
 
 # ---------------------------------------------------------------------------
-# Issue body construction
+# Reporting helpers
 # ---------------------------------------------------------------------------
 
 def mergers_fyi_url(merger_id: str) -> str:
     return f"{_MERGERS_FYI_BASE}/{merger_id}"
-
-
-def edit_related_mergers_url(branch: str = "main") -> str:
-    return f"https://github.com/{_REPO}/edit/{branch}/{_RELATED_PATH}"
-
-
-def json_line_for(candidate: dict) -> str:
-    """Render the exact line to paste into the `pairs` array of related_mergers.json."""
-    return (
-        f'    {{ "from": "{candidate["source"]}", '
-        f'"to": "{candidate["target"]}", "type": "{candidate["type"]}" }},'
-    )
 
 
 def _format_signals(signals: dict) -> str:
@@ -381,100 +370,145 @@ def _format_signals(signals: dict) -> str:
 
 
 def pair_id(candidate: dict) -> str:
-    """Canonical, parseable identifier used in titles and for de-duplication."""
+    """Canonical, parseable identifier for a candidate pair."""
     return f"{candidate['source']}/{candidate['target']}"
 
 
-def build_issue_title(candidate: dict) -> str:
-    src = candidate["source"]
-    tgt = candidate["target"]
-    # The `<ID>/<ID>` substring is the marker the workflow greps for to decide
-    # whether an issue already exists for this pair.
-    name = candidate.get("source_name") or candidate.get("target_name") or ""
-    base = f"Related mergers: {src}/{tgt}"
-    if name:
-        base = f"{base} — {name}"
-    # GitHub issue title limit is 256 chars
-    if len(base) > 240:
-        base = base[:237] + "..."
-    return base
-
-
 def _relationship_blurb(candidate: dict) -> str:
-    """One-line description of the relationship pattern for the issue body."""
+    """One-line description of the relationship pattern for the PR body."""
     if candidate["type"] == SUSPENDED_REFILED:
         return (
-            "A \"related merger\" here is a matter whose assessment was "
-            "**suspended** and which appears to have been **re-filed** as a "
-            "separate matter (see the `_README` field in the JSON)."
+            "A matter whose assessment was **suspended** and which appears to "
+            "have been **re-filed** as a separate matter."
         )
     return (
-        "A \"related merger\" is one that was initially filed as a **waiver** "
-        "application, declined, then re-filed as a formal **notification** "
-        "(see the `_README` field in the JSON)."
+        "A matter initially filed as a **waiver** application, declined, then "
+        "re-filed as a formal **notification**."
     )
 
 
-def build_issue_body(candidate: dict, branch: str = "main") -> str:
-    src = candidate["source"]
-    tgt = candidate["target"]
-    edit_url = edit_related_mergers_url(branch)
-    related_blob = f"https://github.com/{_REPO}/blob/{branch}/{_RELATED_PATH}"
+# ---------------------------------------------------------------------------
+# Applying suggestions to related_mergers.json
+# ---------------------------------------------------------------------------
 
-    if candidate["type"] == SUSPENDED_REFILED:
-        source_label = "Suspended matter"
-        source_detail = f"status: {candidate['source_status'] or 'unknown'}"
-        target_label = "Re-filed as"
-        target_detail = f"status: {candidate['target_status'] or 'unknown'}"
-    else:
-        source_label = "Waiver"
-        source_detail = (
-            f"determination: {candidate['source_determination'] or 'unknown'}"
+def _pair_from_candidate(candidate: dict) -> dict:
+    """Render a candidate as a pair entry for related_mergers.json."""
+    return {
+        "from": candidate["source"],
+        "to": candidate["target"],
+        "type": candidate["type"],
+    }
+
+
+def write_related_mergers(path: Path, data: dict) -> None:
+    """Write related_mergers.json, preserving the compact one-line-per-pair style."""
+    pairs = data.get("pairs", [])
+    lines = ["{"]
+    if "_README" in data:
+        lines.append(f"  {json.dumps('_README')}: {json.dumps(data['_README'])},")
+    lines.append('  "pairs": [')
+    for i, p in enumerate(pairs):
+        trailing = "," if i < len(pairs) - 1 else ""
+        lines.append(
+            f'    {{ "from": "{p["from"]}", "to": "{p["to"]}", '
+            f'"type": "{p.get("type", WAIVER_REFILED)}" }}{trailing}'
         )
-        target_label = "Notification"
-        target_detail = f"status: {candidate['target_status'] or 'unknown'}"
+    lines.append("  ]")
+    lines.append("}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n")
 
+
+def apply_suggestions(related_path: Path, candidates: list[dict]) -> int:
+    """Append candidate pairs to related_mergers.json in-place. Returns count added."""
+    if related_path.exists():
+        with related_path.open() as fh:
+            data = json.load(fh)
+    else:
+        data = {"pairs": []}
+    data.setdefault("pairs", [])
+    data["pairs"].extend(_pair_from_candidate(c) for c in candidates)
+    write_related_mergers(related_path, data)
+    return len(candidates)
+
+
+# ---------------------------------------------------------------------------
+# PR body construction
+# ---------------------------------------------------------------------------
+
+def build_pr_body(candidates: list[dict], date: str) -> str:
+    """Build a markdown PR body recommending the candidate pairs."""
+    related_blob = f"https://github.com/{_REPO}/blob/main/{_RELATED_PATH}"
     lines = [
-        f"<!-- pair-id: {pair_id(candidate)} -->",
-        f"The daily detector thinks **`{src}`** and **`{tgt}`** look like a "
-        f"related-merger pair that isn't yet in "
+        f"The daily detector found **{len(candidates)}** candidate related-merger "
+        f"pair(s) on **{date}** that aren't yet recorded in "
         f"[`{_RELATED_PATH}`]({related_blob}).",
         "",
-        _relationship_blurb(candidate),
+        "Each pair below is one matter that appears to have been re-filed as "
+        "another. The change in this PR adds them to `related_mergers.json`; once "
+        "merged, each merger detail page links to its related matter.",
         "",
-        "## The two mergers",
+        "Review each pair, **edit or remove any that are wrong**, then merge.",
         "",
-        f"- **{source_label}:** [{src} — {candidate['source_name']}]({mergers_fyi_url(src)}) "
-        f"· filed {candidate['source_filed'] or 'unknown'} · {source_detail}",
-        f"- **{target_label}:** [{tgt} — {candidate['target_name']}]({mergers_fyi_url(tgt)}) "
-        f"· filed {candidate['target_filed'] or 'unknown'} · {target_detail}",
+        "---",
         "",
-        f"**Match confidence:** {candidate['score']:.2f}  ",
-        f"**Signals:** {_format_signals(candidate['signals'])}",
-        "",
-        "## To accept this suggestion",
-        "",
-        f"1. [**Open `related_mergers.json` for editing on GitHub →**]({edit_url})",
-        "2. Paste the following line into the `pairs` array:",
-        "",
-        "```json",
-        json_line_for(candidate),
-        "```",
-        "",
-        "3. Commit on `main` (or via a PR) — the next run will then see the "
-        "pair is recorded and will auto-close this issue.",
-        "",
-        "## If this isn't a real pair",
-        "",
-        "Just close the issue. The workflow treats any closed issue for this "
-        "pair as a permanent \"no\" and will not re-raise it on future runs.",
     ]
+    for c in candidates:
+        src, tgt = c["source"], c["target"]
+        if c["type"] == SUSPENDED_REFILED:
+            source_label = "Suspended matter"
+            source_detail = f"status: {c['source_status'] or 'unknown'}"
+            target_label = "Re-filed as"
+            target_detail = f"status: {c['target_status'] or 'unknown'}"
+        else:
+            source_label = "Waiver"
+            source_detail = f"determination: {c['source_determination'] or 'unknown'}"
+            target_label = "Notification"
+            target_detail = f"status: {c['target_status'] or 'unknown'}"
+
+        lines.append(f"### `{src}` ↔ `{tgt}`  ·  `type: {c['type']}`")
+        lines.append("")
+        lines.append(
+            f"_{_relationship_blurb(c)} (confidence {c['score']:.2f})._"
+        )
+        lines.append("")
+        lines.append(
+            f"- **{source_label}:** [{src} — {c['source_name']}]({mergers_fyi_url(src)}) "
+            f"· filed {c['source_filed'] or 'unknown'} · {source_detail}"
+        )
+        lines.append(
+            f"- **{target_label}:** [{tgt} — {c['target_name']}]({mergers_fyi_url(tgt)}) "
+            f"· filed {c['target_filed'] or 'unknown'} · {target_detail}"
+        )
+        lines.append("")
+        lines.append(f"**Signals:** {_format_signals(c['signals'])}")
+        lines.append("")
+    lines.extend([
+        "---",
+        "",
+        f"*Generated automatically by the [Detect Related Mergers]"
+        f"(https://github.com/{_REPO}/actions/workflows/detect-related-mergers.yml) workflow.*",
+    ])
     return "\n".join(lines)
 
 
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
+
+def print_summary(candidates: list[dict], threshold: float) -> None:
+    if not candidates:
+        print("No new related-merger candidates found.")
+        return
+    print(f"Found {len(candidates)} candidate pair(s) above threshold {threshold}:")
+    print()
+    for c in candidates:
+        print(f"  {c['source']} ↔ {c['target']}  (score {c['score']:.2f}, {c['type']})")
+        print(f"    source : {c['source_name']}")
+        print(f"    target : {c['target_name']}")
+        print(f"    signals: {_format_signals(c['signals'])}")
+        print()
+
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
@@ -487,21 +521,22 @@ def main() -> int:
         help=f"Minimum confidence score to report (default {DEFAULT_THRESHOLD})",
     )
     parser.add_argument(
-        "--branch",
-        default="main",
-        help="Branch name used in GitHub links within issue bodies",
-    )
-    parser.add_argument(
-        "--issue-json",
-        type=Path,
-        default=None,
-        help="If set, write a JSON payload (candidates + per-pair title/body + "
-        "recorded_pairs) to this path, for use by the workflow.",
-    )
-    parser.add_argument(
         "--summary",
         action="store_true",
         help="Print a human-readable summary to stdout",
+    )
+    parser.add_argument(
+        "--apply-suggestions",
+        action="store_true",
+        dest="apply_suggestions",
+        help="Append candidate pairs to the related_mergers.json file in-place",
+    )
+    parser.add_argument(
+        "--pr-markdown",
+        type=Path,
+        default=None,
+        dest="pr_markdown",
+        help="Write a PR body (markdown) recommending the candidates to this path",
     )
     args = parser.parse_args()
 
@@ -516,39 +551,19 @@ def main() -> int:
     known = load_related_pairs(args.related)
     candidates = find_candidates(mergers, known, args.threshold)
 
-    if args.summary or not args.issue_json:
-        if not candidates:
-            print("No new related-merger candidates found.")
-        else:
-            print(f"Found {len(candidates)} candidate pair(s) above threshold {args.threshold}:")
-            print()
-            for c in candidates:
-                print(f"  {c['source']} ↔ {c['target']}  (score {c['score']:.2f}, {c['type']})")
-                print(f"    source : {c['source_name']}")
-                print(f"    target : {c['target_name']}")
-                print(f"    signals: {_format_signals(c['signals'])}")
-                print()
+    if args.summary or not (args.apply_suggestions or args.pr_markdown):
+        print_summary(candidates, args.threshold)
 
-    if args.issue_json:
-        enriched = []
-        for c in candidates:
-            enriched.append({
-                **c,
-                "pair_id": pair_id(c),
-                "title": build_issue_title(c),
-                "body": build_issue_body(c, args.branch),
-            })
-        payload = {
-            "count": len(enriched),
-            "candidates": enriched,
-            # Pairs already recorded in related_mergers.json — used by the
-            # workflow to produce nicer close messages when an open issue's
-            # pair has been recorded since it was raised.
-            "recorded_pairs": sorted(f"{w}/{n}" for w, n in known),
-        }
-        args.issue_json.parent.mkdir(parents=True, exist_ok=True)
-        with args.issue_json.open("w") as fh:
-            json.dump(payload, fh, indent=2)
+    if args.pr_markdown and candidates:
+        from datetime import timezone
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        args.pr_markdown.parent.mkdir(parents=True, exist_ok=True)
+        with args.pr_markdown.open("w") as fh:
+            fh.write(build_pr_body(candidates, today))
+
+    if args.apply_suggestions and candidates:
+        added = apply_suggestions(args.related, candidates)
+        print(f"Added {added} candidate pair(s) to {args.related}", file=sys.stderr)
 
     return 1 if candidates else 0
 

--- a/scripts/tests/test_related_mergers.py
+++ b/scripts/tests/test_related_mergers.py
@@ -180,28 +180,56 @@ def test_soft_date_ordering_rejects_earlier_refile():
 
 
 # ---------------------------------------------------------------------------
-# detector: issue rendering
+# detector: applying suggestions to related_mergers.json
 # ---------------------------------------------------------------------------
 
-def test_json_line_waiver_uses_typed_shape():
-    c = {"type": drm.WAIVER_REFILED, "source": "WA-100", "target": "MN-200"}
-    line = drm.json_line_for(c)
-    assert '"from": "WA-100"' in line
-    assert '"to": "MN-200"' in line
-    assert '"type": "waiver_refiled"' in line
+def test_apply_suggestions_appends_typed_pairs(tmp_path):
+    path = tmp_path / "related_mergers.json"
+    path.write_text(json.dumps({
+        "_README": "doc",
+        "pairs": [{"from": "WA-1", "to": "MN-2", "type": "waiver_refiled"}],
+    }))
+    cands = drm.find_candidates(_mergers(), known_pairs=set(), threshold=0.70)
+    added = drm.apply_suggestions(path, cands)
+    assert added == len(cands)
+
+    data = json.loads(path.read_text())
+    # Original pair preserved, candidates appended.
+    assert {"from": "WA-1", "to": "MN-2", "type": "waiver_refiled"} in data["pairs"]
+    assert {"from": "WA-100", "to": "MN-200", "type": "waiver_refiled"} in data["pairs"]
+    assert {"from": "MN-300", "to": "MN-400", "type": "suspended_refiled"} in data["pairs"]
+    # _README is retained.
+    assert data["_README"] == "doc"
+    # Re-reading the written pairs round-trips through the loader.
+    assert ("WA-100", "MN-200") in drm.load_related_pairs(path)
 
 
-def test_json_line_suspended_uses_typed_shape():
-    c = {"type": drm.SUSPENDED_REFILED, "source": "MN-300", "target": "MN-400"}
-    line = drm.json_line_for(c)
-    assert '"from": "MN-300"' in line
-    assert '"to": "MN-400"' in line
-    assert '"type": "suspended_refiled"' in line
+def test_apply_suggestions_creates_file_when_missing(tmp_path):
+    path = tmp_path / "nested" / "related_mergers.json"
+    cands = drm.find_candidates(_mergers(), known_pairs=set(), threshold=0.70)
+    drm.apply_suggestions(path, cands)
+    data = json.loads(path.read_text())
+    assert len(data["pairs"]) == len(cands)
 
 
-def test_issue_body_describes_suspension_for_suspended_pair():
+def test_write_related_mergers_keeps_compact_one_line_pairs(tmp_path):
+    path = tmp_path / "related_mergers.json"
+    drm.write_related_mergers(path, {
+        "_README": "doc",
+        "pairs": [{"from": "WA-1", "to": "MN-2", "type": "waiver_refiled"}],
+    })
+    text = path.read_text()
+    assert '    { "from": "WA-1", "to": "MN-2", "type": "waiver_refiled" }' in text
+
+
+# ---------------------------------------------------------------------------
+# detector: PR body rendering
+# ---------------------------------------------------------------------------
+
+def test_pr_body_describes_suspension_for_suspended_pair():
     cands = drm.find_candidates(_mergers(), known_pairs=set(), threshold=0.70)
     suspended = next(c for c in cands if c["type"] == drm.SUSPENDED_REFILED)
-    body = drm.build_issue_body(suspended)
+    body = drm.build_pr_body([suspended], "2026-01-01")
     assert "suspended" in body.lower()
+    assert "MN-300" in body and "MN-400" in body
     assert drm.pair_id(suspended) == "MN-300/MN-400"


### PR DESCRIPTION
The related-merger detector now opens (or updates) a pull request that
directly adds the candidate pairs to data/processed/related_mergers.json,
mirroring the existing detect-related-parties workflow, rather than filing
a GitHub issue asking a human to paste the JSON line in manually.

- detect_related_mergers.py: replace issue-payload rendering with
  --apply-suggestions (appends typed pairs in-place, preserving the
  compact one-line-per-pair style) and --pr-markdown (renders a PR body).
- detect-related-mergers.yml: switch from issue create/close logic to the
  well-known suggestion branch + create/update/close PR pattern.
- Update tests and deployment docs accordingly.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FpYEYjL2zwGJ3pzEs8VsKs