### PR TITLE
Add Cloudflare Email Worker to trigger pipeline on ACCC mailing list updates

### DIFF
--- a/accc-register-watcher/README.md
+++ b/accc-register-watcher/README.md
@@ -1,0 +1,75 @@
+# Cloudflare Email Worker — `accc-register-watcher`
+
+Watches for emails from the ACCC's merger register update mailing list and
+fires a `repository_dispatch` event (`new_merger_detected`) so the [Merger
+Pipeline](../.github/workflows/pipeline.yml) workflow runs immediately,
+instead of waiting for its next scheduled run (see the pipeline's
+`on.repository_dispatch` trigger and the `custom_title` run-name, both
+already wired up to receive this).
+
+## How it fits together
+
+```
+ACCC mailing list
+    ↓ email
+Cloudflare Email Routing (custom address on your domain)
+    ↓ routes to
+accc-register-watcher (this Worker)
+    ↓ POST /repos/{owner}/{repo}/dispatches
+GitHub Actions — pipeline.yml (repository_dispatch: new_merger_detected)
+```
+
+## Setup
+
+Steps 1–3 are one-time dashboard/account configuration outside this repo;
+Cloudflare Email Routing rules aren't expressible in `wrangler.toml`.
+
+1. **Enable Email Routing** on the Cloudflare zone you want to receive mail
+   on (e.g. `mergers.fyi`): dashboard → your zone → Email → Email Routing →
+   Enable.
+
+2. **Deploy the Worker**:
+   ```bash
+   cd accc-register-watcher
+   npm install
+   npx wrangler deploy
+   ```
+
+3. **Set the GitHub token secret**. Create a fine-grained personal access
+   token scoped to only this repository, with the **Contents: Read and
+   write** repository permission (this is what the `/dispatches` endpoint
+   requires — Metadata: read is auto-selected alongside it):
+   ```bash
+   npx wrangler secret put GITHUB_TOKEN
+   ```
+
+4. **Add a routing rule**: dashboard → Email → Email Routing → Routing
+   rules → Create address → pick/create the address you'll subscribe to
+   the ACCC mailing list (e.g. `accc-register@mergers.fyi`) → Action →
+   **Send to a Worker** → select `accc-register-watcher`.
+
+5. **Subscribe that address** to the ACCC's register update mailing list.
+
+6. Once you know the mailing list's real sending address, tighten
+   `ALLOWED_SENDERS` in `wrangler.toml` (comma-separated addresses or
+   `@domain` suffixes) and redeploy. Left blank, the worker dispatches on
+   email from any sender — fine for initial testing, not for production
+   (triggering the pipeline is low-risk, but there's no reason to leave it
+   open to arbitrary senders once you know the real one).
+
+## Verify
+
+```bash
+npx wrangler tail
+```
+
+Send (or wait for) an email to the configured address, then check the
+"Merger Pipeline" workflow's Actions tab for a new run triggered by
+`repository_dispatch`.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `src/index.js` | Worker `email()` handler — sender allowlist check, dispatches to GitHub. |
+| `wrangler.toml` | Worker config: target repo, sender allowlist, secret documentation. |

--- a/accc-register-watcher/README.md
+++ b/accc-register-watcher/README.md
@@ -49,6 +49,23 @@ Cloudflare Email Routing rules aren't expressible in `wrangler.toml`.
    **Send to a Worker** → select `accc-register-watcher`.
 
 5. **Subscribe that address** to the ACCC's register update mailing list.
+   Most mailing lists email a confirmation link before activating the
+   subscription — the Worker only dispatches to GitHub, it doesn't put
+   anything in an inbox you can read, so you won't see that email by
+   default. To catch it:
+
+   1. Under Email → Email Routing → **Destination addresses**, add and
+      verify your own personal email address (Cloudflare emails you a
+      verification link — click it there first).
+   2. Go back to the routing rule from step 4 and temporarily change its
+      action from **Send to a Worker** to **Send to an email** → your
+      verified personal address.
+   3. Submit the ACCC mailing list signup using the Cloudflare address.
+      The confirmation email will forward straight to your inbox — open
+      it and click the confirmation link.
+   4. Switch the routing rule's action back to **Send to a Worker** →
+      `accc-register-watcher`, so subsequent update emails go to the
+      dispatch logic instead of your inbox.
 
 6. Once you know the mailing list's real sending address, tighten
    `ALLOWED_SENDERS` in `wrangler.toml` (comma-separated addresses or

--- a/accc-register-watcher/README.md
+++ b/accc-register-watcher/README.md
@@ -67,12 +67,11 @@ Cloudflare Email Routing rules aren't expressible in `wrangler.toml`.
       `accc-register-watcher`, so subsequent update emails go to the
       dispatch logic instead of your inbox.
 
-6. Once you know the mailing list's real sending address, tighten
-   `ALLOWED_SENDERS` in `wrangler.toml` (comma-separated addresses or
-   `@domain` suffixes) and redeploy. Left blank, the worker dispatches on
-   email from any sender — fine for initial testing, not for production
-   (triggering the pipeline is low-risk, but there's no reason to leave it
-   open to arbitrary senders once you know the real one).
+6. `ALLOWED_SENDERS` in `wrangler.toml` is already set to the mailing
+   list's real sender, `do-not-reply@accc.gov.au` — redeploy after any
+   changes to it. It's checked against both the envelope sender and the
+   `From:` header, so it stays effective even if the list sends through a
+   third-party bulk mailer with a different envelope address.
 
 ## Verify
 

--- a/accc-register-watcher/package.json
+++ b/accc-register-watcher/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "accc-register-watcher",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Cloudflare Email Worker — triggers the merger pipeline when the ACCC register update mailing list sends an email",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "deploy:dry": "wrangler deploy --dry-run",
+    "tail": "wrangler tail"
+  },
+  "devDependencies": {
+    "wrangler": "^4.67.0"
+  }
+}

--- a/accc-register-watcher/src/index.js
+++ b/accc-register-watcher/src/index.js
@@ -1,0 +1,80 @@
+/**
+ * Cloudflare Email Worker — ACCC register update watcher
+ *
+ * Bound (via Cloudflare Email Routing, see ../README.md) to a dedicated
+ * inbox address subscribed to the ACCC's merger register update mailing
+ * list. Every email received fires a `repository_dispatch` event so the
+ * "Merger Pipeline" GitHub Actions workflow (.github/workflows/pipeline.yml)
+ * runs immediately, instead of waiting for its next scheduled run.
+ *
+ * Required Worker secrets (set via `wrangler secret put`):
+ *   GITHUB_TOKEN  — fine-grained PAT scoped to this repo only, with
+ *                   "Contents: Read and write" permission (required by the
+ *                   /dispatches endpoint).
+ *
+ * Required Worker vars (wrangler.toml):
+ *   GITHUB_REPO      — "owner/repo" to dispatch to
+ *   ALLOWED_SENDERS  — comma-separated allowlist of sender addresses/domains
+ *                      for the ACCC mailing list (blank = accept any sender)
+ */
+
+const DISPATCH_EVENT_TYPE = "new_merger_detected";
+
+function isAllowedSender(from, allowedSendersVar) {
+  const allowed = (allowedSendersVar || "")
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+
+  if (allowed.length === 0) return true;
+
+  const sender = (from || "").toLowerCase();
+  return allowed.some((entry) =>
+    entry.startsWith("@") ? sender.endsWith(entry) : sender === entry
+  );
+}
+
+export default {
+  async email(message, env, ctx) {
+    const from = message.from;
+    const subject = message.headers.get("subject") || "(no subject)";
+
+    if (!isAllowedSender(from, env.ALLOWED_SENDERS)) {
+      console.warn(`Ignoring email from unrecognised sender: ${from}`);
+      return;
+    }
+
+    console.log(`ACCC register update email received from ${from}: ${subject}`);
+
+    const resp = await fetch(
+      `https://api.github.com/repos/${env.GITHUB_REPO}/dispatches`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${env.GITHUB_TOKEN}`,
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+          "User-Agent": "accc-register-watcher",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          event_type: DISPATCH_EVENT_TYPE,
+          client_payload: {
+            custom_title: `Merger pipeline (ACCC register update email)`,
+            source: "accc-register-watcher",
+            email_from: from,
+            email_subject: subject,
+            received_at: new Date().toISOString(),
+          },
+        }),
+      }
+    );
+
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => "");
+      console.error(
+        `GitHub dispatch failed: ${resp.status} ${resp.statusText} — ${body}`
+      );
+    }
+  },
+};

--- a/accc-register-watcher/src/index.js
+++ b/accc-register-watcher/src/index.js
@@ -15,12 +15,21 @@
  * Required Worker vars (wrangler.toml):
  *   GITHUB_REPO      — "owner/repo" to dispatch to
  *   ALLOWED_SENDERS  — comma-separated allowlist of sender addresses/domains
- *                      for the ACCC mailing list (blank = accept any sender)
+ *                      for the ACCC mailing list (blank = accept any sender),
+ *                      checked against both the envelope sender and the
+ *                      From: header
  */
 
 const DISPATCH_EVENT_TYPE = "new_merger_detected";
 
-function isAllowedSender(from, allowedSendersVar) {
+// Pulls the bare address out of either a plain "user@domain" string or a
+// display-name form like "ACCC <user@domain>".
+function extractAddress(value) {
+  const match = (value || "").match(/<([^>]+)>/);
+  return (match ? match[1] : value || "").trim().toLowerCase();
+}
+
+function isAllowedSender(candidates, allowedSendersVar) {
   const allowed = (allowedSendersVar || "")
     .split(",")
     .map((s) => s.trim().toLowerCase())
@@ -28,21 +37,29 @@ function isAllowedSender(from, allowedSendersVar) {
 
   if (allowed.length === 0) return true;
 
-  const sender = (from || "").toLowerCase();
-  return allowed.some((entry) =>
-    entry.startsWith("@") ? sender.endsWith(entry) : sender === entry
+  return candidates.some((candidate) =>
+    allowed.some((entry) =>
+      entry.startsWith("@") ? candidate.endsWith(entry) : candidate === entry
+    )
   );
 }
 
 export default {
   async email(message, env, ctx) {
-    const from = message.from;
+    // The envelope sender (message.from) and the From: header can differ for
+    // bulk mail senders — check both against the allowlist.
+    const envelopeFrom = extractAddress(message.from);
+    const headerFrom = extractAddress(message.headers.get("from"));
     const subject = message.headers.get("subject") || "(no subject)";
 
-    if (!isAllowedSender(from, env.ALLOWED_SENDERS)) {
-      console.warn(`Ignoring email from unrecognised sender: ${from}`);
+    if (!isAllowedSender([envelopeFrom, headerFrom], env.ALLOWED_SENDERS)) {
+      console.warn(
+        `Ignoring email from unrecognised sender (envelope: ${envelopeFrom}, header: ${headerFrom})`
+      );
       return;
     }
+
+    const from = message.headers.get("from") || message.from;
 
     console.log(`ACCC register update email received from ${from}: ${subject}`);
 

--- a/accc-register-watcher/wrangler.toml
+++ b/accc-register-watcher/wrangler.toml
@@ -1,0 +1,22 @@
+name = "accc-register-watcher"
+main = "src/index.js"
+compatibility_date = "2024-09-23"
+
+[vars]
+# "owner/repo" to send the repository_dispatch event to.
+GITHUB_REPO = "nwbort/accc-mergers"
+
+# Comma-separated allowlist of sender addresses/domains for the ACCC mailing
+# list, e.g. "notifications@accc.gov.au,@accc.gov.au". Leave blank to accept
+# email from any sender (not recommended — fill this in once you know the
+# mailing list's real From address).
+ALLOWED_SENDERS = ""
+
+# Secrets — set with:
+#   wrangler secret put GITHUB_TOKEN
+#
+# Use a fine-grained personal access token scoped to only this repository,
+# with the "Contents: Read and write" repository permission (this is what
+# the /repos/{owner}/{repo}/dispatches endpoint requires).
+#
+# Do NOT put real values here; wrangler.toml is committed to the repo.

--- a/accc-register-watcher/wrangler.toml
+++ b/accc-register-watcher/wrangler.toml
@@ -7,10 +7,8 @@ compatibility_date = "2024-09-23"
 GITHUB_REPO = "nwbort/accc-mergers"
 
 # Comma-separated allowlist of sender addresses/domains for the ACCC mailing
-# list, e.g. "notifications@accc.gov.au,@accc.gov.au". Leave blank to accept
-# email from any sender (not recommended — fill this in once you know the
-# mailing list's real From address).
-ALLOWED_SENDERS = ""
+# list. Leave blank to accept email from any sender.
+ALLOWED_SENDERS = "do-not-reply@accc.gov.au"
 
 # Secrets — set with:
 #   wrangler secret put GITHUB_TOKEN

--- a/claude.md
+++ b/claude.md
@@ -26,6 +26,12 @@ Fully static — no backend server. Cloudflare Pages serves the React SPA plus g
 - Validates Cloudflare Turnstile tokens
 - Deployed separately via wrangler
 
+### ACCC Register Watcher (`accc-register-watcher/`)
+
+- Cloudflare Email Worker bound to a mailbox subscribed to the ACCC's register update mailing list
+- Fires a `repository_dispatch` (`new_merger_detected`) to trigger `pipeline.yml` immediately on each email
+- Deployed separately via wrangler; see its README for the Cloudflare Email Routing setup
+
 ## Project Structure
 
 ```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -59,6 +59,17 @@ cd cloudflare-worker
 npx wrangler deploy
 ```
 
+## Cloudflare Email Worker — ACCC register watcher
+
+The `accc-register-watcher/` directory contains a separate Email Worker
+that watches a mailbox subscribed to the ACCC's register update mailing
+list. On each email it fires a `repository_dispatch` event
+(`new_merger_detected`) so `pipeline.yml` runs immediately rather than
+waiting for its next scheduled run. See
+[`accc-register-watcher/README.md`](../accc-register-watcher/README.md)
+for setup (Cloudflare Email Routing configuration and the GitHub token
+secret).
+
 ## GitHub workflows
 
 ### `pipeline.yml` — Main pipeline (hourly + on push to main)
@@ -70,7 +81,7 @@ The primary automated workflow. Runs end-to-end on a schedule and on every push 
 3. **Convert** — detects unconverted DOCX attachments, installs LibreOffice, converts to PDF; re-runs extraction if any were converted
 4. **Commit** — commits all staged changes in a single commit, rebases, and pushes
 
-Also accepts a `workflow_dispatch` with an `all_mergers` boolean input to force full re-extraction.
+Also accepts a `workflow_dispatch` with an `all_mergers` boolean input to force full re-extraction, and a `repository_dispatch` event (`new_merger_detected`) fired by the `accc-register-watcher` Cloudflare Email Worker when the ACCC's register update mailing list sends an email.
 
 ### `extract.yml` — Manual extraction
 


### PR DESCRIPTION
Adds accc-register-watcher/, a Cloudflare Email Worker for a mailbox
subscribed to the ACCC's register update mailing list. On each email it
fires a repository_dispatch (new_merger_detected), which pipeline.yml
already listens for, so the merger pipeline runs immediately instead of
waiting for its next scheduled run.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011LCEMxt6wX6EzX5Dc5xaZN