### PR TITLE
Link VC Operations entities to Vets Central Holdings group

### DIFF
--- a/data/processed/related_parties.json
+++ b/data/processed/related_parties.json
@@ -136,6 +136,22 @@
         {
           "name": "VETS CENTRAL PTY LTD",
           "identifier": "25 646 462 973"
+        },
+        {
+          "name": "VC OPERATIONS (WA) PTY LTD",
+          "identifier": "28 646 499 005"
+        },
+        {
+          "name": "VC OPERATIONS PTY LTD",
+          "identifier": "86 641 403 938"
+        },
+        {
+          "name": "VC OPERATIONS (NSW) PTY LTD",
+          "identifier": "86 646 515 433"
+        },
+        {
+          "name": "Vets Central (New Zealand) Limited",
+          "identifier": "NZBN  9429051820992"
         }
       ]
     },


### PR DESCRIPTION
Adds VC Operations (WA), VC Operations, VC Operations (NSW) and Vets
Central (New Zealand) Limited — all named in WA-55023 — to the existing
vets-central-holdings-pty-ltd related-parties group.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Dis4urz8PDztocnZhRCjAK