### PR TITLE
Fail loudly when the ACT holiday calendar horizon runs out (spec 4)

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -65,6 +65,14 @@ merger-tracker/frontend/src/
 ├── hooks/                # useDebounce.js, useKeyboardShortcuts.js
 ├── utils/                # dates.js, dataCache.js, lastVisit.js, classNames.js, searchIndex.js
 └── data/                 # ACT public holidays JSON
+                          #   (act-public-holidays.json — source of truth for both the Python
+                          #   pipeline and the frontend; authoritative list published at
+                          #   https://www.cmtedd.act.gov.au/communication/holidays. Substitute-day
+                          #   rules: a weekend ANZAC Day moves to the following Monday; Christmas
+                          #   Day/Boxing Day substitutes are moot since the statutory 23 Dec-10 Jan
+                          #   shutdown already excludes that period. The pipeline and a frontend
+                          #   vitest test both fail loudly if the calendar's horizon shrinks to
+                          #   less than ~1 year ahead — extend this file when that happens.)
 
 scripts/
 ├── scrape.sh             # Bash wrapper using pup to scrape ACCC register

--- a/merger-tracker/frontend/src/utils/__tests__/actPublicHolidays.test.js
+++ b/merger-tracker/frontend/src/utils/__tests__/actPublicHolidays.test.js
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import actPublicHolidays from '../../data/act-public-holidays.json';
+
+// Tripwire for spec 4 (issue #578): `isBusinessDay` silently treats any date
+// beyond the calendar's covered years as a workday. This test fails loudly
+// once the calendar's horizon shrinks to less than a year ahead of "today",
+// so a maintainer refreshes act-public-holidays.json before the gap causes
+// silently wrong business-day durations. A failure on a January CI run
+// (i.e. the file covers less than a year further out) is deliberate and
+// expected — it means it's time to add the next year's holidays.
+describe('act-public-holidays.json horizon', () => {
+  it('covers at least one year beyond the current year', () => {
+    const latestYear = Math.max(
+      ...actPublicHolidays.holidays.map((yearData) => yearData.year)
+    );
+    const currentYear = new Date().getFullYear();
+
+    expect(latestYear).toBeGreaterThanOrEqual(currentYear + 1);
+  });
+});

--- a/scripts/generate_static_data.py
+++ b/scripts/generate_static_data.py
@@ -26,8 +26,11 @@ Output files:
 """
 
 import json
+import os
+import sys
 from pathlib import Path
 
+from static_data.business_days import check_holiday_horizon
 from static_data.enrichment import (
     enrich_merger,
     link_related_mergers,
@@ -64,6 +67,12 @@ DATA_OUTPUT_DIR = REPO_ROOT / "data" / "output"
 
 def main():
     """Generate all static data files."""
+    horizon_warning = check_holiday_horizon()
+    if horizon_warning:
+        print(f"WARNING: {horizon_warning}", file=sys.stderr)
+        if os.environ.get("CI"):
+            sys.exit(1)
+
     print("Loading mergers.json...")
     mergers = load_mergers()
     print(f"Loaded {len(mergers)} mergers")

--- a/scripts/static_data/business_days.py
+++ b/scripts/static_data/business_days.py
@@ -5,7 +5,7 @@ and is not within the Christmas/New Year shutdown (23 Dec - 10 Jan inclusive).
 """
 
 import json
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from pathlib import Path
 
 from date_utils import parse_iso_datetime
@@ -35,6 +35,37 @@ def _ensure_holidays_loaded() -> set:
     if PUBLIC_HOLIDAYS is None:
         PUBLIC_HOLIDAYS = load_public_holidays()
     return PUBLIC_HOLIDAYS
+
+
+def get_latest_holiday_year() -> int:
+    """Return the latest year covered by the ACT public holiday calendar."""
+    with open(HOLIDAYS_JSON, 'r') as f:
+        data = json.load(f)
+    return max(year_data['year'] for year_data in data['holidays'])
+
+
+def check_holiday_horizon(today: date | None = None, horizon_months: int = 15) -> str | None:
+    """Warn when the holiday calendar doesn't extend far enough into the future.
+
+    Returns a human-readable warning message if the calendar's latest covered
+    year ends before `horizon_months` from today, else None. 15 months covers
+    the longest computed horizon (a Phase 2 end of determination period is
+    roughly 120 business days / 6 months, plus slack).
+    """
+    today = today or date.today()
+    latest_year = get_latest_holiday_year()
+
+    total_months = today.month - 1 + horizon_months
+    horizon_year = today.year + total_months // 12
+
+    if latest_year < horizon_year:
+        return (
+            f"ACT public holiday calendar only covers through {latest_year}, "
+            f"which is less than {horizon_months} months ahead of {today.isoformat()}. "
+            f"Business-day calculations beyond {latest_year} will silently treat holidays "
+            f"as workdays. Add holiday entries to {HOLIDAYS_JSON} for the missing year(s)."
+        )
+    return None
 
 
 def is_christmas_new_year_period(date: datetime) -> bool:

--- a/scripts/tests/test_pipeline.py
+++ b/scripts/tests/test_pipeline.py
@@ -5,7 +5,7 @@ import sys
 import os
 import json
 import unittest.mock
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 
 # Add scripts directory to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
@@ -1270,6 +1270,8 @@ from static_data.business_days import (
     is_christmas_new_year_period,
     _count_weekdays_in_range,
     calculate_calendar_days,
+    check_holiday_horizon,
+    get_latest_holiday_year,
 )
 from static_data.enrichment import (
     enrich_merger,
@@ -1374,6 +1376,45 @@ class TestCalculateCalendarDays:
 
     def test_empty_strings(self):
         assert calculate_calendar_days("", "") is None
+
+
+# ---------------------------------------------------------------------------
+# generate_static_data: check_holiday_horizon
+# ---------------------------------------------------------------------------
+
+class TestCheckHolidayHorizon:
+    def test_current_date_passes(self):
+        # The current holiday file (2025-2029) must cover >=15 months ahead
+        # of "today" for the real generator run to pass.
+        assert check_holiday_horizon() is None
+
+    def test_within_horizon_passes(self):
+        latest_year = get_latest_holiday_year()
+        # 15 months before Jan 1 of the year after latest_year is well within
+        # the covered range.
+        today = date(latest_year - 1, 6, 1)
+        assert check_holiday_horizon(today=today) is None
+
+    def test_beyond_horizon_warns(self):
+        latest_year = get_latest_holiday_year()
+        today = date(latest_year + 2, 1, 1)
+        message = check_holiday_horizon(today=today)
+        assert message is not None
+        assert str(latest_year) in message
+
+    def test_just_inside_horizon_passes(self):
+        latest_year = get_latest_holiday_year()
+        # 15 months ahead of Sep of the year before latest_year lands exactly
+        # on latest_year, which the calendar covers.
+        today = date(latest_year - 1, 9, 1)
+        assert check_holiday_horizon(today=today) is None
+
+    def test_just_outside_horizon_warns(self):
+        latest_year = get_latest_holiday_year()
+        # 15 months ahead of Oct of the year before latest_year lands in
+        # latest_year + 1, which the calendar does not cover.
+        today = date(latest_year - 1, 10, 1)
+        assert check_holiday_horizon(today=today) is not None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
is_business_day silently treats years missing from
act-public-holidays.json as ordinary workdays, quietly skewing
durations once the calendar's coverage window closes in. Add a
pipeline check that warns to stderr (and exits non-zero in CI) when
the calendar covers less than ~15 months ahead, plus a frontend
vitest tripwire that fails once the calendar's horizon shrinks to
less than a year ahead.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QRjiJRN3knsHJMJDTSR7uh