### PR TITLE
Harden is_safe_url domain check (spec 9)

### DIFF
--- a/scripts/extract_mergers.py
+++ b/scripts/extract_mergers.py
@@ -122,8 +122,10 @@ def sanitize_filename(filename):
 def is_safe_url(url):
     """Validate that a URL points to an allowed domain to prevent SSRF attacks."""
     parsed = urlparse(url)
+    hostname = parsed.hostname
     return (parsed.scheme in ('http', 'https')
-            and parsed.netloc.endswith('accc.gov.au'))
+            and hostname is not None
+            and (hostname == 'accc.gov.au' or hostname.endswith('.accc.gov.au')))
 
 
 def download_attachment(merger_id, attachment_url, event_title=None, cached_determination_data=None):

--- a/scripts/tests/test_pipeline.py
+++ b/scripts/tests/test_pipeline.py
@@ -1157,11 +1157,15 @@ class TestIsSafeUrl:
     def test_subdomain_accc(self):
         assert is_safe_url("https://register.accc.gov.au/some-page") is True
 
+    def test_bare_accc_domain(self):
+        assert is_safe_url("https://accc.gov.au/x") is True
+
     def test_non_accc_domain(self):
         assert is_safe_url("https://example.com/some-page") is False
 
     def test_ftp_scheme(self):
         assert is_safe_url("ftp://www.accc.gov.au/file") is False
+        assert is_safe_url("ftp://accc.gov.au/x") is False
 
     def test_empty_url(self):
         assert is_safe_url("") is False
@@ -1171,6 +1175,19 @@ class TestIsSafeUrl:
 
     def test_javascript_scheme(self):
         assert is_safe_url("javascript:alert(1)") is False
+
+    def test_suffix_domain_bypass(self):
+        """A hostname that merely ends with 'accc.gov.au' without a dot
+        boundary (e.g. evilaccc.gov.au) must be rejected."""
+        assert is_safe_url("https://evilaccc.gov.au/x") is False
+
+    def test_subdomain_of_attacker_domain_bypass(self):
+        """accc.gov.au as a prefix of an attacker-controlled domain must
+        be rejected."""
+        assert is_safe_url("https://accc.gov.au.evil.com/x") is False
+
+    def test_no_host(self):
+        assert is_safe_url("/relative/path") is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `is_safe_url` in `scripts/extract_mergers.py` allowed downloads when `parsed.netloc.endswith('accc.gov.au')`, which also matched attacker-controlled hosts like `evilaccc.gov.au` (no dot boundary) and could be confused by `user:pass@`/`:port` components in `netloc`.
- Switched to `parsed.hostname` with an exact-or-dot-boundary check: `hostname == 'accc.gov.au' or hostname.endswith('.accc.gov.au')`, with an explicit `hostname is not None` guard.
- Grepped the repo for other `endswith(...gov.au')` / domain-allowlist patterns — `scripts/extract_mergers.py` was the only one.
- Added unit tests covering the bypass cases from the spec: `evilaccc.gov.au`, `accc.gov.au.evil.com`, bare `accc.gov.au`, `ftp://accc.gov.au`, and no-host URLs.

Implements spec 9 from `docs/repo-review-specs.md`.

Closes #582

## Test plan
- [x] `python3 -m pytest scripts/tests/test_pipeline.py -k TestIsSafeUrl -v` — 12 passed
- [x] `python3 -m pytest scripts/tests/test_pipeline.py -q` — 253 passed (full suite, no regressions)


---
_Generated by [Claude Code](https://claude.ai/code/session_014X2aY5GrpDeDKezubW71gw)_