### PR TITLE
Add clock-restart analysis to analysis.json (spec 14)

### DIFF
--- a/scripts/static_data/outputs/analysis.py
+++ b/scripts/static_data/outputs/analysis.py
@@ -143,6 +143,35 @@ def deadline_utilisation(mergers: list) -> dict:
     }
 
 
+def notification_restarts(mergers: list) -> list[dict]:
+    """Notifications whose clock restarted: original vs effective notification date.
+
+    ``effective_notification_datetime`` moves forward when the ACCC treats a
+    notification as amended/restarted; ``original_notification_datetime``
+    stays fixed at first filing. Waivers have no such clock, so only
+    notifications are considered. Sorted by delta (days) descending.
+    """
+    restarts = []
+    for m in filter_notifications(mergers):
+        original = m.get('original_notification_datetime')
+        effective = m.get('effective_notification_datetime')
+        if not original or not effective or original == effective:
+            continue
+        delta = calculate_calendar_days(original, effective)
+        if delta is None:
+            continue
+        restarts.append({
+            "merger_id": m.get('merger_id'),
+            "merger_name": m.get('merger_name'),
+            "original_date": original[:10],
+            "effective_date": effective[:10],
+            "delta_calendar_days": delta,
+        })
+
+    restarts.sort(key=lambda x: -x['delta_calendar_days'])
+    return restarts
+
+
 def generate(mergers: list) -> dict:
     """Return the analysis.json payload for pre-enriched mergers."""
     notification_mergers = filter_notifications(mergers)
@@ -276,6 +305,10 @@ def generate(mergers: list) -> dict:
         "waivers": [monthly_counts[m]["waivers"] for m in sorted_months],
     }
 
+    restarts = notification_restarts(mergers)
+    total_notifications = len(notification_mergers)
+    restart_rate = round(len(restarts) / total_notifications, 4) if total_notifications else None
+
     return {
         "phase1_duration": {
             "scatter_data": phase1_scatter,
@@ -290,4 +323,6 @@ def generate(mergers: list) -> dict:
         "monthly_volume": monthly_volume,
         "industry_phase1_duration": industry_phase1_duration(mergers),
         "deadline_utilisation": deadline_utilisation(mergers),
+        "notification_restarts": restarts,
+        "restart_rate": restart_rate,
     }

--- a/scripts/tests/test_static_data_outputs.py
+++ b/scripts/tests/test_static_data_outputs.py
@@ -498,7 +498,7 @@ class TestAnalysisGenerate:
         json.dumps(payload)
         assert set(payload.keys()) == {
             'phase1_duration', 'waiver_duration', 'monthly_volume', 'industry_phase1_duration',
-            'deadline_utilisation',
+            'deadline_utilisation', 'notification_restarts', 'restart_rate',
         }
         assert 'scatter_data' in payload['phase1_duration']
         assert 'scatter_data' in payload['waiver_duration']
@@ -527,6 +527,92 @@ class TestAnalysisGenerate:
         mining = divisions[0]
         assert mining['name'] == 'Mining'
         assert mining['count'] == 1
+
+
+class TestNotificationRestarts:
+    """Spec 14: original_notification_datetime vs effective_notification_datetime."""
+
+    def _restarted_notification_raw(self):
+        return {
+            'merger_id': 'MN-9001',
+            'merger_name': 'Restarted notification',
+            'status': 'Under assessment',
+            'accc_determination': None,
+            'stage': 'Phase 1 - preliminary assessment',
+            'original_notification_datetime': '2026-02-06T12:00:00Z',
+            'effective_notification_datetime': '2026-02-20T12:00:00Z',
+            'determination_publication_date': None,
+            'page_modified_datetime': '2026-02-20T12:30:00Z',
+            'anzsic_codes': [],
+            'acquirers': ['Omicron'],
+            'targets': ['Pi'],
+            'other_parties': [],
+            'url': 'https://example.com/MN-9001',
+            'events': [
+                {'title': 'Merger notified to ACCC', 'date': '2026-02-20T12:00:00Z'},
+            ],
+        }
+
+    def _restarted_waiver_raw(self):
+        # Same original/effective mismatch, but a waiver — must not count as
+        # a notification restart, since waivers have no Phase 1 clock.
+        return {
+            'merger_id': 'WA-9002',
+            'merger_name': 'Restarted waiver (excluded)',
+            'status': 'Determined',
+            'accc_determination': 'Waiver granted',
+            'stage': 'Waiver',
+            'original_notification_datetime': '2026-03-01T12:00:00Z',
+            'effective_notification_datetime': '2026-03-10T12:00:00Z',
+            'determination_publication_date': '2026-03-20T12:00:00Z',
+            'page_modified_datetime': '2026-03-20T12:30:00Z',
+            'anzsic_codes': [],
+            'acquirers': ['Rho'],
+            'targets': ['Sigma'],
+            'other_parties': [],
+            'url': 'https://example.com/WA-9002',
+            'events': [
+                {'title': 'Waiver application received', 'date': '2026-03-10T12:00:00Z'},
+            ],
+        }
+
+    def test_finds_restarted_notification(self):
+        enriched = [enrich_merger(self._restarted_notification_raw())]
+        restarts = analysis.notification_restarts(enriched)
+        assert len(restarts) == 1
+        entry = restarts[0]
+        assert entry['merger_id'] == 'MN-9001'
+        assert entry['original_date'] == '2026-02-06'
+        assert entry['effective_date'] == '2026-02-20'
+        assert entry['delta_calendar_days'] == 14
+
+    def test_excludes_waivers(self):
+        enriched = [enrich_merger(self._restarted_waiver_raw())]
+        assert analysis.notification_restarts(enriched) == []
+
+    def test_excludes_unchanged_dates(self):
+        # The base fixture's mergers all have matching original/effective dates.
+        assert analysis.notification_restarts(_enriched_fixture()) == []
+
+    def test_sorted_by_delta_descending(self):
+        small_delta = self._restarted_notification_raw()
+        small_delta['merger_id'] = 'MN-9003'
+        small_delta['effective_notification_datetime'] = '2026-02-08T12:00:00Z'
+        enriched = [
+            enrich_merger(small_delta),
+            enrich_merger(self._restarted_notification_raw()),
+        ]
+        restarts = analysis.notification_restarts(enriched)
+        assert [r['merger_id'] for r in restarts] == ['MN-9001', 'MN-9003']
+        assert restarts[0]['delta_calendar_days'] > restarts[1]['delta_calendar_days']
+
+    def test_restart_rate_in_generate_payload(self):
+        mergers = _raw_fixture() + [self._restarted_notification_raw(), self._restarted_waiver_raw()]
+        enriched = [enrich_merger(m) for m in mergers]
+        payload = analysis.generate(enriched)
+        assert len(payload['notification_restarts']) == 1
+        notification_count = sum(1 for m in enriched if not m.get('is_waiver'))
+        assert payload['restart_rate'] == round(1 / notification_count, 4)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `original_notification_datetime` vs `effective_notification_datetime` captures restarted/amended notifications but was never analysed.
- Add `notification_restarts` to `analysis.json`: per-notification `{merger_id, merger_name, original_date, effective_date, delta_calendar_days}` for every notification where the dates differ, sorted by delta descending. Waivers are excluded (no Phase 1 clock to restart).
- Add `restart_rate` (restarted ÷ total notifications) alongside it.
- Verified against real data: 3 known restarts found (MN-95001: 53 days, MN-30003: 14 days, MN-60022: 4 days), restart rate 1.82% — matches the issue's note that known restarts exist, so an empty list would have signalled a bug.

## Test plan
- [x] `python3 -m pytest scripts/tests/test_static_data_outputs.py -q` — new `TestNotificationRestarts` class plus updated `TestAnalysisGenerate` shape assertion, all passing
- [x] `python3 -m pytest scripts/tests -q` — full suite (637 tests) passing
- [x] Ran `analysis.generate()` against real `data/processed/mergers.json` and eyeballed the output

Closes #587


---
_Generated by [Claude Code](https://claude.ai/code/session_01VBkooJytpnVbyMCM7WstcG)_