### PR TITLE
Replace deprecated datetime.utcnow() with datetime.now(timezone.utc)

### DIFF
--- a/scripts/detect_duplicates.py
+++ b/scripts/detect_duplicates.py
@@ -29,7 +29,7 @@ import argparse
 import json
 import re
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from difflib import SequenceMatcher
 from pathlib import Path
 
@@ -648,7 +648,7 @@ def main() -> None:
         print(f"JSON report written to {args.output}")
 
     if args.issues_json:
-        today = datetime.utcnow().strftime("%Y-%m-%d")
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
         issues_data = build_issues_data(report, args.input, args.branch, today)
         args.issues_json.parent.mkdir(parents=True, exist_ok=True)
         with args.issues_json.open("w") as fh:
@@ -663,7 +663,7 @@ def main() -> None:
                 fh.write("\n")
             print(f"Applied {len(changes)} deletion(s) to {args.input}", file=sys.stderr)
         if args.pr_markdown:
-            today = datetime.utcnow().strftime("%Y-%m-%d")
+            today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
             pr_body = build_pr_body(changes, report, today)
             args.pr_markdown.parent.mkdir(parents=True, exist_ok=True)
             with args.pr_markdown.open("w") as fh:

--- a/scripts/extract_mergers.py
+++ b/scripts/extract_mergers.py
@@ -8,7 +8,7 @@ from urllib.parse import urljoin, urlparse, unquote
 import unicodedata
 import requests
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from markdownify import markdownify as md
 from parse_determination import parse_determination_pdf
 from parse_phase2_notice import parse_phase2_notice_pdf
@@ -1035,7 +1035,7 @@ def auto_fix_missing_event_dates(all_mergers_data, frozen_events_mergers):
 
     Returns a set of newly frozen merger IDs (empty set if nothing was fixed).
     """
-    today = datetime.utcnow()
+    today = datetime.now(timezone.utc)
     today_iso = today.strftime('%Y-%m-%dT12:00:00Z')
     day = str(today.day)
     today_display = f"{day} {today.strftime('%b %Y')}"  # e.g. "6 May 2026"


### PR DESCRIPTION
Fixes spec 7 from the July 2026 repo review (issue #580). Covers all
utcnow() call sites in scripts/: extract_mergers.py and
detect_duplicates.py. strftime output formats are unaffected since none
depend on tzinfo.

Spec 6 (duplicate dict key in upcoming_events.py) does not apply — git
history shows the file has only ever had a single
"effective_notification_datetime" key per event dict, so there is
nothing to remove.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AV54WjfVkpv74q9J3xmezP