### PR TITLE
Add questionnaire document for Heidelberg Materials MAAS merger

### DIFF
--- a/data/processed/mergers.json
+++ b/data/processed/mergers.json
@@ -11372,6 +11372,14 @@
         "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/Heidelberg%20Materials%20Australia%20%E2%80%93%20construction%20materials%20business%20of%20MAAS%20-%20Remedy%20Offer%20-%2029%20June%202026_0.pdf",
         "url_gh": "/mergers/MN-50009/Heidelberg Materials Australia \u2013 construction materials business of MAAS - Remedy Offer - 29 June 2026_0.pdf",
         "status": "live"
+      },
+      {
+        "date": "2026-06-29T12:00:00Z",
+        "title": "Heidelberg Materials Australia - Construction materials business of MAAS - Questionnaire - Remedy offer",
+        "display_title": "Heidelberg Materials Australia - Construction materials business of MAAS - Questionnaire - Remedy offer",
+        "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/HMA%20MAAS%20-%20Questionnaire%20re%3A%20Remedy%20Offer%20%2829%20June%202026%29_0.docx",
+        "url_gh": "/mergers/MN-50009/HMA MAAS - Questionnaire re - Remedy Offer (29 June 2026)_0.pdf",
+        "status": "live"
       }
     ],
     "is_waiver": false


### PR DESCRIPTION
## Summary
Added a new document entry to the Heidelberg Materials Australia - MAAS merger record in the processed mergers dataset.

## Changes
- Added a new questionnaire document dated June 29, 2026 regarding the remedy offer for the Heidelberg Materials Australia construction materials business acquisition of MAAS
- Document includes:
  - Title and display title for the questionnaire
  - Direct link to the ACCC public merger register document (DOCX format)
  - GitHub repository path reference (PDF format)
  - Live status marking

## Details
This entry supplements the existing remedy offer document for merger case MN-50009, providing the associated questionnaire that was issued as part of the remedy offer process.

https://claude.ai/code/session_01LfZoa7pUZ3Gx1S9NMtCrds