### PR TITLE
Fix missing ACT holiday and end_of_determination_period off-by-one (#576)

### DIFF
--- a/data/output/mergers.json
+++ b/data/output/mergers.json
@@ -13991,7 +13991,7 @@
       "effective_notification_datetime": "2026-05-19T12:00:00Z",
       "original_notification_datetime": "2026-05-19T12:00:00Z",
       "stage": "Phase 1 - initial assessment",
-      "end_of_determination_period": "2026-07-01T12:00:00Z",
+      "end_of_determination_period": "2026-07-02T12:00:00Z",
       "determination_publication_date": "2026-06-15T12:00:00Z",
       "accc_determination": "Approved",
       "page_modified_datetime": "2026-06-15T09:48:36+10:00",
@@ -21436,7 +21436,7 @@
       "effective_notification_datetime": "2026-07-01T12:00:00Z",
       "original_notification_datetime": "2026-07-01T12:00:00Z",
       "stage": "Phase 1 - initial assessment",
-      "end_of_determination_period": "2026-08-11T12:00:00Z",
+      "end_of_determination_period": "2026-08-12T12:00:00Z",
       "page_modified_datetime": "2026-07-01T16:35:28+10:00",
       "consultation_response_due_date": "2026-07-08T12:00:00Z",
       "acquirers": [

--- a/data/processed/mergers.json
+++ b/data/processed/mergers.json
@@ -8531,7 +8531,7 @@
     "effective_notification_datetime": "2026-05-19T12:00:00Z",
     "original_notification_datetime": "2026-05-19T12:00:00Z",
     "stage": "Phase 1 - initial assessment",
-    "end_of_determination_period": "2026-07-01T12:00:00Z",
+    "end_of_determination_period": "2026-07-02T12:00:00Z",
     "determination_publication_date": "2026-06-15T12:00:00Z",
     "accc_determination": "Approved",
     "page_modified_datetime": "2026-06-15T09:48:36+10:00",
@@ -12704,7 +12704,7 @@
     "effective_notification_datetime": "2026-07-01T12:00:00Z",
     "original_notification_datetime": "2026-07-01T12:00:00Z",
     "stage": "Phase 1 - initial assessment",
-    "end_of_determination_period": "2026-08-11T12:00:00Z",
+    "end_of_determination_period": "2026-08-12T12:00:00Z",
     "page_modified_datetime": "2026-07-01T16:35:28+10:00",
     "consultation_response_due_date": "2026-07-08T12:00:00Z",
     "acquirers": [

--- a/merger-tracker/frontend/public/data/analysis.json
+++ b/merger-tracker/frontend/public/data/analysis.json
@@ -390,7 +390,7 @@
       },
       {
         "notification_date": "2026-03-05",
-        "business_days": 59,
+        "business_days": 58,
         "calendar_days": 89,
         "merger_name": "Peter Warren - Wakeling Automotive",
         "merger_id": "MN-30002",
@@ -534,7 +534,7 @@
       },
       {
         "notification_date": "2026-03-26",
-        "business_days": 23,
+        "business_days": 22,
         "calendar_days": 35,
         "merger_name": "Sinopec - CNAF",
         "merger_id": "MN-01093",
@@ -543,7 +543,7 @@
       },
       {
         "notification_date": "2026-03-26",
-        "business_days": 21,
+        "business_days": 20,
         "calendar_days": 33,
         "merger_name": "Tega and Apollo Funds consortium - Molycop",
         "merger_id": "MN-85006",
@@ -552,7 +552,7 @@
       },
       {
         "notification_date": "2026-03-27",
-        "business_days": 20,
+        "business_days": 19,
         "calendar_days": 32,
         "merger_name": "Calvary - Holmesglen Private Hospital",
         "merger_id": "MN-55010",
@@ -561,7 +561,7 @@
       },
       {
         "notification_date": "2026-03-31",
-        "business_days": 23,
+        "business_days": 22,
         "calendar_days": 35,
         "merger_name": "Eagers - Audi Melbourne and Audi Richmond",
         "merger_id": "MN-05012",
@@ -570,7 +570,7 @@
       },
       {
         "notification_date": "2026-04-02",
-        "business_days": 21,
+        "business_days": 20,
         "calendar_days": 33,
         "merger_name": "Danaher - Masimo",
         "merger_id": "MN-15011",
@@ -579,7 +579,7 @@
       },
       {
         "notification_date": "2026-04-03",
-        "business_days": 26,
+        "business_days": 25,
         "calendar_days": 39,
         "merger_name": "eBay - Depop",
         "merger_id": "MN-45002",
@@ -588,7 +588,7 @@
       },
       {
         "notification_date": "2026-04-07",
-        "business_days": 20,
+        "business_days": 19,
         "calendar_days": 28,
         "merger_name": "Journey Beyond \u2013 Kakadu Crocodile Hotel",
         "merger_id": "MN-15013",
@@ -597,7 +597,7 @@
       },
       {
         "notification_date": "2026-04-07",
-        "business_days": 20,
+        "business_days": 19,
         "calendar_days": 28,
         "merger_name": "REA Group - Simplicity Loans & Advisory",
         "merger_id": "MN-65008",
@@ -606,7 +606,7 @@
       },
       {
         "notification_date": "2026-04-07",
-        "business_days": 21,
+        "business_days": 20,
         "calendar_days": 29,
         "merger_name": "Sembcorp Industries Ltd - Alinta Energy",
         "merger_id": "MN-95001",
@@ -615,7 +615,7 @@
       },
       {
         "notification_date": "2026-04-08",
-        "business_days": 18,
+        "business_days": 17,
         "calendar_days": 26,
         "merger_name": "Eli Lilly - Orna Therapeutics",
         "merger_id": "MN-20013",
@@ -624,7 +624,7 @@
       },
       {
         "notification_date": "2026-04-10",
-        "business_days": 16,
+        "business_days": 15,
         "calendar_days": 24,
         "merger_name": "Estia Health \u2013 Norsan residential aged care business",
         "merger_id": "MN-35013",
@@ -633,7 +633,7 @@
       },
       {
         "notification_date": "2026-04-10",
-        "business_days": 18,
+        "business_days": 17,
         "calendar_days": 26,
         "merger_name": "Swiss Re - QBE Insurance's Trade Credit and Surety business",
         "merger_id": "MN-40015",
@@ -642,7 +642,7 @@
       },
       {
         "notification_date": "2026-04-10",
-        "business_days": 16,
+        "business_days": 15,
         "calendar_days": 24,
         "merger_name": "Dubai Aerospace Enterprise - Macquarie AirFinance",
         "merger_id": "MN-95011",
@@ -651,7 +651,7 @@
       },
       {
         "notification_date": "2026-04-13",
-        "business_days": 16,
+        "business_days": 15,
         "calendar_days": 22,
         "merger_name": "Lawrence & Hanson - Gordon Macdonald",
         "merger_id": "MN-55013",
@@ -660,7 +660,7 @@
       },
       {
         "notification_date": "2026-04-14",
-        "business_days": 16,
+        "business_days": 15,
         "calendar_days": 22,
         "merger_name": "Eli Lilly \u2013 acquisition of licence from CSL Behring",
         "merger_id": "MN-40012",
@@ -669,7 +669,7 @@
       },
       {
         "notification_date": "2026-04-14",
-        "business_days": 53,
+        "business_days": 52,
         "calendar_days": 77,
         "merger_name": "Trescal \u2013 TR Calibration",
         "merger_id": "MN-90009",
@@ -678,7 +678,7 @@
       },
       {
         "notification_date": "2026-04-15",
-        "business_days": 16,
+        "business_days": 15,
         "calendar_days": 22,
         "merger_name": "Ventura Motors \u2013 Crown Coaches",
         "merger_id": "MN-70013",
@@ -687,7 +687,7 @@
       },
       {
         "notification_date": "2026-04-16",
-        "business_days": 16,
+        "business_days": 15,
         "calendar_days": 22,
         "merger_name": "Daikin - AAMS Group",
         "merger_id": "MN-30009",
@@ -696,7 +696,7 @@
       },
       {
         "notification_date": "2026-04-16",
-        "business_days": 22,
+        "business_days": 21,
         "calendar_days": 32,
         "merger_name": "Global Infrastructure Management \u2013 TCR",
         "merger_id": "MN-70014",
@@ -705,7 +705,7 @@
       },
       {
         "notification_date": "2026-04-17",
-        "business_days": 19,
+        "business_days": 18,
         "calendar_days": 27,
         "merger_name": "Accenture - Ziff Davis' connectivity business",
         "merger_id": "MN-10013",
@@ -714,7 +714,7 @@
       },
       {
         "notification_date": "2026-04-21",
-        "business_days": 22,
+        "business_days": 21,
         "calendar_days": 30,
         "merger_name": "MassMutual, Rest, Aware Super and Goodman \u2013 Moorabbin Airport",
         "merger_id": "MN-10012",
@@ -723,7 +723,7 @@
       },
       {
         "notification_date": "2026-04-21",
-        "business_days": 17,
+        "business_days": 16,
         "calendar_days": 23,
         "merger_name": "Zurich - ClearView",
         "merger_id": "MN-55016",
@@ -732,7 +732,7 @@
       },
       {
         "notification_date": "2026-04-22",
-        "business_days": 18,
+        "business_days": 17,
         "calendar_days": 26,
         "merger_name": "Gilead - Ouro",
         "merger_id": "MN-60014",
@@ -741,7 +741,7 @@
       },
       {
         "notification_date": "2026-04-24",
-        "business_days": 20,
+        "business_days": 19,
         "calendar_days": 28,
         "merger_name": "Australian Meat Group - Killara Feedlot",
         "merger_id": "MN-20012",
@@ -750,7 +750,7 @@
       },
       {
         "notification_date": "2026-04-24",
-        "business_days": 16,
+        "business_days": 15,
         "calendar_days": 24,
         "merger_name": "WIN Television Network - NBN Enterprises & Television Holdings Darwin",
         "merger_id": "MN-50008",
@@ -1155,7 +1155,7 @@
       }
     ],
     "stats": {
-      "average": 18.8,
+      "average": 18.6,
       "median": 17,
       "min": 15,
       "max": 59,
@@ -1981,7 +1981,7 @@
       },
       {
         "application_date": "2026-03-28",
-        "business_days": 20,
+        "business_days": 19,
         "calendar_days": 31,
         "merger_name": "Bendigo and Adelaide Bank \u2013 RACQ Bank",
         "merger_id": "WA-70015",
@@ -2013,7 +2013,7 @@
       },
       {
         "application_date": "2026-03-31",
-        "business_days": 19,
+        "business_days": 18,
         "calendar_days": 29,
         "merger_name": "Export Trading Group Australia \u2013 pulses and grains business and facility in Mount Tyson, QLD",
         "merger_id": "WA-60013",
@@ -2045,7 +2045,7 @@
       },
       {
         "application_date": "2026-04-02",
-        "business_days": 25,
+        "business_days": 24,
         "calendar_days": 39,
         "merger_name": "Energy Bay - Rights to install/operate embedded networks and other assets from Centuria Capital Group members",
         "merger_id": "WA-01094",
@@ -2053,7 +2053,7 @@
       },
       {
         "application_date": "2026-04-02",
-        "business_days": 19,
+        "business_days": 18,
         "calendar_days": 29,
         "merger_name": "Airtree and ors (additional minority co-investors) - Advanced Navigation",
         "merger_id": "WA-45010",
@@ -2109,7 +2109,7 @@
       },
       {
         "application_date": "2026-04-08",
-        "business_days": 16,
+        "business_days": 15,
         "calendar_days": 22,
         "merger_name": "Turner Family Entities - Pedal Group",
         "merger_id": "WA-10014",
@@ -2117,7 +2117,7 @@
       },
       {
         "application_date": "2026-04-08",
-        "business_days": 16,
+        "business_days": 15,
         "calendar_days": 22,
         "merger_name": "Savvy Games Group \u2013 Moonton",
         "merger_id": "WA-65012",
@@ -2149,7 +2149,7 @@
       },
       {
         "application_date": "2026-04-10",
-        "business_days": 13,
+        "business_days": 12,
         "calendar_days": 19,
         "merger_name": "Salter Brothers - Buroserv",
         "merger_id": "WA-90011",
@@ -2157,7 +2157,7 @@
       },
       {
         "application_date": "2026-04-13",
-        "business_days": 18,
+        "business_days": 17,
         "calendar_days": 24,
         "merger_name": "Herron Todd White \u2013 CJA Lee Property Valuers",
         "merger_id": "WA-20015",
@@ -2165,7 +2165,7 @@
       },
       {
         "application_date": "2026-04-16",
-        "business_days": 12,
+        "business_days": 11,
         "calendar_days": 18,
         "merger_name": "Hostplus \u2013 CH Investment Holding Trust",
         "merger_id": "WA-25016",
@@ -2173,7 +2173,7 @@
       },
       {
         "application_date": "2026-04-16",
-        "business_days": 10,
+        "business_days": 9,
         "calendar_days": 14,
         "merger_name": "MA Financial Group (Redcape Fund) \u2013 The Entrance Social Club",
         "merger_id": "WA-60017",
@@ -2181,7 +2181,7 @@
       },
       {
         "application_date": "2026-04-20",
-        "business_days": 12,
+        "business_days": 11,
         "calendar_days": 16,
         "merger_name": "Mayfair Corporation \u2013 Phosphate Hill",
         "merger_id": "WA-25017",
@@ -2189,7 +2189,7 @@
       },
       {
         "application_date": "2026-04-20",
-        "business_days": 19,
+        "business_days": 18,
         "calendar_days": 25,
         "merger_name": "MAG South Coast - Country Motor Company / Kinghorn Motors",
         "merger_id": "WA-30010",
@@ -2197,7 +2197,7 @@
       },
       {
         "application_date": "2026-04-20",
-        "business_days": 17,
+        "business_days": 16,
         "calendar_days": 23,
         "merger_name": "26North Funds - Intermedia Cloud Communications",
         "merger_id": "WA-65014",
@@ -2205,7 +2205,7 @@
       },
       {
         "application_date": "2026-04-20",
-        "business_days": 7,
+        "business_days": 6,
         "calendar_days": 9,
         "merger_name": "Publicis \u2013 160over90",
         "merger_id": "WA-95014",
@@ -2213,7 +2213,7 @@
       },
       {
         "application_date": "2026-04-21",
-        "business_days": 10,
+        "business_days": 9,
         "calendar_days": 14,
         "merger_name": "Coles - substation in Yarrawonga VIC",
         "merger_id": "WA-05016",
@@ -2221,7 +2221,7 @@
       },
       {
         "application_date": "2026-04-21",
-        "business_days": 15,
+        "business_days": 14,
         "calendar_days": 21,
         "merger_name": "AustralianSuper - IFM Global Infrastructure (Australia) Trust",
         "merger_id": "WA-40018",
@@ -2229,7 +2229,7 @@
       },
       {
         "application_date": "2026-04-21",
-        "business_days": 8,
+        "business_days": 7,
         "calendar_days": 10,
         "merger_name": "Coles - Leasehold interest in shopping centre on Capricorn Highway, Emerald, QLD",
         "merger_id": "WA-55017",
@@ -2237,7 +2237,7 @@
       },
       {
         "application_date": "2026-04-21",
-        "business_days": 20,
+        "business_days": 19,
         "calendar_days": 28,
         "merger_name": "Hillhouse - Barwon Investment Partners",
         "merger_id": "WA-65015",
@@ -2245,7 +2245,7 @@
       },
       {
         "application_date": "2026-04-22",
-        "business_days": 9,
+        "business_days": 8,
         "calendar_days": 13,
         "merger_name": "Apollo Funds - Nippon Sheet Glass",
         "merger_id": "WA-45012",
@@ -2253,7 +2253,7 @@
       },
       {
         "application_date": "2026-04-22",
-        "business_days": 8,
+        "business_days": 7,
         "calendar_days": 12,
         "merger_name": "Oceania Capital Partners - Hudson Global Resources (Aust)",
         "merger_id": "WA-70016",
@@ -2261,7 +2261,7 @@
       },
       {
         "application_date": "2026-04-23",
-        "business_days": 4,
+        "business_days": 3,
         "calendar_days": 6,
         "merger_name": "Allianz - Lease of commercial office space in North Sydney from Lendlease (Victoria Cross)",
         "merger_id": "WA-55015",
@@ -2269,7 +2269,7 @@
       },
       {
         "application_date": "2026-04-24",
-        "business_days": 17,
+        "business_days": 16,
         "calendar_days": 25,
         "merger_name": "AXDI - minority interest in La Trobe Financial",
         "merger_id": "WA-30011",
@@ -2277,7 +2277,7 @@
       },
       {
         "application_date": "2026-04-24",
-        "business_days": 11,
+        "business_days": 10,
         "calendar_days": 17,
         "merger_name": "Allied Retail Finance \u2013 automotive retail finance assets of Macquarie Leasing",
         "merger_id": "WA-35015",
@@ -2285,7 +2285,7 @@
       },
       {
         "application_date": "2026-04-24",
-        "business_days": 11,
+        "business_days": 10,
         "calendar_days": 17,
         "merger_name": "Australian Venue Co \u2013 assets of White Cockatoo Hotel, Petersham",
         "merger_id": "WA-45013",
@@ -2293,7 +2293,7 @@
       },
       {
         "application_date": "2026-04-24",
-        "business_days": 9,
+        "business_days": 8,
         "calendar_days": 13,
         "merger_name": "BHP \u2013 expansion of Special Mining Lease at Olympic Dam, SA",
         "merger_id": "WA-65013",
@@ -2301,7 +2301,7 @@
       },
       {
         "application_date": "2026-04-24",
-        "business_days": 11,
+        "business_days": 10,
         "calendar_days": 17,
         "merger_name": "CRH - Axius Water",
         "merger_id": "WA-80011",
@@ -2309,7 +2309,7 @@
       },
       {
         "application_date": "2026-04-24",
-        "business_days": 8,
+        "business_days": 7,
         "calendar_days": 12,
         "merger_name": "Francisco Partners - Blackline Safety",
         "merger_id": "WA-85025",
@@ -2317,7 +2317,7 @@
       },
       {
         "application_date": "2026-04-24",
-        "business_days": 11,
+        "business_days": 10,
         "calendar_days": 17,
         "merger_name": "Cement Australia \u2013 Global Manufacturing Group",
         "merger_id": "WA-90013",
@@ -2325,7 +2325,7 @@
       },
       {
         "application_date": "2026-04-26",
-        "business_days": 12,
+        "business_days": 11,
         "calendar_days": 16,
         "merger_name": "Ochre Health - New Lambton Family Practice, NSW",
         "merger_id": "WA-40021",
@@ -3197,10 +3197,10 @@
       }
     ],
     "stats": {
-      "average": 12.3,
+      "average": 12.2,
       "median": 12,
       "min": 2,
-      "max": 25,
+      "max": 24,
       "count": 253
     },
     "calendar_stats": {
@@ -3256,8 +3256,8 @@
     {
       "code": "S",
       "name": "Other Services",
-      "average_business_days": 30.0,
-      "median_business_days": 19.0,
+      "average_business_days": 29.5,
+      "median_business_days": 18.5,
       "average_calendar_days": 44.3,
       "median_calendar_days": 28.0,
       "count": 6
@@ -3265,7 +3265,7 @@
     {
       "code": "G",
       "name": "Retail Trade",
-      "average_business_days": 26.4,
+      "average_business_days": 26.2,
       "median_business_days": 18.5,
       "average_calendar_days": 42.8,
       "median_calendar_days": 28.5,
@@ -3274,7 +3274,7 @@
     {
       "code": "F",
       "name": "Wholesale Trade",
-      "average_business_days": 22.4,
+      "average_business_days": 22.1,
       "median_business_days": 18.0,
       "average_calendar_days": 36.0,
       "median_calendar_days": 28.0,
@@ -3283,8 +3283,8 @@
     {
       "code": "I",
       "name": "Transport, Postal and Warehousing",
-      "average_business_days": 22.4,
-      "median_business_days": 22,
+      "average_business_days": 22.1,
+      "median_business_days": 21,
       "average_calendar_days": 32.9,
       "median_calendar_days": 30,
       "count": 9
@@ -3292,20 +3292,11 @@
     {
       "code": "M",
       "name": "Professional, Scientific and Technical Services",
-      "average_business_days": 21.5,
-      "median_business_days": 18.0,
+      "average_business_days": 21.3,
+      "median_business_days": 17.5,
       "average_calendar_days": 33.3,
       "median_calendar_days": 27.0,
       "count": 30
-    },
-    {
-      "code": "L",
-      "name": "Rental, Hiring and Real Estate Services",
-      "average_business_days": 20.7,
-      "median_business_days": 19,
-      "average_calendar_days": 32.1,
-      "median_calendar_days": 29,
-      "count": 11
     },
     {
       "code": "B",
@@ -3315,6 +3306,15 @@
       "average_calendar_days": 30.2,
       "median_calendar_days": 26,
       "count": 5
+    },
+    {
+      "code": "L",
+      "name": "Rental, Hiring and Real Estate Services",
+      "average_business_days": 20.5,
+      "median_business_days": 19,
+      "average_calendar_days": 32.1,
+      "median_calendar_days": 29,
+      "count": 11
     },
     {
       "code": "O",
@@ -3337,8 +3337,8 @@
     {
       "code": "E",
       "name": "Construction",
-      "average_business_days": 19.6,
-      "median_business_days": 16.0,
+      "average_business_days": 19.5,
+      "median_business_days": 15.5,
       "average_calendar_days": 28.5,
       "median_calendar_days": 22.5,
       "count": 8
@@ -3346,7 +3346,7 @@
     {
       "code": "K",
       "name": "Financial and Insurance Services",
-      "average_business_days": 19.5,
+      "average_business_days": 19.3,
       "median_business_days": 16,
       "average_calendar_days": 28.7,
       "median_calendar_days": 24,
@@ -3355,8 +3355,8 @@
     {
       "code": "C",
       "name": "Manufacturing",
-      "average_business_days": 19.3,
-      "median_business_days": 17.5,
+      "average_business_days": 19.1,
+      "median_business_days": 17.0,
       "average_calendar_days": 29.5,
       "median_calendar_days": 26.0,
       "count": 36
@@ -3364,29 +3364,29 @@
     {
       "code": "D",
       "name": "Electricity, Gas, Water and Waste Services",
-      "average_business_days": 18.7,
+      "average_business_days": 18.3,
       "median_business_days": 20,
       "average_calendar_days": 26.3,
       "median_calendar_days": 28,
       "count": 3
     },
     {
-      "code": "R",
-      "name": "Arts and Recreation Services",
-      "average_business_days": 18.0,
-      "median_business_days": 18.0,
-      "average_calendar_days": 26.0,
-      "median_calendar_days": 26.0,
-      "count": 2
-    },
-    {
       "code": "A",
       "name": "Agriculture, Forestry and Fishing",
-      "average_business_days": 17.8,
+      "average_business_days": 17.5,
       "median_business_days": 18.0,
       "average_calendar_days": 26.0,
       "median_calendar_days": 27.0,
       "count": 4
+    },
+    {
+      "code": "R",
+      "name": "Arts and Recreation Services",
+      "average_business_days": 17.5,
+      "median_business_days": 17.5,
+      "average_calendar_days": 26.0,
+      "median_calendar_days": 26.0,
+      "count": 2
     },
     {
       "code": "N",
@@ -3400,7 +3400,7 @@
     {
       "code": "H",
       "name": "Accommodation and Food Services",
-      "average_business_days": 16.8,
+      "average_business_days": 16.6,
       "median_business_days": 16,
       "average_calendar_days": 24.6,
       "median_calendar_days": 24,
@@ -3409,7 +3409,7 @@
     {
       "code": "Q",
       "name": "Health Care and Social Assistance",
-      "average_business_days": 16.0,
+      "average_business_days": 15.8,
       "median_business_days": 15.0,
       "average_calendar_days": 24.7,
       "median_calendar_days": 24.5,

--- a/merger-tracker/frontend/public/data/industries/01.json
+++ b/merger-tracker/frontend/public/data/industries/01.json
@@ -170,7 +170,7 @@
   "phase_duration": {
     "average_days": 26.0,
     "median_days": 27,
-    "average_business_days": 17.75,
+    "average_business_days": 17.5,
     "median_business_days": 18,
     "completed_count": 4
   }

--- a/merger-tracker/frontend/public/data/industries/014.json
+++ b/merger-tracker/frontend/public/data/industries/014.json
@@ -109,8 +109,8 @@
   "phase_duration": {
     "average_days": 28.0,
     "median_days": 28,
-    "average_business_days": 20.0,
-    "median_business_days": 20,
+    "average_business_days": 19.0,
+    "median_business_days": 19,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/0143.json
+++ b/merger-tracker/frontend/public/data/industries/0143.json
@@ -62,8 +62,8 @@
   "phase_duration": {
     "average_days": 28.0,
     "median_days": 28,
-    "average_business_days": 20.0,
-    "median_business_days": 20,
+    "average_business_days": 19.0,
+    "median_business_days": 19,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/11.json
+++ b/merger-tracker/frontend/public/data/industries/11.json
@@ -179,7 +179,7 @@
   "phase_duration": {
     "average_days": 29.166666666666668,
     "median_days": 27,
-    "average_business_days": 17.333333333333332,
+    "average_business_days": 17.166666666666668,
     "median_business_days": 18,
     "completed_count": 6
   }

--- a/merger-tracker/frontend/public/data/industries/111.json
+++ b/merger-tracker/frontend/public/data/industries/111.json
@@ -85,7 +85,7 @@
   "phase_duration": {
     "average_days": 26.666666666666668,
     "median_days": 27,
-    "average_business_days": 17.666666666666668,
+    "average_business_days": 17.333333333333332,
     "median_business_days": 18,
     "completed_count": 3
   }

--- a/merger-tracker/frontend/public/data/industries/1111.json
+++ b/merger-tracker/frontend/public/data/industries/1111.json
@@ -62,8 +62,8 @@
   "phase_duration": {
     "average_days": 27.5,
     "median_days": 28,
-    "average_business_days": 19.0,
-    "median_business_days": 20,
+    "average_business_days": 18.5,
+    "median_business_days": 19,
     "completed_count": 2
   }
 }

--- a/merger-tracker/frontend/public/data/industries/18.json
+++ b/merger-tracker/frontend/public/data/industries/18.json
@@ -188,8 +188,8 @@
   "phase_duration": {
     "average_days": 26.375,
     "median_days": 26,
-    "average_business_days": 17.5,
-    "median_business_days": 18,
+    "average_business_days": 17.125,
+    "median_business_days": 17,
     "completed_count": 8
   }
 }

--- a/merger-tracker/frontend/public/data/industries/184.json
+++ b/merger-tracker/frontend/public/data/industries/184.json
@@ -133,8 +133,8 @@
   "phase_duration": {
     "average_days": 25.166666666666668,
     "median_days": 26,
-    "average_business_days": 16.833333333333332,
-    "median_business_days": 18,
+    "average_business_days": 16.333333333333332,
+    "median_business_days": 17,
     "completed_count": 6
   }
 }

--- a/merger-tracker/frontend/public/data/industries/1841.json
+++ b/merger-tracker/frontend/public/data/industries/1841.json
@@ -116,8 +116,8 @@
   "phase_duration": {
     "average_days": 25.166666666666668,
     "median_days": 26,
-    "average_business_days": 16.833333333333332,
-    "median_business_days": 18,
+    "average_business_days": 16.333333333333332,
+    "median_business_days": 17,
     "completed_count": 6
   }
 }

--- a/merger-tracker/frontend/public/data/industries/19.json
+++ b/merger-tracker/frontend/public/data/industries/19.json
@@ -146,7 +146,7 @@
   "phase_duration": {
     "average_days": 26.6,
     "median_days": 22,
-    "average_business_days": 18.2,
+    "average_business_days": 18.0,
     "median_business_days": 15,
     "completed_count": 5
   }

--- a/merger-tracker/frontend/public/data/industries/191.json
+++ b/merger-tracker/frontend/public/data/industries/191.json
@@ -181,7 +181,7 @@
   "phase_duration": {
     "average_days": 26.6,
     "median_days": 22,
-    "average_business_days": 18.2,
+    "average_business_days": 18.0,
     "median_business_days": 15,
     "completed_count": 5
   }

--- a/merger-tracker/frontend/public/data/industries/1919.json
+++ b/merger-tracker/frontend/public/data/industries/1919.json
@@ -62,7 +62,7 @@
   "phase_duration": {
     "average_days": 34.5,
     "median_days": 36,
-    "average_business_days": 23.0,
+    "average_business_days": 22.5,
     "median_business_days": 25,
     "completed_count": 2
   }

--- a/merger-tracker/frontend/public/data/industries/192.json
+++ b/merger-tracker/frontend/public/data/industries/192.json
@@ -55,8 +55,8 @@
   "phase_duration": {
     "average_days": 33.0,
     "median_days": 33,
-    "average_business_days": 21.0,
-    "median_business_days": 21,
+    "average_business_days": 20.0,
+    "median_business_days": 20,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/1920.json
+++ b/merger-tracker/frontend/public/data/industries/1920.json
@@ -53,8 +53,8 @@
   "phase_duration": {
     "average_days": 33.0,
     "median_days": 33,
-    "average_business_days": 21.0,
-    "median_business_days": 21,
+    "average_business_days": 20.0,
+    "median_business_days": 20,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/24.json
+++ b/merger-tracker/frontend/public/data/industries/24.json
@@ -392,7 +392,7 @@
   "phase_duration": {
     "average_days": 27.583333333333332,
     "median_days": 29,
-    "average_business_days": 19.166666666666668,
+    "average_business_days": 18.916666666666668,
     "median_business_days": 20,
     "completed_count": 12
   }

--- a/merger-tracker/frontend/public/data/industries/241.json
+++ b/merger-tracker/frontend/public/data/industries/241.json
@@ -139,7 +139,7 @@
   "phase_duration": {
     "average_days": 28.333333333333332,
     "median_days": 29,
-    "average_business_days": 19.333333333333332,
+    "average_business_days": 19.0,
     "median_business_days": 20,
     "completed_count": 3
   }

--- a/merger-tracker/frontend/public/data/industries/2412.json
+++ b/merger-tracker/frontend/public/data/industries/2412.json
@@ -80,8 +80,8 @@
   "phase_duration": {
     "average_days": 28.0,
     "median_days": 33,
-    "average_business_days": 19.0,
-    "median_business_days": 21,
+    "average_business_days": 18.5,
+    "median_business_days": 20,
     "completed_count": 2
   }
 }

--- a/merger-tracker/frontend/public/data/industries/2419.json
+++ b/merger-tracker/frontend/public/data/industries/2419.json
@@ -89,8 +89,8 @@
   "phase_duration": {
     "average_days": 31.0,
     "median_days": 33,
-    "average_business_days": 20.5,
-    "median_business_days": 21,
+    "average_business_days": 20.0,
+    "median_business_days": 20,
     "completed_count": 2
   }
 }

--- a/merger-tracker/frontend/public/data/industries/245.json
+++ b/merger-tracker/frontend/public/data/industries/245.json
@@ -79,7 +79,7 @@
   "phase_duration": {
     "average_days": 27.5,
     "median_days": 33,
-    "average_business_days": 19.0,
+    "average_business_days": 18.5,
     "median_business_days": 22,
     "completed_count": 2
   }

--- a/merger-tracker/frontend/public/data/industries/2452.json
+++ b/merger-tracker/frontend/public/data/industries/2452.json
@@ -71,7 +71,7 @@
   "phase_duration": {
     "average_days": 27.5,
     "median_days": 33,
-    "average_business_days": 19.0,
+    "average_business_days": 18.5,
     "median_business_days": 22,
     "completed_count": 2
   }

--- a/merger-tracker/frontend/public/data/industries/246.json
+++ b/merger-tracker/frontend/public/data/industries/246.json
@@ -145,7 +145,7 @@
   "phase_duration": {
     "average_days": 30.75,
     "median_days": 33,
-    "average_business_days": 21.5,
+    "average_business_days": 21.25,
     "median_business_days": 22,
     "completed_count": 4
   }

--- a/merger-tracker/frontend/public/data/industries/2469.json
+++ b/merger-tracker/frontend/public/data/industries/2469.json
@@ -80,8 +80,8 @@
   "phase_duration": {
     "average_days": 28.333333333333332,
     "median_days": 31,
-    "average_business_days": 19.333333333333332,
-    "median_business_days": 21,
+    "average_business_days": 19.0,
+    "median_business_days": 20,
     "completed_count": 3
   }
 }

--- a/merger-tracker/frontend/public/data/industries/26.json
+++ b/merger-tracker/frontend/public/data/industries/26.json
@@ -167,7 +167,7 @@
   "phase_duration": {
     "average_days": 26.333333333333332,
     "median_days": 28,
-    "average_business_days": 18.666666666666668,
+    "average_business_days": 18.333333333333332,
     "median_business_days": 20,
     "completed_count": 3
   }

--- a/merger-tracker/frontend/public/data/industries/261.json
+++ b/merger-tracker/frontend/public/data/industries/261.json
@@ -139,7 +139,7 @@
   "phase_duration": {
     "average_days": 26.333333333333332,
     "median_days": 28,
-    "average_business_days": 18.666666666666668,
+    "average_business_days": 18.333333333333332,
     "median_business_days": 20,
     "completed_count": 3
   }

--- a/merger-tracker/frontend/public/data/industries/2611.json
+++ b/merger-tracker/frontend/public/data/industries/2611.json
@@ -62,8 +62,8 @@
   "phase_duration": {
     "average_days": 29.0,
     "median_days": 29,
-    "average_business_days": 21.0,
-    "median_business_days": 21,
+    "average_business_days": 20.0,
+    "median_business_days": 20,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/2619.json
+++ b/merger-tracker/frontend/public/data/industries/2619.json
@@ -107,7 +107,7 @@
   "phase_duration": {
     "average_days": 26.333333333333332,
     "median_days": 28,
-    "average_business_days": 18.666666666666668,
+    "average_business_days": 18.333333333333332,
     "median_business_days": 20,
     "completed_count": 3
   }

--- a/merger-tracker/frontend/public/data/industries/264.json
+++ b/merger-tracker/frontend/public/data/industries/264.json
@@ -64,8 +64,8 @@
   "phase_duration": {
     "average_days": 29.0,
     "median_days": 29,
-    "average_business_days": 21.0,
-    "median_business_days": 21,
+    "average_business_days": 20.0,
+    "median_business_days": 20,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/2640.json
+++ b/merger-tracker/frontend/public/data/industries/2640.json
@@ -62,8 +62,8 @@
   "phase_duration": {
     "average_days": 29.0,
     "median_days": 29,
-    "average_business_days": 21.0,
-    "median_business_days": 21,
+    "average_business_days": 20.0,
+    "median_business_days": 20,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/27.json
+++ b/merger-tracker/frontend/public/data/industries/27.json
@@ -41,8 +41,8 @@
   "phase_duration": {
     "average_days": 29.0,
     "median_days": 29,
-    "average_business_days": 21.0,
-    "median_business_days": 21,
+    "average_business_days": 20.0,
+    "median_business_days": 20,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/270.json
+++ b/merger-tracker/frontend/public/data/industries/270.json
@@ -46,8 +46,8 @@
   "phase_duration": {
     "average_days": 29.0,
     "median_days": 29,
-    "average_business_days": 21.0,
-    "median_business_days": 21,
+    "average_business_days": 20.0,
+    "median_business_days": 20,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/2700.json
+++ b/merger-tracker/frontend/public/data/industries/2700.json
@@ -44,8 +44,8 @@
   "phase_duration": {
     "average_days": 29.0,
     "median_days": 29,
-    "average_business_days": 21.0,
-    "median_business_days": 21,
+    "average_business_days": 20.0,
+    "median_business_days": 20,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/32.json
+++ b/merger-tracker/frontend/public/data/industries/32.json
@@ -227,8 +227,8 @@
   "phase_duration": {
     "average_days": 22.75,
     "median_days": 22,
-    "average_business_days": 16.0,
-    "median_business_days": 16,
+    "average_business_days": 15.75,
+    "median_business_days": 15,
     "completed_count": 4
   }
 }

--- a/merger-tracker/frontend/public/data/industries/323.json
+++ b/merger-tracker/frontend/public/data/industries/323.json
@@ -133,8 +133,8 @@
   "phase_duration": {
     "average_days": 22.0,
     "median_days": 22,
-    "average_business_days": 16.0,
-    "median_business_days": 16,
+    "average_business_days": 15.0,
+    "median_business_days": 15,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/3233.json
+++ b/merger-tracker/frontend/public/data/industries/3233.json
@@ -71,8 +71,8 @@
   "phase_duration": {
     "average_days": 22.0,
     "median_days": 22,
-    "average_business_days": 16.0,
-    "median_business_days": 16,
+    "average_business_days": 15.0,
+    "median_business_days": 15,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/3234.json
+++ b/merger-tracker/frontend/public/data/industries/3234.json
@@ -62,8 +62,8 @@
   "phase_duration": {
     "average_days": 22.0,
     "median_days": 22,
-    "average_business_days": 16.0,
-    "median_business_days": 16,
+    "average_business_days": 15.0,
+    "median_business_days": 15,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/33.json
+++ b/merger-tracker/frontend/public/data/industries/33.json
@@ -125,8 +125,8 @@
   "phase_duration": {
     "average_days": 55.0,
     "median_days": 35,
-    "average_business_days": 33.333333333333336,
-    "median_business_days": 23,
+    "average_business_days": 33.0,
+    "median_business_days": 22,
     "completed_count": 3
   }
 }

--- a/merger-tracker/frontend/public/data/industries/332.json
+++ b/merger-tracker/frontend/public/data/industries/332.json
@@ -85,8 +85,8 @@
   "phase_duration": {
     "average_days": 55.0,
     "median_days": 35,
-    "average_business_days": 33.333333333333336,
-    "median_business_days": 23,
+    "average_business_days": 33.0,
+    "median_business_days": 22,
     "completed_count": 3
   }
 }

--- a/merger-tracker/frontend/public/data/industries/3321.json
+++ b/merger-tracker/frontend/public/data/industries/3321.json
@@ -62,8 +62,8 @@
   "phase_duration": {
     "average_days": 55.0,
     "median_days": 35,
-    "average_business_days": 33.333333333333336,
-    "median_business_days": 23,
+    "average_business_days": 33.0,
+    "median_business_days": 22,
     "completed_count": 3
   }
 }

--- a/merger-tracker/frontend/public/data/industries/34.json
+++ b/merger-tracker/frontend/public/data/industries/34.json
@@ -182,8 +182,8 @@
   "phase_duration": {
     "average_days": 37.625,
     "median_days": 33,
-    "average_business_days": 23.875,
-    "median_business_days": 21,
+    "average_business_days": 23.375,
+    "median_business_days": 20,
     "completed_count": 8
   }
 }

--- a/merger-tracker/frontend/public/data/industries/341.json
+++ b/merger-tracker/frontend/public/data/industries/341.json
@@ -52,8 +52,8 @@
   "phase_duration": {
     "average_days": 33.0,
     "median_days": 33,
-    "average_business_days": 21.0,
-    "median_business_days": 21,
+    "average_business_days": 20.0,
+    "median_business_days": 20,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/3419.json
+++ b/merger-tracker/frontend/public/data/industries/3419.json
@@ -44,8 +44,8 @@
   "phase_duration": {
     "average_days": 33.0,
     "median_days": 33,
-    "average_business_days": 21.0,
-    "median_business_days": 21,
+    "average_business_days": 20.0,
+    "median_business_days": 20,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/349.json
+++ b/merger-tracker/frontend/public/data/industries/349.json
@@ -196,7 +196,7 @@
   "phase_duration": {
     "average_days": 38.285714285714285,
     "median_days": 33,
-    "average_business_days": 24.285714285714285,
+    "average_business_days": 23.857142857142858,
     "median_business_days": 20,
     "completed_count": 7
   }

--- a/merger-tracker/frontend/public/data/industries/3491.json
+++ b/merger-tracker/frontend/public/data/industries/3491.json
@@ -80,8 +80,8 @@
   "phase_duration": {
     "average_days": 27.5,
     "median_days": 33,
-    "average_business_days": 18.5,
-    "median_business_days": 21,
+    "average_business_days": 18.0,
+    "median_business_days": 20,
     "completed_count": 2
   }
 }

--- a/merger-tracker/frontend/public/data/industries/3494.json
+++ b/merger-tracker/frontend/public/data/industries/3494.json
@@ -89,8 +89,8 @@
   "phase_duration": {
     "average_days": 49.5,
     "median_days": 77,
-    "average_business_days": 34.5,
-    "median_business_days": 53,
+    "average_business_days": 33.5,
+    "median_business_days": 52,
     "completed_count": 2
   }
 }

--- a/merger-tracker/frontend/public/data/industries/39.json
+++ b/merger-tracker/frontend/public/data/industries/39.json
@@ -137,8 +137,8 @@
   "phase_duration": {
     "average_days": 50.666666666666664,
     "median_days": 35,
-    "average_business_days": 33.333333333333336,
-    "median_business_days": 23,
+    "average_business_days": 32.666666666666664,
+    "median_business_days": 22,
     "completed_count": 3
   }
 }

--- a/merger-tracker/frontend/public/data/industries/391.json
+++ b/merger-tracker/frontend/public/data/industries/391.json
@@ -148,8 +148,8 @@
   "phase_duration": {
     "average_days": 50.666666666666664,
     "median_days": 35,
-    "average_business_days": 33.333333333333336,
-    "median_business_days": 23,
+    "average_business_days": 32.666666666666664,
+    "median_business_days": 22,
     "completed_count": 3
   }
 }

--- a/merger-tracker/frontend/public/data/industries/3911.json
+++ b/merger-tracker/frontend/public/data/industries/3911.json
@@ -134,8 +134,8 @@
   "phase_duration": {
     "average_days": 50.666666666666664,
     "median_days": 35,
-    "average_business_days": 33.333333333333336,
-    "median_business_days": 23,
+    "average_business_days": 32.666666666666664,
+    "median_business_days": 22,
     "completed_count": 3
   }
 }

--- a/merger-tracker/frontend/public/data/industries/392.json
+++ b/merger-tracker/frontend/public/data/industries/392.json
@@ -70,8 +70,8 @@
   "phase_duration": {
     "average_days": 62.0,
     "median_days": 89,
-    "average_business_days": 41.0,
-    "median_business_days": 59,
+    "average_business_days": 40.0,
+    "median_business_days": 58,
     "completed_count": 2
   }
 }

--- a/merger-tracker/frontend/public/data/industries/3921.json
+++ b/merger-tracker/frontend/public/data/industries/3921.json
@@ -62,8 +62,8 @@
   "phase_duration": {
     "average_days": 62.0,
     "median_days": 89,
-    "average_business_days": 41.0,
-    "median_business_days": 59,
+    "average_business_days": 40.0,
+    "median_business_days": 58,
     "completed_count": 2
   }
 }

--- a/merger-tracker/frontend/public/data/industries/43.json
+++ b/merger-tracker/frontend/public/data/industries/43.json
@@ -47,8 +47,8 @@
   "phase_duration": {
     "average_days": 39.0,
     "median_days": 39,
-    "average_business_days": 26.0,
-    "median_business_days": 26,
+    "average_business_days": 25.0,
+    "median_business_days": 25,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/432.json
+++ b/merger-tracker/frontend/public/data/industries/432.json
@@ -46,8 +46,8 @@
   "phase_duration": {
     "average_days": 39.0,
     "median_days": 39,
-    "average_business_days": 26.0,
-    "median_business_days": 26,
+    "average_business_days": 25.0,
+    "median_business_days": 25,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/4320.json
+++ b/merger-tracker/frontend/public/data/industries/4320.json
@@ -44,8 +44,8 @@
   "phase_duration": {
     "average_days": 39.0,
     "median_days": 39,
-    "average_business_days": 26.0,
-    "median_business_days": 26,
+    "average_business_days": 25.0,
+    "median_business_days": 25,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/44.json
+++ b/merger-tracker/frontend/public/data/industries/44.json
@@ -167,7 +167,7 @@
   "phase_duration": {
     "average_days": 25.666666666666668,
     "median_days": 25,
-    "average_business_days": 17.666666666666668,
+    "average_business_days": 17.333333333333332,
     "median_business_days": 17,
     "completed_count": 3
   }

--- a/merger-tracker/frontend/public/data/industries/440.json
+++ b/merger-tracker/frontend/public/data/industries/440.json
@@ -172,7 +172,7 @@
   "phase_duration": {
     "average_days": 25.666666666666668,
     "median_days": 25,
-    "average_business_days": 17.666666666666668,
+    "average_business_days": 17.333333333333332,
     "median_business_days": 17,
     "completed_count": 3
   }

--- a/merger-tracker/frontend/public/data/industries/4400.json
+++ b/merger-tracker/frontend/public/data/industries/4400.json
@@ -170,7 +170,7 @@
   "phase_duration": {
     "average_days": 25.666666666666668,
     "median_days": 25,
-    "average_business_days": 17.666666666666668,
+    "average_business_days": 17.333333333333332,
     "median_business_days": 17,
     "completed_count": 3
   }

--- a/merger-tracker/frontend/public/data/industries/46.json
+++ b/merger-tracker/frontend/public/data/industries/46.json
@@ -110,7 +110,7 @@
   "phase_duration": {
     "average_days": 33.333333333333336,
     "median_days": 36,
-    "average_business_days": 22.666666666666668,
+    "average_business_days": 22.333333333333332,
     "median_business_days": 24,
     "completed_count": 3
   }

--- a/merger-tracker/frontend/public/data/industries/462.json
+++ b/merger-tracker/frontend/public/data/industries/462.json
@@ -76,8 +76,8 @@
   "phase_duration": {
     "average_days": 22.0,
     "median_days": 22,
-    "average_business_days": 16.0,
-    "median_business_days": 16,
+    "average_business_days": 15.0,
+    "median_business_days": 15,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/4622.json
+++ b/merger-tracker/frontend/public/data/industries/4622.json
@@ -53,8 +53,8 @@
   "phase_duration": {
     "average_days": 22.0,
     "median_days": 22,
-    "average_business_days": 16.0,
-    "median_business_days": 16,
+    "average_business_days": 15.0,
+    "median_business_days": 15,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/50.json
+++ b/merger-tracker/frontend/public/data/industries/50.json
@@ -83,8 +83,8 @@
   "phase_duration": {
     "average_days": 26.0,
     "median_days": 28,
-    "average_business_days": 18.0,
-    "median_business_days": 20,
+    "average_business_days": 17.5,
+    "median_business_days": 19,
     "completed_count": 2
   }
 }

--- a/merger-tracker/frontend/public/data/industries/501.json
+++ b/merger-tracker/frontend/public/data/industries/501.json
@@ -82,8 +82,8 @@
   "phase_duration": {
     "average_days": 26.0,
     "median_days": 28,
-    "average_business_days": 18.0,
-    "median_business_days": 20,
+    "average_business_days": 17.5,
+    "median_business_days": 19,
     "completed_count": 2
   }
 }

--- a/merger-tracker/frontend/public/data/industries/5010.json
+++ b/merger-tracker/frontend/public/data/industries/5010.json
@@ -80,8 +80,8 @@
   "phase_duration": {
     "average_days": 26.0,
     "median_days": 28,
-    "average_business_days": 18.0,
-    "median_business_days": 20,
+    "average_business_days": 17.5,
+    "median_business_days": 19,
     "completed_count": 2
   }
 }

--- a/merger-tracker/frontend/public/data/industries/52.json
+++ b/merger-tracker/frontend/public/data/industries/52.json
@@ -143,7 +143,7 @@
   "phase_duration": {
     "average_days": 37.2,
     "median_days": 42,
-    "average_business_days": 25.2,
+    "average_business_days": 25.0,
     "median_business_days": 28,
     "completed_count": 5
   }

--- a/merger-tracker/frontend/public/data/industries/522.json
+++ b/merger-tracker/frontend/public/data/industries/522.json
@@ -55,7 +55,7 @@
   "phase_duration": {
     "average_days": 39.5,
     "median_days": 49,
-    "average_business_days": 27.5,
+    "average_business_days": 27.0,
     "median_business_days": 33,
     "completed_count": 2
   }

--- a/merger-tracker/frontend/public/data/industries/5220.json
+++ b/merger-tracker/frontend/public/data/industries/5220.json
@@ -53,7 +53,7 @@
   "phase_duration": {
     "average_days": 39.5,
     "median_days": 49,
-    "average_business_days": 27.5,
+    "average_business_days": 27.0,
     "median_business_days": 33,
     "completed_count": 2
   }

--- a/merger-tracker/frontend/public/data/industries/56.json
+++ b/merger-tracker/frontend/public/data/industries/56.json
@@ -74,7 +74,7 @@
   "phase_duration": {
     "average_days": 32.5,
     "median_days": 41,
-    "average_business_days": 21.5,
+    "average_business_days": 21.0,
     "median_business_days": 27,
     "completed_count": 2
   }

--- a/merger-tracker/frontend/public/data/industries/562.json
+++ b/merger-tracker/frontend/public/data/industries/562.json
@@ -70,7 +70,7 @@
   "phase_duration": {
     "average_days": 32.5,
     "median_days": 41,
-    "average_business_days": 21.5,
+    "average_business_days": 21.0,
     "median_business_days": 27,
     "completed_count": 2
   }

--- a/merger-tracker/frontend/public/data/industries/5621.json
+++ b/merger-tracker/frontend/public/data/industries/5621.json
@@ -53,7 +53,7 @@
   "phase_duration": {
     "average_days": 32.5,
     "median_days": 41,
-    "average_business_days": 21.5,
+    "average_business_days": 21.0,
     "median_business_days": 27,
     "completed_count": 2
   }

--- a/merger-tracker/frontend/public/data/industries/62.json
+++ b/merger-tracker/frontend/public/data/industries/62.json
@@ -572,7 +572,7 @@
   "phase_duration": {
     "average_days": 30.181818181818183,
     "median_days": 23,
-    "average_business_days": 20.545454545454547,
+    "average_business_days": 20.363636363636363,
     "median_business_days": 16,
     "completed_count": 11
   }

--- a/merger-tracker/frontend/public/data/industries/623.json
+++ b/merger-tracker/frontend/public/data/industries/623.json
@@ -73,8 +73,8 @@
   "phase_duration": {
     "average_days": 89.0,
     "median_days": 89,
-    "average_business_days": 59.0,
-    "median_business_days": 59,
+    "average_business_days": 58.0,
+    "median_business_days": 58,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/6230.json
+++ b/merger-tracker/frontend/public/data/industries/6230.json
@@ -71,8 +71,8 @@
   "phase_duration": {
     "average_days": 89.0,
     "median_days": 89,
-    "average_business_days": 59.0,
-    "median_business_days": 59,
+    "average_business_days": 58.0,
+    "median_business_days": 58,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/624.json
+++ b/merger-tracker/frontend/public/data/industries/624.json
@@ -505,7 +505,7 @@
   "phase_duration": {
     "average_days": 24.444444444444443,
     "median_days": 23,
-    "average_business_days": 16.77777777777778,
+    "average_business_days": 16.666666666666668,
     "median_business_days": 16,
     "completed_count": 9
   }

--- a/merger-tracker/frontend/public/data/industries/6240.json
+++ b/merger-tracker/frontend/public/data/industries/6240.json
@@ -503,7 +503,7 @@
   "phase_duration": {
     "average_days": 24.444444444444443,
     "median_days": 23,
-    "average_business_days": 16.77777777777778,
+    "average_business_days": 16.666666666666668,
     "median_business_days": 16,
     "completed_count": 9
   }

--- a/merger-tracker/frontend/public/data/industries/63.json
+++ b/merger-tracker/frontend/public/data/industries/63.json
@@ -161,8 +161,8 @@
   "phase_duration": {
     "average_days": 41.6,
     "median_days": 26,
-    "average_business_days": 27.8,
-    "median_business_days": 18,
+    "average_business_days": 27.2,
+    "median_business_days": 17,
     "completed_count": 5
   }
 }

--- a/merger-tracker/frontend/public/data/industries/631.json
+++ b/merger-tracker/frontend/public/data/industries/631.json
@@ -55,8 +55,8 @@
   "phase_duration": {
     "average_days": 24.5,
     "median_days": 26,
-    "average_business_days": 16.5,
-    "median_business_days": 17,
+    "average_business_days": 16.0,
+    "median_business_days": 16,
     "completed_count": 2
   }
 }

--- a/merger-tracker/frontend/public/data/industries/6310.json
+++ b/merger-tracker/frontend/public/data/industries/6310.json
@@ -53,8 +53,8 @@
   "phase_duration": {
     "average_days": 24.5,
     "median_days": 26,
-    "average_business_days": 16.5,
-    "median_business_days": 17,
+    "average_business_days": 16.0,
+    "median_business_days": 16,
     "completed_count": 2
   }
 }

--- a/merger-tracker/frontend/public/data/industries/632.json
+++ b/merger-tracker/frontend/public/data/industries/632.json
@@ -115,8 +115,8 @@
   "phase_duration": {
     "average_days": 41.6,
     "median_days": 26,
-    "average_business_days": 27.8,
-    "median_business_days": 18,
+    "average_business_days": 27.2,
+    "median_business_days": 17,
     "completed_count": 5
   }
 }

--- a/merger-tracker/frontend/public/data/industries/6322.json
+++ b/merger-tracker/frontend/public/data/industries/6322.json
@@ -98,8 +98,8 @@
   "phase_duration": {
     "average_days": 41.6,
     "median_days": 26,
-    "average_business_days": 27.8,
-    "median_business_days": 18,
+    "average_business_days": 27.2,
+    "median_business_days": 17,
     "completed_count": 5
   }
 }

--- a/merger-tracker/frontend/public/data/industries/64.json
+++ b/merger-tracker/frontend/public/data/industries/64.json
@@ -344,7 +344,7 @@
   "phase_duration": {
     "average_days": 25.11111111111111,
     "median_days": 24,
-    "average_business_days": 17.11111111111111,
+    "average_business_days": 17.0,
     "median_business_days": 16,
     "completed_count": 9
   }

--- a/merger-tracker/frontend/public/data/industries/641.json
+++ b/merger-tracker/frontend/public/data/industries/641.json
@@ -340,7 +340,7 @@
   "phase_duration": {
     "average_days": 25.11111111111111,
     "median_days": 24,
-    "average_business_days": 17.11111111111111,
+    "average_business_days": 17.0,
     "median_business_days": 16,
     "completed_count": 9
   }

--- a/merger-tracker/frontend/public/data/industries/6411.json
+++ b/merger-tracker/frontend/public/data/industries/6411.json
@@ -44,8 +44,8 @@
   "phase_duration": {
     "average_days": 28.0,
     "median_days": 28,
-    "average_business_days": 20.0,
-    "median_business_days": 20,
+    "average_business_days": 19.0,
+    "median_business_days": 19,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/6419.json
+++ b/merger-tracker/frontend/public/data/industries/6419.json
@@ -332,7 +332,7 @@
   "phase_duration": {
     "average_days": 25.11111111111111,
     "median_days": 24,
-    "average_business_days": 17.11111111111111,
+    "average_business_days": 17.0,
     "median_business_days": 16,
     "completed_count": 9
   }

--- a/merger-tracker/frontend/public/data/industries/66.json
+++ b/merger-tracker/frontend/public/data/industries/66.json
@@ -104,7 +104,7 @@
   "phase_duration": {
     "average_days": 31.75,
     "median_days": 40,
-    "average_business_days": 21.25,
+    "average_business_days": 21.0,
     "median_business_days": 27,
     "completed_count": 4
   }

--- a/merger-tracker/frontend/public/data/industries/661.json
+++ b/merger-tracker/frontend/public/data/industries/661.json
@@ -52,8 +52,8 @@
   "phase_duration": {
     "average_days": 24.0,
     "median_days": 24,
-    "average_business_days": 16.0,
-    "median_business_days": 16,
+    "average_business_days": 15.0,
+    "median_business_days": 15,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/6619.json
+++ b/merger-tracker/frontend/public/data/industries/6619.json
@@ -44,8 +44,8 @@
   "phase_duration": {
     "average_days": 24.0,
     "median_days": 24,
-    "average_business_days": 16.0,
-    "median_business_days": 16,
+    "average_business_days": 15.0,
+    "median_business_days": 15,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/67.json
+++ b/merger-tracker/frontend/public/data/industries/67.json
@@ -263,7 +263,7 @@
   "phase_duration": {
     "average_days": 32.285714285714285,
     "median_days": 29,
-    "average_business_days": 20.428571428571427,
+    "average_business_days": 20.285714285714285,
     "median_business_days": 19,
     "completed_count": 7
   }

--- a/merger-tracker/frontend/public/data/industries/671.json
+++ b/merger-tracker/frontend/public/data/industries/671.json
@@ -241,8 +241,8 @@
   "phase_duration": {
     "average_days": 34.166666666666664,
     "median_days": 30,
-    "average_business_days": 21.333333333333332,
-    "median_business_days": 22,
+    "average_business_days": 21.166666666666668,
+    "median_business_days": 21,
     "completed_count": 6
   }
 }

--- a/merger-tracker/frontend/public/data/industries/6712.json
+++ b/merger-tracker/frontend/public/data/industries/6712.json
@@ -215,8 +215,8 @@
   "phase_duration": {
     "average_days": 34.166666666666664,
     "median_days": 30,
-    "average_business_days": 21.333333333333332,
-    "median_business_days": 22,
+    "average_business_days": 21.166666666666668,
+    "median_business_days": 21,
     "completed_count": 6
   }
 }

--- a/merger-tracker/frontend/public/data/industries/69.json
+++ b/merger-tracker/frontend/public/data/industries/69.json
@@ -596,7 +596,7 @@
   "phase_duration": {
     "average_days": 35.73684210526316,
     "median_days": 28,
-    "average_business_days": 23.31578947368421,
+    "average_business_days": 23.0,
     "median_business_days": 18,
     "completed_count": 19
   }

--- a/merger-tracker/frontend/public/data/industries/691.json
+++ b/merger-tracker/frontend/public/data/industries/691.json
@@ -145,7 +145,7 @@
   "phase_duration": {
     "average_days": 25.375,
     "median_days": 25,
-    "average_business_days": 16.875,
+    "average_business_days": 16.375,
     "median_business_days": 16,
     "completed_count": 8
   }

--- a/merger-tracker/frontend/public/data/industries/6910.json
+++ b/merger-tracker/frontend/public/data/industries/6910.json
@@ -143,7 +143,7 @@
   "phase_duration": {
     "average_days": 25.375,
     "median_days": 25,
-    "average_business_days": 16.875,
+    "average_business_days": 16.375,
     "median_business_days": 16,
     "completed_count": 8
   }

--- a/merger-tracker/frontend/public/data/industries/692.json
+++ b/merger-tracker/frontend/public/data/industries/692.json
@@ -232,7 +232,7 @@
   "phase_duration": {
     "average_days": 43.8,
     "median_days": 28,
-    "average_business_days": 29.8,
+    "average_business_days": 29.6,
     "median_business_days": 18,
     "completed_count": 5
   }

--- a/merger-tracker/frontend/public/data/industries/6925.json
+++ b/merger-tracker/frontend/public/data/industries/6925.json
@@ -107,8 +107,8 @@
   "phase_duration": {
     "average_days": 51.0,
     "median_days": 77,
-    "average_business_days": 34.5,
-    "median_business_days": 53,
+    "average_business_days": 34.0,
+    "median_business_days": 52,
     "completed_count": 2
   }
 }

--- a/merger-tracker/frontend/public/data/industries/694.json
+++ b/merger-tracker/frontend/public/data/industries/694.json
@@ -100,7 +100,7 @@
   "phase_duration": {
     "average_days": 39.25,
     "median_days": 41,
-    "average_business_days": 26.25,
+    "average_business_days": 26.0,
     "median_business_days": 27,
     "completed_count": 4
   }

--- a/merger-tracker/frontend/public/data/industries/6940.json
+++ b/merger-tracker/frontend/public/data/industries/6940.json
@@ -98,7 +98,7 @@
   "phase_duration": {
     "average_days": 39.25,
     "median_days": 41,
-    "average_business_days": 26.25,
+    "average_business_days": 26.0,
     "median_business_days": 27,
     "completed_count": 4
   }

--- a/merger-tracker/frontend/public/data/industries/70.json
+++ b/merger-tracker/frontend/public/data/industries/70.json
@@ -419,8 +419,8 @@
   "phase_duration": {
     "average_days": 31.285714285714285,
     "median_days": 28,
-    "average_business_days": 20.071428571428573,
-    "median_business_days": 19,
+    "average_business_days": 20.0,
+    "median_business_days": 18,
     "completed_count": 14
   }
 }

--- a/merger-tracker/frontend/public/data/industries/700.json
+++ b/merger-tracker/frontend/public/data/industries/700.json
@@ -424,8 +424,8 @@
   "phase_duration": {
     "average_days": 31.285714285714285,
     "median_days": 28,
-    "average_business_days": 20.071428571428573,
-    "median_business_days": 19,
+    "average_business_days": 20.0,
+    "median_business_days": 18,
     "completed_count": 14
   }
 }

--- a/merger-tracker/frontend/public/data/industries/7000.json
+++ b/merger-tracker/frontend/public/data/industries/7000.json
@@ -422,8 +422,8 @@
   "phase_duration": {
     "average_days": 31.285714285714285,
     "median_days": 28,
-    "average_business_days": 20.071428571428573,
-    "median_business_days": 19,
+    "average_business_days": 20.0,
+    "median_business_days": 18,
     "completed_count": 14
   }
 }

--- a/merger-tracker/frontend/public/data/industries/84.json
+++ b/merger-tracker/frontend/public/data/industries/84.json
@@ -86,8 +86,8 @@
   "phase_duration": {
     "average_days": 27.0,
     "median_days": 32,
-    "average_business_days": 17.5,
-    "median_business_days": 20,
+    "average_business_days": 17.0,
+    "median_business_days": 19,
     "completed_count": 2
   }
 }

--- a/merger-tracker/frontend/public/data/industries/840.json
+++ b/merger-tracker/frontend/public/data/industries/840.json
@@ -97,8 +97,8 @@
   "phase_duration": {
     "average_days": 27.0,
     "median_days": 32,
-    "average_business_days": 17.5,
-    "median_business_days": 20,
+    "average_business_days": 17.0,
+    "median_business_days": 19,
     "completed_count": 2
   }
 }

--- a/merger-tracker/frontend/public/data/industries/8401.json
+++ b/merger-tracker/frontend/public/data/industries/8401.json
@@ -89,8 +89,8 @@
   "phase_duration": {
     "average_days": 27.0,
     "median_days": 32,
-    "average_business_days": 17.5,
-    "median_business_days": 20,
+    "average_business_days": 17.0,
+    "median_business_days": 19,
     "completed_count": 2
   }
 }

--- a/merger-tracker/frontend/public/data/industries/86.json
+++ b/merger-tracker/frontend/public/data/industries/86.json
@@ -104,7 +104,7 @@
   "phase_duration": {
     "average_days": 25.2,
     "median_days": 24,
-    "average_business_days": 16.2,
+    "average_business_days": 15.8,
     "median_business_days": 15,
     "completed_count": 5
   }

--- a/merger-tracker/frontend/public/data/industries/860.json
+++ b/merger-tracker/frontend/public/data/industries/860.json
@@ -115,7 +115,7 @@
   "phase_duration": {
     "average_days": 25.2,
     "median_days": 24,
-    "average_business_days": 16.2,
+    "average_business_days": 15.8,
     "median_business_days": 15,
     "completed_count": 5
   }

--- a/merger-tracker/frontend/public/data/industries/8601.json
+++ b/merger-tracker/frontend/public/data/industries/8601.json
@@ -107,7 +107,7 @@
   "phase_duration": {
     "average_days": 25.2,
     "median_days": 24,
-    "average_business_days": 16.2,
+    "average_business_days": 15.8,
     "median_business_days": 15,
     "completed_count": 5
   }

--- a/merger-tracker/frontend/public/data/industries/8609.json
+++ b/merger-tracker/frontend/public/data/industries/8609.json
@@ -53,8 +53,8 @@
   "phase_duration": {
     "average_days": 24.0,
     "median_days": 24,
-    "average_business_days": 16.0,
-    "median_business_days": 16,
+    "average_business_days": 15.0,
+    "median_business_days": 15,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/91.json
+++ b/merger-tracker/frontend/public/data/industries/91.json
@@ -71,8 +71,8 @@
   "phase_duration": {
     "average_days": 28.0,
     "median_days": 28,
-    "average_business_days": 20.0,
-    "median_business_days": 20,
+    "average_business_days": 19.0,
+    "median_business_days": 19,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/913.json
+++ b/merger-tracker/frontend/public/data/industries/913.json
@@ -61,8 +61,8 @@
   "phase_duration": {
     "average_days": 28.0,
     "median_days": 28,
-    "average_business_days": 20.0,
-    "median_business_days": 20,
+    "average_business_days": 19.0,
+    "median_business_days": 19,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/9139.json
+++ b/merger-tracker/frontend/public/data/industries/9139.json
@@ -53,8 +53,8 @@
   "phase_duration": {
     "average_days": 28.0,
     "median_days": 28,
-    "average_business_days": 20.0,
-    "median_business_days": 20,
+    "average_business_days": 19.0,
+    "median_business_days": 19,
     "completed_count": 1
   }
 }

--- a/merger-tracker/frontend/public/data/industries/94.json
+++ b/merger-tracker/frontend/public/data/industries/94.json
@@ -152,8 +152,8 @@
   "phase_duration": {
     "average_days": 44.333333333333336,
     "median_days": 32,
-    "average_business_days": 30.0,
-    "median_business_days": 22,
+    "average_business_days": 29.5,
+    "median_business_days": 21,
     "completed_count": 6
   }
 }

--- a/merger-tracker/frontend/public/data/industries/941.json
+++ b/merger-tracker/frontend/public/data/industries/941.json
@@ -112,8 +112,8 @@
   "phase_duration": {
     "average_days": 48.333333333333336,
     "median_days": 32,
-    "average_business_days": 32.0,
-    "median_business_days": 22,
+    "average_business_days": 31.333333333333332,
+    "median_business_days": 21,
     "completed_count": 3
   }
 }

--- a/merger-tracker/frontend/public/data/industries/9412.json
+++ b/merger-tracker/frontend/public/data/industries/9412.json
@@ -53,8 +53,8 @@
   "phase_duration": {
     "average_days": 28.0,
     "median_days": 32,
-    "average_business_days": 18.5,
-    "median_business_days": 22,
+    "average_business_days": 18.0,
+    "median_business_days": 21,
     "completed_count": 2
   }
 }

--- a/merger-tracker/frontend/public/data/industries/9419.json
+++ b/merger-tracker/frontend/public/data/industries/9419.json
@@ -89,8 +89,8 @@
   "phase_duration": {
     "average_days": 56.5,
     "median_days": 89,
-    "average_business_days": 37.0,
-    "median_business_days": 59,
+    "average_business_days": 36.5,
+    "median_business_days": 58,
     "completed_count": 2
   }
 }

--- a/merger-tracker/frontend/public/data/industries/942.json
+++ b/merger-tracker/frontend/public/data/industries/942.json
@@ -94,7 +94,7 @@
   "phase_duration": {
     "average_days": 40.333333333333336,
     "median_days": 22,
-    "average_business_days": 28.0,
+    "average_business_days": 27.666666666666668,
     "median_business_days": 16,
     "completed_count": 3
   }

--- a/merger-tracker/frontend/public/data/industries/9422.json
+++ b/merger-tracker/frontend/public/data/industries/9422.json
@@ -53,8 +53,8 @@
   "phase_duration": {
     "average_days": 49.5,
     "median_days": 77,
-    "average_business_days": 34.5,
-    "median_business_days": 53,
+    "average_business_days": 34.0,
+    "median_business_days": 52,
     "completed_count": 2
   }
 }

--- a/merger-tracker/frontend/public/data/industries/A.json
+++ b/merger-tracker/frontend/public/data/industries/A.json
@@ -163,7 +163,7 @@
   "phase_duration": {
     "average_days": 26.0,
     "median_days": 27,
-    "average_business_days": 17.75,
+    "average_business_days": 17.5,
     "median_business_days": 18,
     "completed_count": 4
   }

--- a/merger-tracker/frontend/public/data/industries/C.json
+++ b/merger-tracker/frontend/public/data/industries/C.json
@@ -1006,8 +1006,8 @@
   "phase_duration": {
     "average_days": 29.47222222222222,
     "median_days": 26,
-    "average_business_days": 19.333333333333332,
-    "median_business_days": 18,
+    "average_business_days": 19.13888888888889,
+    "median_business_days": 17,
     "completed_count": 36
   }
 }

--- a/merger-tracker/frontend/public/data/industries/D.json
+++ b/merger-tracker/frontend/public/data/industries/D.json
@@ -220,7 +220,7 @@
   "phase_duration": {
     "average_days": 26.333333333333332,
     "median_days": 28,
-    "average_business_days": 18.666666666666668,
+    "average_business_days": 18.333333333333332,
     "median_business_days": 20,
     "completed_count": 3
   }

--- a/merger-tracker/frontend/public/data/industries/E.json
+++ b/merger-tracker/frontend/public/data/industries/E.json
@@ -295,7 +295,7 @@
   "phase_duration": {
     "average_days": 28.5,
     "median_days": 23,
-    "average_business_days": 19.625,
+    "average_business_days": 19.5,
     "median_business_days": 16,
     "completed_count": 8
   }

--- a/merger-tracker/frontend/public/data/industries/F.json
+++ b/merger-tracker/frontend/public/data/industries/F.json
@@ -403,7 +403,7 @@
   "phase_duration": {
     "average_days": 36.05,
     "median_days": 29,
-    "average_business_days": 22.4,
+    "average_business_days": 22.15,
     "median_business_days": 18,
     "completed_count": 20
   }

--- a/merger-tracker/frontend/public/data/industries/G.json
+++ b/merger-tracker/frontend/public/data/industries/G.json
@@ -469,7 +469,7 @@
   "phase_duration": {
     "average_days": 42.833333333333336,
     "median_days": 29,
-    "average_business_days": 26.416666666666668,
+    "average_business_days": 26.166666666666668,
     "median_business_days": 19,
     "completed_count": 12
   }

--- a/merger-tracker/frontend/public/data/industries/H.json
+++ b/merger-tracker/frontend/public/data/industries/H.json
@@ -298,7 +298,7 @@
   "phase_duration": {
     "average_days": 24.6,
     "median_days": 24,
-    "average_business_days": 16.8,
+    "average_business_days": 16.6,
     "median_business_days": 16,
     "completed_count": 5
   }

--- a/merger-tracker/frontend/public/data/industries/I.json
+++ b/merger-tracker/frontend/public/data/industries/I.json
@@ -316,8 +316,8 @@
   "phase_duration": {
     "average_days": 32.888888888888886,
     "median_days": 30,
-    "average_business_days": 22.444444444444443,
-    "median_business_days": 22,
+    "average_business_days": 22.11111111111111,
+    "median_business_days": 21,
     "completed_count": 9
   }
 }

--- a/merger-tracker/frontend/public/data/industries/J.json
+++ b/merger-tracker/frontend/public/data/industries/J.json
@@ -526,7 +526,7 @@
   "phase_duration": {
     "average_days": 31.27777777777778,
     "median_days": 28,
-    "average_business_days": 19.833333333333332,
+    "average_business_days": 19.77777777777778,
     "median_business_days": 18,
     "completed_count": 18
   }

--- a/merger-tracker/frontend/public/data/industries/K.json
+++ b/merger-tracker/frontend/public/data/industries/K.json
@@ -862,7 +862,7 @@
   "phase_duration": {
     "average_days": 28.666666666666668,
     "median_days": 24,
-    "average_business_days": 19.523809523809526,
+    "average_business_days": 19.285714285714285,
     "median_business_days": 16,
     "completed_count": 21
   }

--- a/merger-tracker/frontend/public/data/industries/L.json
+++ b/merger-tracker/frontend/public/data/industries/L.json
@@ -307,7 +307,7 @@
   "phase_duration": {
     "average_days": 32.09090909090909,
     "median_days": 29,
-    "average_business_days": 20.727272727272727,
+    "average_business_days": 20.545454545454547,
     "median_business_days": 19,
     "completed_count": 11
   }

--- a/merger-tracker/frontend/public/data/industries/M.json
+++ b/merger-tracker/frontend/public/data/industries/M.json
@@ -865,7 +865,7 @@
   "phase_duration": {
     "average_days": 33.3,
     "median_days": 27,
-    "average_business_days": 21.5,
+    "average_business_days": 21.266666666666666,
     "median_business_days": 18,
     "completed_count": 30
   }

--- a/merger-tracker/frontend/public/data/industries/Q.json
+++ b/merger-tracker/frontend/public/data/industries/Q.json
@@ -328,7 +328,7 @@
   "phase_duration": {
     "average_days": 24.7,
     "median_days": 25,
-    "average_business_days": 16.0,
+    "average_business_days": 15.8,
     "median_business_days": 15,
     "completed_count": 10
   }

--- a/merger-tracker/frontend/public/data/industries/R.json
+++ b/merger-tracker/frontend/public/data/industries/R.json
@@ -85,8 +85,8 @@
   "phase_duration": {
     "average_days": 26.0,
     "median_days": 28,
-    "average_business_days": 18.0,
-    "median_business_days": 20,
+    "average_business_days": 17.5,
+    "median_business_days": 19,
     "completed_count": 2
   }
 }

--- a/merger-tracker/frontend/public/data/industries/S.json
+++ b/merger-tracker/frontend/public/data/industries/S.json
@@ -232,8 +232,8 @@
   "phase_duration": {
     "average_days": 44.333333333333336,
     "median_days": 32,
-    "average_business_days": 30.0,
-    "median_business_days": 22,
+    "average_business_days": 29.5,
+    "median_business_days": 21,
     "completed_count": 6
   }
 }

--- a/merger-tracker/frontend/public/data/mergers/MN-30008.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-30008.json
@@ -6,7 +6,7 @@
   "effective_notification_datetime": "2026-05-19T12:00:00Z",
   "original_notification_datetime": "2026-05-19T12:00:00Z",
   "stage": "Phase 1 - initial assessment",
-  "end_of_determination_period": "2026-07-01T12:00:00Z",
+  "end_of_determination_period": "2026-07-02T12:00:00Z",
   "determination_publication_date": "2026-06-15T12:00:00Z",
   "accc_determination": "Approved",
   "page_modified_datetime": "2026-06-15T09:48:36+10:00",

--- a/merger-tracker/frontend/public/data/mergers/MN-50030.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-50030.json
@@ -6,7 +6,7 @@
   "effective_notification_datetime": "2026-07-01T12:00:00Z",
   "original_notification_datetime": "2026-07-01T12:00:00Z",
   "stage": "Phase 1 - initial assessment",
-  "end_of_determination_period": "2026-08-11T12:00:00Z",
+  "end_of_determination_period": "2026-08-12T12:00:00Z",
   "page_modified_datetime": "2026-07-01T16:35:28+10:00",
   "consultation_response_due_date": "2026-07-08T12:00:00Z",
   "acquirers": [

--- a/merger-tracker/frontend/public/data/mergers/list-page-6.json
+++ b/merger-tracker/frontend/public/data/mergers/list-page-6.json
@@ -2349,7 +2349,7 @@
       "is_waiver": false,
       "effective_notification_datetime": "2026-05-19T12:00:00Z",
       "determination_publication_date": "2026-06-15T12:00:00Z",
-      "end_of_determination_period": "2026-07-01T12:00:00Z",
+      "end_of_determination_period": "2026-07-02T12:00:00Z",
       "stage": "Phase 1 - initial assessment",
       "acquirers": [
         {

--- a/merger-tracker/frontend/public/data/mergers/list-page-9.json
+++ b/merger-tracker/frontend/public/data/mergers/list-page-9.json
@@ -794,7 +794,7 @@
       "is_waiver": false,
       "effective_notification_datetime": "2026-07-01T12:00:00Z",
       "determination_publication_date": null,
-      "end_of_determination_period": "2026-08-11T12:00:00Z",
+      "end_of_determination_period": "2026-08-12T12:00:00Z",
       "stage": "Phase 1 - initial assessment",
       "acquirers": [
         {

--- a/merger-tracker/frontend/public/data/stats.json
+++ b/merger-tracker/frontend/public/data/stats.json
@@ -17,16 +17,16 @@
   "phase_duration": {
     "average_days": 29.9921875,
     "median_days": 26,
-    "average_business_days": 19.75,
+    "average_business_days": 19.546875,
     "median_business_days": 17,
     "percentiles": {
       "day15": {
-        "count": 26,
-        "percentage": 20.3
+        "count": 33,
+        "percentage": 25.8
       },
       "day20": {
-        "count": 96,
-        "percentage": 75.0
+        "count": 99,
+        "percentage": 77.3
       },
       "day30": {
         "count": 122,

--- a/merger-tracker/frontend/public/data/upcoming-events.json
+++ b/merger-tracker/frontend/public/data/upcoming-events.json
@@ -464,16 +464,6 @@
       "type": "determination_due",
       "event_type_display": "Determination due",
       "date": "2026-08-11T12:00:00Z",
-      "merger_id": "MN-50030",
-      "merger_name": "Symal Group - Shamrock Engineering and Equipment",
-      "status": "Under assessment",
-      "stage": "Phase 1 - initial assessment",
-      "effective_notification_datetime": "2026-07-01T12:00:00Z"
-    },
-    {
-      "type": "determination_due",
-      "event_type_display": "Determination due",
-      "date": "2026-08-11T12:00:00Z",
       "merger_id": "MN-75027",
       "merger_name": "SLB \u2013 S&P Global\u2019s Geoscience Software Portfolio",
       "status": "Under assessment",
@@ -516,6 +506,16 @@
       "date": "2026-08-12T12:00:00Z",
       "merger_id": "MN-50011",
       "merger_name": "Journey Beyond - SeaLink Rottnest",
+      "status": "Under assessment",
+      "stage": "Phase 1 - initial assessment",
+      "effective_notification_datetime": "2026-07-01T12:00:00Z"
+    },
+    {
+      "type": "determination_due",
+      "event_type_display": "Determination due",
+      "date": "2026-08-12T12:00:00Z",
+      "merger_id": "MN-50030",
+      "merger_name": "Symal Group - Shamrock Engineering and Equipment",
       "status": "Under assessment",
       "stage": "Phase 1 - initial assessment",
       "effective_notification_datetime": "2026-07-01T12:00:00Z"

--- a/merger-tracker/frontend/src/data/act-public-holidays.json
+++ b/merger-tracker/frontend/src/data/act-public-holidays.json
@@ -30,6 +30,7 @@
         {"date": "2026-04-05", "name": "Easter Sunday"},
         {"date": "2026-04-06", "name": "Easter Monday"},
         {"date": "2026-04-25", "name": "ANZAC Day"},
+        {"date": "2026-04-27", "name": "ANZAC Day (Observed Monday)"},
         {"date": "2026-06-01", "name": "Reconciliation Day"},
         {"date": "2026-06-08", "name": "King's Birthday"},
         {"date": "2026-10-05", "name": "Labour Day"},

--- a/merger-tracker/frontend/src/utils/__tests__/dates.test.js
+++ b/merger-tracker/frontend/src/utils/__tests__/dates.test.js
@@ -40,6 +40,10 @@ describe('isBusinessDay', () => {
     expect(isBusinessDay(d('2025-03-10'))).toBe(false);
   });
 
+  it('returns false for ANZAC Day observed Monday 2026 (27 April)', () => {
+    expect(isBusinessDay(d('2026-04-27'))).toBe(false);
+  });
+
   describe('Christmas / New Year period (23 Dec – 10 Jan)', () => {
     it('returns false on 23 December', () => {
       expect(isBusinessDay(d('2025-12-23'))).toBe(false);

--- a/scripts/extract_mergers.py
+++ b/scripts/extract_mergers.py
@@ -772,7 +772,10 @@ def _calculate_missing_end_of_determination_period(merger_data, merger_id):
     start_dt = parse_iso_datetime(merger_data.get('effective_notification_datetime'))
     if start_dt:
         from static_data.business_days import add_business_days
-        end_dt = add_business_days(start_dt, 30)
+        # BD 1 of the review period is the day after notification (day 0), but
+        # add_business_days counts its start date as day 1 - so shift the start
+        # forward one day before adding 30 business days.
+        end_dt = add_business_days(start_dt + timedelta(days=1), 30)
         merger_data['end_of_determination_period'] = end_dt.strftime('%Y-%m-%dT%H:%M:%SZ')
 
 

--- a/scripts/tests/test_pipeline.py
+++ b/scripts/tests/test_pipeline.py
@@ -32,7 +32,9 @@ from extract_mergers import (
     _add_synthetic_events,
     find_pending_phase2_notice_events,
     extract_phase2_notice_data,
+    _calculate_missing_end_of_determination_period,
 )
+from static_data.business_days import calculate_business_days
 import extract_mergers
 from bs4 import BeautifulSoup
 
@@ -2447,3 +2449,35 @@ class TestExtractAnzsicCodes:
     def test_no_anzsic_field(self):
         html = '<div class="field field--name-field-other">nothing here</div>'
         assert _extract_anzsic_codes(BeautifulSoup(html, 'html.parser')) == []
+
+
+# ---------------------------------------------------------------------------
+# extract_mergers: _calculate_missing_end_of_determination_period
+# ---------------------------------------------------------------------------
+
+class TestCalculateMissingEndOfDeterminationPeriod:
+    """BD 1 of the review period is the day after notification, but
+    add_business_days counts its start date as day 1 - the fallback must
+    compensate for that mismatch (issue #576)."""
+
+    def test_computed_end_is_exactly_30_business_days_after_notification(self):
+        merger_data = {
+            'effective_notification_datetime': '2026-05-19T12:00:00Z',
+        }
+        _calculate_missing_end_of_determination_period(merger_data, 'MN-30008')
+        assert calculate_business_days(
+            '2026-05-19T12:00:00Z', merger_data['end_of_determination_period']
+        ) == 30
+
+    def test_skips_waiver_mergers(self):
+        merger_data = {'effective_notification_datetime': '2026-05-19T12:00:00Z'}
+        _calculate_missing_end_of_determination_period(merger_data, 'WA-00001')
+        assert 'end_of_determination_period' not in merger_data
+
+    def test_does_not_overwrite_existing_value(self):
+        merger_data = {
+            'effective_notification_datetime': '2026-05-19T12:00:00Z',
+            'end_of_determination_period': '2026-07-01T12:00:00Z',
+        }
+        _calculate_missing_end_of_determination_period(merger_data, 'MN-30008')
+        assert merger_data['end_of_determination_period'] == '2026-07-01T12:00:00Z'


### PR DESCRIPTION
Closes #576.

## Summary
- **Spec 1**: added the missing `2026-04-27` ANZAC Day observed-Monday substitute to `act-public-holidays.json` — the 2026 calendar was missing this entry, causing 36 mergers' 30-BD windows to measure 31.
- **Spec 2**: `_calculate_missing_end_of_determination_period` (`extract_mergers.py`) used `add_business_days(start, 30)`, which counts the start date as day 1. Per the repo's BD-1-is-the-day-after convention, this landed the fallback deadline one business day early. Fixed by shifting the start date forward one day before adding 30 business days (`add_business_days` itself is untouched, per the spec). Hand-corrected the two affected stored values in `data/processed/mergers.json` (`MN-30008`: 2026-07-01 → 2026-07-02; `MN-50030`: 2026-08-11 → 2026-08-12) since the extractor only computes this field when absent.
- Regenerated all static data (`stats.json`, `analysis.json`, industry files, paginated lists, per-merger files, etc.) so published durations/countdowns reflect the corrected calendar and deadlines.

## Test plan
- [x] `python -m pytest scripts/tests/` — 615 passed, including new unit tests for `_calculate_missing_end_of_determination_period` (verifies the fallback lands exactly on BD 30, respects the waiver skip, and doesn't overwrite an existing value).
- [x] `npx vitest run` (frontend) — 120 passed, including a new test asserting `isBusinessDay(new Date('2026-04-27'))` is `false`.
- [x] Verified no non-waiver merger's stored `end_of_determination_period` now measures other than 30 BDs from notification (spot-checked MN-01090: notified 2026-03-12, end 2026-04-28 → 30 BD, per the issue's acceptance criteria).


---
_Generated by [Claude Code](https://claude.ai/code/session_01SwcTJnDeePQbBNj4GfgNXM)_