### PR TITLE
Fix accessibility issues on dashboard and industry pages

### DIFF
--- a/merger-tracker/frontend/src/components/PhaseDurationComparison.jsx
+++ b/merger-tracker/frontend/src/components/PhaseDurationComparison.jsx
@@ -17,7 +17,7 @@ function Bar({ widthPct, value, barClass, valueClass, caption, delta }) {
         </span>
       </div>
       <div className="flex items-center justify-between gap-2 mt-1">
-        <p className="text-[11px] text-gray-400 truncate">{caption}</p>
+        <p className="text-[11px] text-gray-500 truncate">{caption}</p>
         {delta}
       </div>
     </>
@@ -30,7 +30,7 @@ function DeltaChip({ current, comparison }) {
   if (comparison == null) return null;
   const delta = current - comparison;
   if (delta === 0) {
-    return <span className="text-[11px] font-medium text-gray-400 shrink-0">Same</span>;
+    return <span className="text-[11px] font-medium text-gray-500 shrink-0">Same</span>;
   }
   const longer = delta > 0;
   const pct = comparison > 0 ? Math.round((delta / comparison) * 100) : null;
@@ -46,7 +46,7 @@ function DeltaChip({ current, comparison }) {
         <FaArrowDown className="w-2.5 h-2.5" aria-hidden="true" />
       )}
       {Math.abs(delta)} days {longer ? 'longer' : 'shorter'}
-      {pct != null && pct !== 0 && <span className="text-gray-400">({Math.abs(pct)}%)</span>}
+      {pct != null && pct !== 0 && <span className="text-gray-500">({Math.abs(pct)}%)</span>}
     </span>
   );
 }
@@ -62,7 +62,7 @@ function MetricComparison({ label, current, comparisons }) {
     return (
       <div>
         <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">{label}</p>
-        <p className="text-sm text-gray-400 mt-2">No completed Phase 1 reviews</p>
+        <p className="text-sm text-gray-500 mt-2">No completed Phase 1 reviews</p>
       </div>
     );
   }
@@ -136,7 +136,7 @@ function PhaseDurationComparison({ duration, comparisons = [] }) {
         <h2 className="text-xs font-medium text-gray-500 uppercase tracking-wider">
           Phase 1 duration
         </h2>
-        <span className="text-[11px] text-gray-400">business days</span>
+        <span className="text-[11px] text-gray-500">business days</span>
       </div>
 
       <div className="grid sm:grid-cols-2 gap-x-8 gap-y-6">

--- a/merger-tracker/frontend/src/components/UpcomingEventsTimeline.jsx
+++ b/merger-tracker/frontend/src/components/UpcomingEventsTimeline.jsx
@@ -148,7 +148,7 @@ function UpcomingEventsTimeline({ events }) {
                   <span className={`text-sm font-semibold ${urgency.text}`}>
                     {relativeLabel(daysRemaining)}
                   </span>
-                  <span className="text-xs text-gray-400">{formatWeekday(day.date)}</span>
+                  <span className="text-xs text-gray-500">{formatWeekday(day.date)}</span>
                 </div>
 
                 <ul className="mt-1.5 space-y-1">

--- a/merger-tracker/frontend/src/pages/Dashboard.jsx
+++ b/merger-tracker/frontend/src/pages/Dashboard.jsx
@@ -57,7 +57,7 @@ function Dashboard() {
   }, [stats]);
 
   if (loading) return <LoadingSpinner />;
-  if (error) return <div className="text-red-600 p-8 text-center">Error: {error}</div>;
+  if (error) return <div role="alert" className="text-red-600 p-8 text-center">Error: {error}</div>;
   if (!stats) return null;
 
   const determinationData = {
@@ -127,6 +127,7 @@ function Dashboard() {
         url="/"
       />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 animate-fade-in">
+      <h1 className="sr-only">Australian merger tracker dashboard</h1>
       {/* Stats Grid */}
       <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 mb-8">
         <StatCard

--- a/merger-tracker/frontend/src/pages/Industries.jsx
+++ b/merger-tracker/frontend/src/pages/Industries.jsx
@@ -104,7 +104,7 @@ function Industries() {
   };
 
   if (loading) return <LoadingSpinner />;
-  if (error) return <div className="text-red-600 p-8 text-center">Error: {error}</div>;
+  if (error) return <div role="alert" className="text-red-600 p-8 text-center">Error: {error}</div>;
 
   return (
     <>
@@ -132,7 +132,7 @@ function Industries() {
           ].map(({ label, value }) => (
             <div key={label}>
               <div className="text-2xl font-bold tracking-tight text-gray-900 tabular-nums">{value}</div>
-              <div className="text-xs text-gray-400">{label}</div>
+              <div className="text-xs text-gray-500">{label}</div>
             </div>
           ))}
         </div>

--- a/merger-tracker/frontend/src/pages/IndustryDetail.jsx
+++ b/merger-tracker/frontend/src/pages/IndustryDetail.jsx
@@ -244,7 +244,7 @@ function IndustryDetail() {
                     className="flex items-center justify-between gap-3 py-2.5 group"
                   >
                     <span className="text-sm text-gray-900 group-hover:text-primary transition-colors">
-                      <span className="text-gray-400 tabular-nums mr-2">{child.code}</span>
+                      <span className="text-gray-500 tabular-nums mr-2">{child.code}</span>
                       {child.name}
                     </span>
                     <span className="flex items-center gap-2 shrink-0">


### PR DESCRIPTION
- Add an h1 to the dashboard (was starting at h2, leaving the page
  with no top-level heading for screen reader navigation)
- Announce fetch errors on the dashboard and industries pages with
  role="alert"
- Raise low-contrast gray-400 text to gray-500 (gray-400 on white is
  ~2.5:1, below the WCAG AA 4.5:1 threshold) for the industries summary
  stats, sub-industry codes, phase-duration captions/deltas and the
  upcoming-events weekday labels

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012yrqwjgLcTGWp65VAcsfLf