### PR TITLE
Add industry phase 1 duration comparison chart to Analysis page

### DIFF
--- a/merger-tracker/frontend/public/data/analysis.json
+++ b/merger-tracker/frontend/public/data/analysis.json
@@ -3218,5 +3218,169 @@
       30,
       0
     ]
-  }
+  },
+  "industry_phase1_duration": [
+    {
+      "code": "S",
+      "name": "Other Services",
+      "average_business_days": 32.8,
+      "median_business_days": 22,
+      "average_calendar_days": 48.8,
+      "median_calendar_days": 32,
+      "count": 5
+    },
+    {
+      "code": "G",
+      "name": "Retail Trade",
+      "average_business_days": 26.4,
+      "median_business_days": 18.5,
+      "average_calendar_days": 42.8,
+      "median_calendar_days": 28.5,
+      "count": 12
+    },
+    {
+      "code": "F",
+      "name": "Wholesale Trade",
+      "average_business_days": 22.4,
+      "median_business_days": 18.0,
+      "average_calendar_days": 36.0,
+      "median_calendar_days": 28.0,
+      "count": 20
+    },
+    {
+      "code": "I",
+      "name": "Transport, Postal and Warehousing",
+      "average_business_days": 22.4,
+      "median_business_days": 22,
+      "average_calendar_days": 32.9,
+      "median_calendar_days": 30,
+      "count": 9
+    },
+    {
+      "code": "M",
+      "name": "Professional, Scientific and Technical Services",
+      "average_business_days": 21.5,
+      "median_business_days": 18.0,
+      "average_calendar_days": 33.3,
+      "median_calendar_days": 27.0,
+      "count": 30
+    },
+    {
+      "code": "L",
+      "name": "Rental, Hiring and Real Estate Services",
+      "average_business_days": 20.7,
+      "median_business_days": 19,
+      "average_calendar_days": 32.1,
+      "median_calendar_days": 29,
+      "count": 11
+    },
+    {
+      "code": "B",
+      "name": "Mining",
+      "average_business_days": 20.6,
+      "median_business_days": 17,
+      "average_calendar_days": 30.2,
+      "median_calendar_days": 26,
+      "count": 5
+    },
+    {
+      "code": "O",
+      "name": "Public Administration and Safety",
+      "average_business_days": 20.0,
+      "median_business_days": 20,
+      "average_calendar_days": 29.0,
+      "median_calendar_days": 29,
+      "count": 1
+    },
+    {
+      "code": "J",
+      "name": "Information Media and Telecommunications",
+      "average_business_days": 19.8,
+      "median_business_days": 18.0,
+      "average_calendar_days": 31.3,
+      "median_calendar_days": 28.0,
+      "count": 18
+    },
+    {
+      "code": "E",
+      "name": "Construction",
+      "average_business_days": 19.6,
+      "median_business_days": 16.0,
+      "average_calendar_days": 28.5,
+      "median_calendar_days": 22.5,
+      "count": 8
+    },
+    {
+      "code": "K",
+      "name": "Financial and Insurance Services",
+      "average_business_days": 19.5,
+      "median_business_days": 16,
+      "average_calendar_days": 28.7,
+      "median_calendar_days": 24,
+      "count": 21
+    },
+    {
+      "code": "C",
+      "name": "Manufacturing",
+      "average_business_days": 19.3,
+      "median_business_days": 17.5,
+      "average_calendar_days": 29.5,
+      "median_calendar_days": 26.0,
+      "count": 36
+    },
+    {
+      "code": "D",
+      "name": "Electricity, Gas, Water and Waste Services",
+      "average_business_days": 18.7,
+      "median_business_days": 20,
+      "average_calendar_days": 26.3,
+      "median_calendar_days": 28,
+      "count": 3
+    },
+    {
+      "code": "R",
+      "name": "Arts and Recreation Services",
+      "average_business_days": 18.0,
+      "median_business_days": 18.0,
+      "average_calendar_days": 26.0,
+      "median_calendar_days": 26.0,
+      "count": 2
+    },
+    {
+      "code": "A",
+      "name": "Agriculture, Forestry and Fishing",
+      "average_business_days": 17.8,
+      "median_business_days": 18.0,
+      "average_calendar_days": 26.0,
+      "median_calendar_days": 27.0,
+      "count": 4
+    },
+    {
+      "code": "N",
+      "name": "Administrative and Support Services",
+      "average_business_days": 17.5,
+      "median_business_days": 17.5,
+      "average_calendar_days": 26.5,
+      "median_calendar_days": 26.5,
+      "count": 2
+    },
+    {
+      "code": "H",
+      "name": "Accommodation and Food Services",
+      "average_business_days": 16.8,
+      "median_business_days": 16,
+      "average_calendar_days": 24.6,
+      "median_calendar_days": 24,
+      "count": 5
+    },
+    {
+      "code": "Q",
+      "name": "Health Care and Social Assistance",
+      "average_business_days": 16.0,
+      "median_business_days": 15.0,
+      "average_calendar_days": 24.7,
+      "median_calendar_days": 24.5,
+      "count": 10
+    }
+  ]
 }

--- a/merger-tracker/frontend/src/pages/Analysis.jsx
+++ b/merger-tracker/frontend/src/pages/Analysis.jsx
@@ -290,11 +290,10 @@ function Analysis() {
 
   // --- Industry Phase 1 Duration Comparison ---
   const industryDurationField = calendarDays ? 'average_calendar_days' : 'average_business_days';
-  // Chart.js renders index 0 at the top of a horizontal bar chart, so keep
-  // the backend's descending order to put the longest durations at the top.
   const industryDurations = industry_phase1_duration || [];
 
-  // "Overall" reference bar, pinned to the top, covering every industry.
+  // "Overall" reference bar, covering every industry, slotted in by value
+  // alongside the rest rather than pinned to an end.
   const overallEntry = phase1_duration.stats.average != null ? {
     code: null,
     name: 'Overall',
@@ -305,7 +304,12 @@ function Analysis() {
     count: phase1_duration.stats.count,
   } : null;
 
-  const industryChartRows = overallEntry ? [overallEntry, ...industryDurations] : industryDurations;
+  // Chart.js renders index 0 at the top of a horizontal bar chart, so sort
+  // descending by the currently displayed metric to put the longest
+  // durations at the top.
+  const industryChartRows = (overallEntry ? [...industryDurations, overallEntry] : industryDurations)
+    .slice()
+    .sort((a, b) => b[industryDurationField] - a[industryDurationField]);
 
   const industryDurationData = {
     labels: industryChartRows.map(d => d.name),

--- a/merger-tracker/frontend/src/pages/Analysis.jsx
+++ b/merger-tracker/frontend/src/pages/Analysis.jsx
@@ -16,6 +16,7 @@ import LoadingSpinner from '../components/LoadingSpinner';
 import SEO from '../components/SEO';
 import { API_ENDPOINTS } from '../config';
 import { useFetchData } from '../hooks/useFetchData';
+import { industryPath } from '../utils/slug';
 
 ChartJS.register(
   CategoryScale,
@@ -55,7 +56,7 @@ function Analysis() {
   if (error) return <div className="text-red-600 p-8 text-center">Error: {error}</div>;
   if (!data) return null;
 
-  const { phase1_duration, waiver_duration, monthly_volume } = data;
+  const { phase1_duration, waiver_duration, monthly_volume, industry_phase1_duration } = data;
   const phase1Stats = calendarDays ? phase1_duration.calendar_stats : phase1_duration.stats;
   const waiverStats = calendarDays ? waiver_duration.calendar_stats : waiver_duration.stats;
 
@@ -287,6 +288,78 @@ function Analysis() {
     },
   };
 
+  // --- Industry Phase 1 Duration Comparison ---
+  const industryDurationField = calendarDays ? 'average_calendar_days' : 'average_business_days';
+  // Chart.js renders index 0 at the top of a horizontal bar chart, so keep
+  // the backend's descending order to put the longest durations at the top.
+  const industryDurations = industry_phase1_duration || [];
+
+  const industryDurationData = {
+    labels: industryDurations.map(d => d.name),
+    datasets: [
+      {
+        label: `Avg phase 1 duration (${dayLabel})`,
+        data: industryDurations.map(d => d[industryDurationField]),
+        backgroundColor: COLORS.primary,
+        borderRadius: 4,
+        maxBarThickness: 22,
+      },
+    ],
+  };
+
+  const handleIndustryChartClick = (event, elements) => {
+    if (elements.length > 0) {
+      const { index } = elements[0];
+      const industry = industryDurations[index];
+      if (industry) {
+        navigate(industryPath(industry.code, industry.name));
+      }
+    }
+  };
+
+  const industryDurationOptions = {
+    indexAxis: 'y',
+    responsive: true,
+    maintainAspectRatio: false,
+    animation: false,
+    onClick: handleIndustryChartClick,
+    onHover: (event, elements) => {
+      event.native.target.style.cursor = elements.length > 0 ? 'pointer' : 'default';
+    },
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        callbacks: {
+          label: (item) => {
+            const d = industryDurations[item.dataIndex];
+            return [
+              `Avg: ${d.average_business_days} business days (${d.average_calendar_days} calendar)`,
+              `Median: ${d.median_business_days} business days (${d.median_calendar_days} calendar)`,
+              `${d.count} completed review${d.count === 1 ? '' : 's'}`,
+            ];
+          },
+        },
+      },
+    },
+    scales: {
+      x: {
+        beginAtZero: true,
+        title: {
+          display: true,
+          text: calendarDays ? 'Average calendar days' : 'Average business days',
+          font: { size: 12, family: 'Inter, sans-serif' },
+          color: '#6b7280',
+        },
+        grid: { color: 'rgba(0,0,0,0.04)' },
+        ticks: { font: { size: 11 } },
+      },
+      y: {
+        grid: { display: false },
+        ticks: { font: { size: 11 } },
+      },
+    },
+  };
+
   return (
     <>
       <SEO
@@ -389,6 +462,25 @@ function Analysis() {
             </div>
           </div>
         </div>
+
+        {/* Industry Phase 1 Duration Comparison */}
+        {industryDurations.length > 0 && (
+          <section className="mb-8">
+            <div className="bg-white rounded-2xl border border-gray-100 shadow-card overflow-hidden">
+              <div className="px-6 py-5 border-b border-gray-100">
+                <h2 className="text-lg font-semibold text-gray-900">Phase 1 duration by industry</h2>
+                <p className="text-sm text-gray-500 mt-0.5">
+                  Average phase 1 duration for completed reviews, by top-level industry. Click a bar to view that industry.
+                </p>
+              </div>
+              <div className="p-6">
+                <div style={{ height: `${Math.max(320, industryDurations.length * 32)}px` }}>
+                  <Bar data={industryDurationData} options={industryDurationOptions} />
+                </div>
+              </div>
+            </div>
+          </section>
+        )}
 
         {/* Phase 1 Duration Analysis */}
         <section className="mb-8">

--- a/merger-tracker/frontend/src/pages/Analysis.jsx
+++ b/merger-tracker/frontend/src/pages/Analysis.jsx
@@ -294,13 +294,26 @@ function Analysis() {
   // the backend's descending order to put the longest durations at the top.
   const industryDurations = industry_phase1_duration || [];
 
+  // "Overall" reference bar, pinned to the top, covering every industry.
+  const overallEntry = phase1_duration.stats.average != null ? {
+    code: null,
+    name: 'Overall',
+    average_business_days: phase1_duration.stats.average,
+    median_business_days: phase1_duration.stats.median,
+    average_calendar_days: phase1_duration.calendar_stats.average,
+    median_calendar_days: phase1_duration.calendar_stats.median,
+    count: phase1_duration.stats.count,
+  } : null;
+
+  const industryChartRows = overallEntry ? [overallEntry, ...industryDurations] : industryDurations;
+
   const industryDurationData = {
-    labels: industryDurations.map(d => d.name),
+    labels: industryChartRows.map(d => d.name),
     datasets: [
       {
         label: `Avg phase 1 duration (${dayLabel})`,
-        data: industryDurations.map(d => d[industryDurationField]),
-        backgroundColor: COLORS.primary,
+        data: industryChartRows.map(d => d[industryDurationField]),
+        backgroundColor: industryChartRows.map(d => d.code === null ? COLORS.accent : COLORS.primary),
         borderRadius: 4,
         maxBarThickness: 22,
       },
@@ -310,8 +323,8 @@ function Analysis() {
   const handleIndustryChartClick = (event, elements) => {
     if (elements.length > 0) {
       const { index } = elements[0];
-      const industry = industryDurations[index];
-      if (industry) {
+      const industry = industryChartRows[index];
+      if (industry && industry.code !== null) {
         navigate(industryPath(industry.code, industry.name));
       }
     }
@@ -331,7 +344,7 @@ function Analysis() {
       tooltip: {
         callbacks: {
           label: (item) => {
-            const d = industryDurations[item.dataIndex];
+            const d = industryChartRows[item.dataIndex];
             return [
               `Avg: ${d.average_business_days} business days (${d.average_calendar_days} calendar)`,
               `Median: ${d.median_business_days} business days (${d.median_calendar_days} calendar)`,
@@ -474,7 +487,7 @@ function Analysis() {
                 </p>
               </div>
               <div className="p-6">
-                <div style={{ height: `${Math.max(320, industryDurations.length * 32)}px` }}>
+                <div style={{ height: `${Math.max(320, industryChartRows.length * 32)}px` }}>
                   <Bar data={industryDurationData} options={industryDurationOptions} />
                 </div>
               </div>

--- a/scripts/static_data/outputs/analysis.py
+++ b/scripts/static_data/outputs/analysis.py
@@ -3,9 +3,63 @@
 from collections import defaultdict
 from statistics import median as stat_median
 
+from .. import anzsic
 from ..business_days import calculate_business_days, calculate_calendar_days
-from ..durations import phase_1_end_date
+from ..durations import collect_phase_1_durations, phase_1_end_date
 from ..filters import filter_notifications, filter_waivers
+
+
+def _division_for_code(code: str):
+    """The top-level ANZSIC division (letter) node a tagged code rolls up to.
+
+    ``code`` may already be a division, or a subdivision/group/class beneath
+    one. Returns ``None`` for codes outside the known ANZSIC tree.
+    """
+    node = anzsic.get(code)
+    if node is None:
+        return None
+    if node.level == 'division':
+        return node
+    ancestors = anzsic.ancestors(code)
+    return ancestors[0] if ancestors else None
+
+
+def industry_phase1_duration(mergers: list) -> list[dict]:
+    """Phase 1 duration stats per top-level ANZSIC division, for comparison.
+
+    Each merger is attributed to every division its tagged codes roll up to
+    (deduped, so a merger tagged twice within a division isn't double-counted).
+    Divisions with no completed Phase 1 reviews are omitted.
+    """
+    division_mergers = defaultdict(list)
+    for m in mergers:
+        codes = m.get('anzsic_codes') or m.get('anszic_codes') or []
+        divisions = {}
+        for code_obj in codes:
+            division = _division_for_code(code_obj.get('code', ''))
+            if division is not None:
+                divisions[division.code] = division
+        for division in divisions.values():
+            division_mergers[division.code].append((division.name, m))
+
+    results = []
+    for division_code, entries in division_mergers.items():
+        division_name = entries[0][0]
+        cal_days, bus_days = collect_phase_1_durations([m for _, m in entries])
+        if not bus_days:
+            continue
+        results.append({
+            "code": division_code,
+            "name": division_name,
+            "average_business_days": round(sum(bus_days) / len(bus_days), 1),
+            "median_business_days": stat_median(bus_days),
+            "average_calendar_days": round(sum(cal_days) / len(cal_days), 1) if cal_days else None,
+            "median_calendar_days": stat_median(cal_days) if cal_days else None,
+            "count": len(bus_days),
+        })
+
+    results.sort(key=lambda x: -x['average_business_days'])
+    return results
 
 
 def generate(mergers: list) -> dict:
@@ -153,4 +207,5 @@ def generate(mergers: list) -> dict:
             "calendar_stats": waiver_calendar_stats,
         },
         "monthly_volume": monthly_volume,
+        "industry_phase1_duration": industry_phase1_duration(mergers),
     }

--- a/scripts/tests/test_static_data_outputs.py
+++ b/scripts/tests/test_static_data_outputs.py
@@ -445,7 +445,9 @@ class TestAnalysisGenerate:
     def test_returns_valid_shape(self):
         payload = analysis.generate(_enriched_fixture())
         json.dumps(payload)
-        assert set(payload.keys()) == {'phase1_duration', 'waiver_duration', 'monthly_volume'}
+        assert set(payload.keys()) == {
+            'phase1_duration', 'waiver_duration', 'monthly_volume', 'industry_phase1_duration',
+        }
         assert 'scatter_data' in payload['phase1_duration']
         assert 'scatter_data' in payload['waiver_duration']
         assert 'labels' in payload['monthly_volume']
@@ -461,6 +463,18 @@ class TestAnalysisGenerate:
         payload = analysis.generate(_enriched_fixture())
         ids = {p['merger_id'] for p in payload['waiver_duration']['scatter_data']}
         assert ids == {'WA-0003'}
+
+    def test_industry_phase1_duration_rolls_up_to_division(self):
+        payload = analysis.generate(_enriched_fixture())
+        divisions = payload['industry_phase1_duration']
+        # MN-0001 (code 0600, Coal Mining) has a completed Phase 1 and rolls up
+        # to division B (Mining). MN-0002 shares the code but is in progress,
+        # so it doesn't add a second completed review. WA-0003's code (5400)
+        # is an orphan outside the ANZSIC tree, so Transport contributes nothing.
+        assert [d['code'] for d in divisions] == ['B']
+        mining = divisions[0]
+        assert mining['name'] == 'Mining'
+        assert mining['count'] == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Compute average/median phase 1 duration per top-level ANZSIC division
(rolling up sub-industry codes to their letter-coded division) in
analysis.json, and render it as a horizontal bar chart, positioned
second on the Analysis page between monthly volume and the phase 1
scatter plot. Bars link through to the relevant industry page.