### PR TITLE
Reject unset ALLOWED_SENDERS on register watcher instead of accept-any

### DIFF
--- a/accc-register-watcher/README.md
+++ b/accc-register-watcher/README.md
@@ -71,7 +71,11 @@ Cloudflare Email Routing rules aren't expressible in `wrangler.toml`.
    list's real sender, `do-not-reply@accc.gov.au` — redeploy after any
    changes to it. It's checked against both the envelope sender and the
    `From:` header, so it stays effective even if the list sends through a
-   third-party bulk mailer with a different envelope address.
+   third-party bulk mailer with a different envelope address. **Leaving it
+   blank/unset rejects all senders** (logging a warning) rather than
+   accepting any — if the list starts sending from a different bulk-mail
+   address, add it here (or use a domain entry like `@accc.gov.au`) rather
+   than clearing the var.
 
 ## Verify
 

--- a/accc-register-watcher/package.json
+++ b/accc-register-watcher/package.json
@@ -2,12 +2,14 @@
   "name": "accc-register-watcher",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "description": "Cloudflare Email Worker — triggers the merger pipeline when the ACCC register update mailing list sends an email",
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "deploy:dry": "wrangler deploy --dry-run",
-    "tail": "wrangler tail"
+    "tail": "wrangler tail",
+    "test": "node --test"
   },
   "devDependencies": {
     "wrangler": "^4.67.0"

--- a/accc-register-watcher/src/index.js
+++ b/accc-register-watcher/src/index.js
@@ -15,9 +15,9 @@
  * Required Worker vars (wrangler.toml):
  *   GITHUB_REPO      — "owner/repo" to dispatch to
  *   ALLOWED_SENDERS  — comma-separated allowlist of sender addresses/domains
- *                      for the ACCC mailing list (blank = accept any sender),
- *                      checked against both the envelope sender and the
- *                      From: header
+ *                      for the ACCC mailing list (blank/unset = reject all
+ *                      senders, logging a warning), checked against both the
+ *                      envelope sender and the From: header
  */
 
 const DISPATCH_EVENT_TYPE = "new_merger_detected";
@@ -29,13 +29,15 @@ function extractAddress(value) {
   return (match ? match[1] : value || "").trim().toLowerCase();
 }
 
-function isAllowedSender(candidates, allowedSendersVar) {
+export function isAllowedSender(candidates, allowedSendersVar) {
   const allowed = (allowedSendersVar || "")
     .split(",")
     .map((s) => s.trim().toLowerCase())
     .filter(Boolean);
 
-  if (allowed.length === 0) return true;
+  // No allowlist configured — reject rather than accept-any, so a blank
+  // ALLOWED_SENDERS can't silently let spoofed mail trigger pipeline runs.
+  if (allowed.length === 0) return false;
 
   return candidates.some((candidate) =>
     allowed.some((entry) =>
@@ -53,9 +55,10 @@ export default {
     const subject = message.headers.get("subject") || "(no subject)";
 
     if (!isAllowedSender([envelopeFrom, headerFrom], env.ALLOWED_SENDERS)) {
-      console.warn(
-        `Ignoring email from unrecognised sender (envelope: ${envelopeFrom}, header: ${headerFrom})`
-      );
+      const reason = env.ALLOWED_SENDERS
+        ? `unrecognised sender (envelope: ${envelopeFrom}, header: ${headerFrom})`
+        : "ALLOWED_SENDERS is not configured";
+      console.warn(`Ignoring email — ${reason}`);
       return;
     }
 

--- a/accc-register-watcher/src/index.test.js
+++ b/accc-register-watcher/src/index.test.js
@@ -1,0 +1,42 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isAllowedSender } from "./index.js";
+
+test("rejects everything when ALLOWED_SENDERS is blank/unset", () => {
+  assert.equal(isAllowedSender(["someone@example.com"], ""), false);
+  assert.equal(isAllowedSender(["someone@example.com"], undefined), false);
+});
+
+test("allows an exact address match", () => {
+  assert.equal(
+    isAllowedSender(
+      ["do-not-reply@accc.gov.au"],
+      "do-not-reply@accc.gov.au"
+    ),
+    true
+  );
+});
+
+test("allows a domain match via @domain entries", () => {
+  assert.equal(
+    isAllowedSender(["bulk-mailer@accc.gov.au"], "@accc.gov.au"),
+    true
+  );
+});
+
+test("rejects senders not in the allowlist", () => {
+  assert.equal(
+    isAllowedSender(["attacker@evil.example"], "do-not-reply@accc.gov.au"),
+    false
+  );
+});
+
+test("matches if any candidate (envelope or header from) is allowed", () => {
+  assert.equal(
+    isAllowedSender(
+      ["bulk-mailer@example.com", "do-not-reply@accc.gov.au"],
+      "do-not-reply@accc.gov.au"
+    ),
+    true
+  );
+});

--- a/accc-register-watcher/wrangler.toml
+++ b/accc-register-watcher/wrangler.toml
@@ -7,7 +7,11 @@ compatibility_date = "2024-09-23"
 GITHUB_REPO = "nwbort/accc-mergers"
 
 # Comma-separated allowlist of sender addresses/domains for the ACCC mailing
-# list. Leave blank to accept email from any sender.
+# list, checked against both the envelope sender and the From: header.
+# Leave blank/unset to REJECT all senders (a warning is logged) — this must
+# be set for the watcher to dispatch anything. Recommended: the mailing
+# list's known sender address below, or a domain entry like "@accc.gov.au"
+# to also tolerate a bulk-mail sender with a different envelope address.
 ALLOWED_SENDERS = "do-not-reply@accc.gov.au"
 
 # Secrets — set with:


### PR DESCRIPTION
A blank ALLOWED_SENDERS previously let any sender trigger pipeline runs.
Flip the default to reject-and-warn, clarify the wrangler.toml/README
docs, and add unit tests for isAllowedSender.

Fixes #583