### PR TITLE
Use statistics.median in stats.py to match analysis.json (#577)

### DIFF
--- a/merger-tracker/frontend/public/data/stats.json
+++ b/merger-tracker/frontend/public/data/stats.json
@@ -16,9 +16,9 @@
   },
   "phase_duration": {
     "average_days": 29.9921875,
-    "median_days": 26,
+    "median_days": 26.0,
     "average_business_days": 19.75,
-    "median_business_days": 17,
+    "median_business_days": 17.0,
     "percentiles": {
       "day15": {
         "count": 26,

--- a/merger-tracker/frontend/public/data/stats.json
+++ b/merger-tracker/frontend/public/data/stats.json
@@ -16,9 +16,9 @@
   },
   "phase_duration": {
     "average_days": 29.9921875,
-    "median_days": 26,
+    "median_days": 26.0,
     "average_business_days": 19.546875,
-    "median_business_days": 17,
+    "median_business_days": 17.0,
     "percentiles": {
       "day15": {
         "count": 33,

--- a/merger-tracker/frontend/src/pages/Dashboard.jsx
+++ b/merger-tracker/frontend/src/pages/Dashboard.jsx
@@ -18,6 +18,7 @@ import { API_ENDPOINTS } from '../config';
 import { getDaysRemaining, isDatePast } from '../utils/dates';
 import { useFetchData } from '../hooks/useFetchData';
 import { markItemsAsSeen } from '../utils/lastVisit';
+import { formatMedian } from '../utils/formatMedian';
 
 ChartJS.register(
   Title,
@@ -156,12 +157,12 @@ function Dashboard() {
           title="Median phase 1 duration"
           value={
             stats.phase_duration.median_business_days
-              ? `${stats.phase_duration.median_business_days} business days`
+              ? `${formatMedian(stats.phase_duration.median_business_days)} business days`
               : 'N/A'
           }
           subtitle={
             stats.phase_duration.median_days
-              ? `${stats.phase_duration.median_days} calendar days`
+              ? `${formatMedian(stats.phase_duration.median_days)} calendar days`
               : null
           }
           icon={<FaChartLine />}

--- a/merger-tracker/frontend/src/utils/__tests__/formatMedian.test.js
+++ b/merger-tracker/frontend/src/utils/__tests__/formatMedian.test.js
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { formatMedian } from '../formatMedian';
+
+describe('formatMedian', () => {
+  it('shows whole numbers without a trailing .0', () => {
+    expect(formatMedian(26)).toBe(26);
+    expect(formatMedian(26.0)).toBe(26);
+  });
+
+  it('keeps a single decimal place for .5 medians', () => {
+    expect(formatMedian(26.5)).toBe('26.5');
+  });
+});

--- a/merger-tracker/frontend/src/utils/formatMedian.js
+++ b/merger-tracker/frontend/src/utils/formatMedian.js
@@ -1,0 +1,11 @@
+/**
+ * Format a median duration value for display.
+ *
+ * `statistics.median` (used by both stats.json and analysis.json generators)
+ * averages the two middle values for an even-length sample, so a median can
+ * come back as a whole number or end in `.5`. Trim the trailing `.0` but keep
+ * `.5` so we never show a value like "26.0 business days".
+ */
+export function formatMedian(value) {
+  return Number.isInteger(value) ? value : value.toFixed(1);
+}

--- a/scripts/static_data/outputs/stats.py
+++ b/scripts/static_data/outputs/stats.py
@@ -1,6 +1,7 @@
 """Aggregated statistics — ``stats.json``."""
 
 from collections import defaultdict
+from statistics import median
 
 from constants import merger_status
 
@@ -44,10 +45,10 @@ def generate(mergers: list) -> dict:
     durations, business_durations = collect_phase_1_durations(notification_mergers)
 
     avg_duration = sum(durations) / len(durations) if durations else None
-    median_duration = sorted(durations)[len(durations) // 2] if durations else None
+    median_duration = round(median(durations), 1) if durations else None
 
     avg_business = sum(business_durations) / len(business_durations) if business_durations else None
-    median_business = sorted(business_durations)[len(business_durations) // 2] if business_durations else None
+    median_business = round(median(business_durations), 1) if business_durations else None
 
     # Pre-compute percentile statistics for business days
     total_completed = len(business_durations)

--- a/scripts/tests/test_static_data_outputs.py
+++ b/scripts/tests/test_static_data_outputs.py
@@ -219,6 +219,57 @@ class TestStatsGenerate:
         assert phase_2['determination_date'] == '2026-04-16T12:00:00Z'
 
 
+class TestStatsMedianMatchesAnalysis:
+    """stats.py and analysis.py must agree on 'median Phase 1 duration'.
+
+    Regression test for the two modules previously disagreeing on
+    even-length duration lists: stats.py took the upper-middle element
+    while analysis.py used statistics.median (average of the two middle
+    values).
+    """
+
+    def test_even_length_duration_list_medians_agree(self):
+        mergers = [
+            {
+                'merger_id': f'MN-800{i}',
+                'merger_name': f'Merger {i}',
+                'status': 'Determined',
+                'accc_determination': 'Approved',
+                'stage': 'Phase 1 - preliminary assessment',
+                'effective_notification_datetime': notified,
+                'determination_publication_date': determined,
+                'end_of_determination_period': determined,
+                'page_modified_datetime': determined,
+                'anzsic_codes': [],
+                'acquirers': [f'Acquirer {i}'],
+                'targets': [f'Target {i}'],
+                'other_parties': [],
+                'url': f'https://example.com/MN-800{i}',
+                'events': [
+                    {'title': 'Merger notified to ACCC', 'date': notified},
+                    {'title': 'Phase 1 - Determination', 'date': determined},
+                ],
+            }
+            for i, (notified, determined) in enumerate([
+                ('2025-01-06T09:00:00Z', '2025-01-15T12:00:00Z'),
+                ('2025-02-03T09:00:00Z', '2025-02-19T12:00:00Z'),
+                ('2025-03-03T09:00:00Z', '2025-03-25T12:00:00Z'),
+                ('2025-04-07T09:00:00Z', '2025-05-06T12:00:00Z'),
+            ])
+        ]
+        enriched = [enrich_merger(m) for m in mergers]
+
+        stats_payload = stats.generate(enriched)
+        analysis_payload = analysis.generate(enriched)
+
+        assert stats_payload['phase_duration']['median_business_days'] == (
+            analysis_payload['phase1_duration']['stats']['median']
+        )
+        assert stats_payload['phase_duration']['median_days'] == (
+            analysis_payload['phase1_duration']['calendar_stats']['median']
+        )
+
+
 # ---------------------------------------------------------------------------
 # industries
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
stats.py computed medians as the upper-middle element of a sorted list,
while analysis.py used statistics.median (average of the two middle
values), so the Dashboard and Analysis page could disagree on "median
Phase 1 duration" for even-length duration samples. Switch stats.py to
statistics.median and round to one decimal place, add a matching
Dashboard formatter so whole-number medians don't render with a
spurious ".0", and regenerate stats.json.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017UaaqrzXM6MKshqHp4SXhP