### PR TITLE
fix: detect type-label-suffix titles as distinct events

### DIFF
--- a/scripts/detect_duplicates.py
+++ b/scripts/detect_duplicates.py
@@ -84,6 +84,15 @@ def titles_are_different_event_types(a: str, b: str) -> bool:
        string similarity is high — e.g. 'Phase 2 determination – Statement of
        Reasons' vs 'Phase 2 determination – Summary of reasons' share a long
        common prefix but are genuinely distinct documents.
+
+    3. Extra-segment check: some ACCC titles put the document-type label at the
+       end rather than the start (e.g. '... MAAS - Remedy offer' vs
+       '... MAAS - Questionnaire - Remedy offer'). Here the leading segments
+       are identical and the segment counts differ, so checks 1 and 2 both miss
+       the fact that one title has an inserted 'Questionnaire' segment with no
+       counterpart in the other. If either title has a segment that doesn't
+       match (exactly or fuzzily) any segment in the other title, they are
+       different document types.
     """
     prefix_a = extract_type_prefix(a)
     prefix_b = extract_type_prefix(b)
@@ -101,6 +110,17 @@ def titles_are_different_event_types(a: str, b: str) -> bool:
                 and SequenceMatcher(None, sa, sb).ratio() < _SEGMENT_SIMILARITY_THRESHOLD
             ):
                 return True
+
+    if len(segs_a) != len(segs_b) and len(segs_a) > 1 and len(segs_b) > 1:
+        for segs, other in ((segs_a, segs_b), (segs_b, segs_a)):
+            for seg in segs:
+                if len(seg) < _MIN_SEGMENT_LEN:
+                    continue
+                if not any(
+                    SequenceMatcher(None, seg, o).ratio() >= _SEGMENT_SIMILARITY_THRESHOLD
+                    for o in other
+                ):
+                    return True
 
     return False
 

--- a/scripts/tests/test_detect_duplicates.py
+++ b/scripts/tests/test_detect_duplicates.py
@@ -91,6 +91,31 @@ def test_two_days_apart_not_grouped():
     assert find_duplicates(merger) == []
 
 
+def test_type_label_suffix_not_grouped():
+    """Titles with the document-type label at the end, not the start, must
+    still be told apart. MN-50009 had 'MAAS - Remedy offer' and
+    'MAAS - Questionnaire - Remedy offer' on the same day: the leading
+    segments match and the segment counts differ, so the type-prefix and
+    equal-length segment checks both miss the inserted 'Questionnaire'
+    segment. These are genuinely different documents and must not be
+    reported as duplicates.
+    """
+    merger = {
+        "merger_id": "MN-50009",
+        "events": [
+            {
+                "date": "2026-06-29T12:00:00Z",
+                "title": "Heidelberg Materials Australia - Construction materials business of MAAS - Remedy offer",
+            },
+            {
+                "date": "2026-06-29T12:00:00Z",
+                "title": "Heidelberg Materials Australia - Construction materials business of MAAS - Questionnaire - Remedy offer",
+            },
+        ],
+    }
+    assert find_duplicates(merger) == []
+
+
 def test_three_consecutive_days_no_overlapping_groups():
     """Non-transitive tolerance must not emit overlapping groups that share an index."""
     merger = {


### PR DESCRIPTION
The Heidelberg MAAS events on 2026-06-29 used a title format where the
document-type label comes last ("... MAAS - Remedy offer" vs
"... MAAS - Questionnaire - Remedy offer") instead of the usual leading
prefix. Because both the type-prefix check and the equal-length
segment check missed this (leading segments matched, segment counts
differed), the two genuinely different documents were flagged as a
likely duplicate and one was wrongly removed in PR #563.

Add a third check that flags titles as different event types whenever
either title has a segment with no fuzzy match among the other title's
segments, even when segment counts differ.