### PR TITLE
Add serial-acquirer detection for creeping acquisitions

### DIFF
--- a/merger-tracker/frontend/public/data/serial-acquirers.json
+++ b/merger-tracker/frontend/public/data/serial-acquirers.json
@@ -1,0 +1,319 @@
+{
+  "acquirers": [
+    {
+      "acquirer_name": "Coles Group",
+      "canonical_id": "coles",
+      "anzsic_code": "411",
+      "anzsic_name": "Supermarket and Grocery Stores",
+      "merger_ids": [
+        "MN-01068",
+        "MN-01090",
+        "MN-50019",
+        "MN-25029",
+        "MN-70022"
+      ],
+      "dates": [
+        "2025-11-27T12:00:00Z",
+        "2026-03-12T12:00:00Z",
+        "2026-06-04T12:00:00Z",
+        "2026-06-09T12:00:00Z",
+        "2026-06-23T12:00:00Z"
+      ],
+      "count": 5
+    },
+    {
+      "acquirer_name": "OHCA PROPERTY HOLDINGS PTY LTD",
+      "canonical_id": null,
+      "anzsic_code": "860",
+      "anzsic_name": "Residential Care Services",
+      "merger_ids": [
+        "MN-75002",
+        "MN-75012",
+        "MN-15019"
+      ],
+      "dates": [
+        "2026-01-19T12:00:00Z",
+        "2026-03-19T12:00:00Z",
+        "2026-05-20T12:00:00Z"
+      ],
+      "count": 3
+    },
+    {
+      "acquirer_name": "DPG SERVICES PTY LTD",
+      "canonical_id": null,
+      "anzsic_code": "860",
+      "anzsic_name": "Residential Care Services",
+      "merger_ids": [
+        "MN-75002",
+        "MN-75012",
+        "MN-15019"
+      ],
+      "dates": [
+        "2026-01-19T12:00:00Z",
+        "2026-03-19T12:00:00Z",
+        "2026-05-20T12:00:00Z"
+      ],
+      "count": 3
+    },
+    {
+      "acquirer_name": "Eli Lilly and Company",
+      "canonical_id": "eli-lilly-and-company",
+      "anzsic_code": "184",
+      "anzsic_name": "Pharmaceutical and Medicinal Product Manufacturing",
+      "merger_ids": [
+        "MN-20013",
+        "MN-40012",
+        "MN-95016"
+      ],
+      "dates": [
+        "2026-04-08T12:00:00Z",
+        "2026-04-14T12:00:00Z",
+        "2026-05-18T12:00:00Z"
+      ],
+      "count": 3
+    },
+    {
+      "acquirer_name": "Eli Lilly and Company",
+      "canonical_id": "eli-lilly-and-company",
+      "anzsic_code": "691",
+      "anzsic_name": "Scientific Research Services",
+      "merger_ids": [
+        "MN-20013",
+        "MN-40012",
+        "MN-95016"
+      ],
+      "dates": [
+        "2026-04-08T12:00:00Z",
+        "2026-04-14T12:00:00Z",
+        "2026-05-18T12:00:00Z"
+      ],
+      "count": 3
+    },
+    {
+      "acquirer_name": "Experience Co Limited",
+      "canonical_id": "experience-co-limited",
+      "anzsic_code": "482",
+      "anzsic_name": "Water Passenger Transport",
+      "merger_ids": [
+        "MN-50011",
+        "MN-85015"
+      ],
+      "dates": [
+        "2026-07-01T12:00:00Z",
+        "2026-07-01T12:00:00Z"
+      ],
+      "count": 2
+    },
+    {
+      "acquirer_name": "Experience Co Limited",
+      "canonical_id": "experience-co-limited",
+      "anzsic_code": "501",
+      "anzsic_name": "Scenic and Sightseeing Transport",
+      "merger_ids": [
+        "MN-50011",
+        "MN-85015"
+      ],
+      "dates": [
+        "2026-07-01T12:00:00Z",
+        "2026-07-01T12:00:00Z"
+      ],
+      "count": 2
+    },
+    {
+      "acquirer_name": "SYMAL GROUP LIMITED",
+      "canonical_id": null,
+      "anzsic_code": "310",
+      "anzsic_name": "Heavy and Civil Engineering Construction",
+      "merger_ids": [
+        "MN-55003",
+        "MN-50030"
+      ],
+      "dates": [
+        "2026-02-03T12:00:00Z",
+        "2026-07-01T12:00:00Z"
+      ],
+      "count": 2
+    },
+    {
+      "acquirer_name": "OpenAI Group PBC",
+      "canonical_id": null,
+      "anzsic_code": "592",
+      "anzsic_name": "Data Processing, Web Hosting and Electronic Information Storage Services",
+      "merger_ids": [
+        "MN-25021",
+        "MN-90020"
+      ],
+      "dates": [
+        "2026-05-12T12:00:00Z",
+        "2026-06-26T12:00:00Z"
+      ],
+      "count": 2
+    },
+    {
+      "acquirer_name": "ENDEAVOUR GROUP LIMITED",
+      "canonical_id": null,
+      "anzsic_code": "412",
+      "anzsic_name": "Specialised Food Retailing",
+      "merger_ids": [
+        "MN-30012",
+        "MN-50027"
+      ],
+      "dates": [
+        "2026-05-22T12:00:00Z",
+        "2026-06-22T12:00:00Z"
+      ],
+      "count": 2
+    },
+    {
+      "acquirer_name": "LITTLE COMPANY OF MARY HEALTH CARE LIMITED",
+      "canonical_id": null,
+      "anzsic_code": "840",
+      "anzsic_name": "Hospitals",
+      "merger_ids": [
+        "MN-55010",
+        "MN-40013"
+      ],
+      "dates": [
+        "2026-03-27T12:00:00Z",
+        "2026-06-16T12:00:00Z"
+      ],
+      "count": 2
+    },
+    {
+      "acquirer_name": "CVS VETS (AUSTRALIA) PROPRIETARY LIMITED",
+      "canonical_id": null,
+      "anzsic_code": "697",
+      "anzsic_name": "Veterinary Services",
+      "merger_ids": [
+        "MN-95003",
+        "MN-70020"
+      ],
+      "dates": [
+        "2026-02-13T12:00:00Z",
+        "2026-06-02T12:00:00Z"
+      ],
+      "count": 2
+    },
+    {
+      "acquirer_name": "CSE-Global (Australia) Pty Ltd",
+      "canonical_id": null,
+      "anzsic_code": "349",
+      "anzsic_name": "Other Machinery and Equipment Wholesaling",
+      "merger_ids": [
+        "MN-01071",
+        "MN-95021"
+      ],
+      "dates": [
+        "2025-12-22T12:00:00Z",
+        "2026-05-21T12:00:00Z"
+      ],
+      "count": 2
+    },
+    {
+      "acquirer_name": "Gilead Sciences, Inc.",
+      "canonical_id": null,
+      "anzsic_code": "184",
+      "anzsic_name": "Pharmaceutical and Medicinal Product Manufacturing",
+      "merger_ids": [
+        "MN-40009",
+        "MN-60014"
+      ],
+      "dates": [
+        "2026-03-19T12:00:00Z",
+        "2026-04-22T12:00:00Z"
+      ],
+      "count": 2
+    },
+    {
+      "acquirer_name": "Gilead Sciences, Inc.",
+      "canonical_id": null,
+      "anzsic_code": "691",
+      "anzsic_name": "Scientific Research Services",
+      "merger_ids": [
+        "MN-40009",
+        "MN-60014"
+      ],
+      "dates": [
+        "2026-03-19T12:00:00Z",
+        "2026-04-22T12:00:00Z"
+      ],
+      "count": 2
+    },
+    {
+      "acquirer_name": "Coles Group",
+      "canonical_id": "coles",
+      "anzsic_code": "671",
+      "anzsic_name": "Property Operators",
+      "merger_ids": [
+        "MN-01068",
+        "MN-01090"
+      ],
+      "dates": [
+        "2025-11-27T12:00:00Z",
+        "2026-03-12T12:00:00Z"
+      ],
+      "count": 2
+    },
+    {
+      "acquirer_name": "AVC Operations Pty Limited",
+      "canonical_id": null,
+      "anzsic_code": "451",
+      "anzsic_name": "Cafes, Restaurants and Takeaway Food Services",
+      "merger_ids": [
+        "MN-10006",
+        "MN-65007"
+      ],
+      "dates": [
+        "2026-02-06T12:00:00Z",
+        "2026-02-23T12:00:00Z"
+      ],
+      "count": 2
+    },
+    {
+      "acquirer_name": "AVC Operations Pty Limited",
+      "canonical_id": null,
+      "anzsic_code": "452",
+      "anzsic_name": "Pubs, Taverns and Bars",
+      "merger_ids": [
+        "MN-10006",
+        "MN-65007"
+      ],
+      "dates": [
+        "2026-02-06T12:00:00Z",
+        "2026-02-23T12:00:00Z"
+      ],
+      "count": 2
+    },
+    {
+      "acquirer_name": "ServiceNow, Inc.",
+      "canonical_id": "servicenow-inc",
+      "anzsic_code": "542",
+      "anzsic_name": "Software Publishing",
+      "merger_ids": [
+        "MN-85002",
+        "MN-25004"
+      ],
+      "dates": [
+        "2025-12-22T12:00:00Z",
+        "2026-02-13T12:00:00Z"
+      ],
+      "count": 2
+    },
+    {
+      "acquirer_name": "ASAHI HOLDINGS (AUSTRALIA) PTY LTD",
+      "canonical_id": null,
+      "anzsic_code": "121",
+      "anzsic_name": "Beverage Manufacturing",
+      "merger_ids": [
+        "MN-01016",
+        "MN-01035"
+      ],
+      "dates": [
+        "2025-08-15T12:00:00Z",
+        "2025-10-24T12:00:00Z"
+      ],
+      "count": 2
+    }
+  ],
+  "count": 20
+}

--- a/scripts/generate_static_data.py
+++ b/scripts/generate_static_data.py
@@ -21,6 +21,7 @@ Output files:
   - upcoming-events.json        - Future consultation/determination dates
   - commentary.json             - Mergers with user commentary
   - analysis.json               - Pre-computed analysis data
+  - serial-acquirers.json       - Serial-acquirer ("creeping acquisitions") detection
   - questionnaires/{id}.json    - Lazy-loaded questionnaire files
   - noccs/{id}.json             - Lazy-loaded NOCC summary files
 """
@@ -54,6 +55,7 @@ from static_data.outputs import (
     list as list_out,
     noccs,
     questionnaires,
+    serial_acquirers,
     stats,
     timeline,
     upcoming_events,
@@ -138,6 +140,7 @@ def main():
         ("upcoming-events.json", upcoming_events.generate(enriched)),
         ("commentary.json", commentary_out.generate(enriched, commentary)),
         ("analysis.json", analysis.generate(enriched)),
+        ("serial-acquirers.json", serial_acquirers.generate(enriched)),
     ]
     for filename, payload in single_file_outputs:
         out_path = OUTPUT_DIR / filename

--- a/scripts/static_data/outputs/serial_acquirers.py
+++ b/scripts/static_data/outputs/serial_acquirers.py
@@ -1,0 +1,128 @@
+"""Serial-acquirer ("creeping acquisitions") detection — ``serial-acquirers.json``.
+
+Flags canonical acquirer groups with two or more notifications in the same
+ANZSIC class/group within any rolling 12-month window — the pattern the new
+merger regime's cumulative-turnover thresholds target.
+"""
+
+from datetime import datetime
+
+from date_utils import parse_iso_datetime
+from party_matching import normalise_name
+
+from .. import anzsic
+from ..filters import filter_notifications
+
+# A notification pair counts as "creeping" when it falls within 12 months.
+WINDOW_DAYS = 365
+MIN_NOTIFICATIONS = 2
+
+
+def _group_level_tag(code: str) -> tuple[str, str] | None:
+    """Roll an ANZSIC code up to its ``(group_code, group_name)``, or ``None``.
+
+    Class-level tags roll up to their parent group; group-level tags are used
+    as-is. Coarser (subdivision/division) or unrecognised codes have no single
+    group to resolve to and are skipped — they're too broad for this analysis.
+    """
+    node = anzsic.get(code)
+    if node is None:
+        return None
+    if node.level == "class":
+        parent = anzsic.get(node.parent_code) if node.parent_code else None
+        return (parent.code, parent.name) if parent else None
+    if node.level == "group":
+        return (node.code, node.name)
+    return None
+
+
+def _acquirer_key(party: dict) -> tuple[str, str | None, str] | None:
+    """Return ``(group_key, canonical_id, display_name)`` for a party, or ``None``.
+
+    Prefers the canonical group linked by
+    :func:`static_data.enrichment.link_related_parties`; falls back to the
+    normalised acquirer name (reusing :func:`party_matching.normalise_name`)
+    when no canonical group exists.
+    """
+    canonical = party.get("canonical")
+    if canonical and canonical.get("id"):
+        return (f"canonical:{canonical['id']}", canonical["id"], canonical.get("name") or party.get("name", ""))
+    name = party.get("name") or ""
+    normalised = normalise_name(name)
+    if not normalised:
+        return None
+    return (f"name:{normalised}", None, name)
+
+
+def _has_window_pair(dates: list[datetime]) -> bool:
+    """Return True if two (sorted) dates fall within ``WINDOW_DAYS`` of each other.
+
+    Checking only consecutive pairs is sufficient: in a sorted list the
+    smallest gap between any two elements is always between neighbours, so if
+    every neighbouring gap exceeds the window, no pair can be within it.
+    """
+    return any(
+        (later - earlier).days <= WINDOW_DAYS
+        for earlier, later in zip(dates, dates[1:])
+    )
+
+
+def generate(mergers: list) -> dict:
+    """Return the serial-acquirers.json payload for pre-enriched mergers."""
+    buckets: dict[tuple[str, str], dict] = {}
+
+    for merger in filter_notifications(mergers):
+        merger_id = merger.get("merger_id")
+        date_str = merger.get("effective_notification_datetime")
+        parsed_date = parse_iso_datetime(date_str)
+        if not merger_id or parsed_date is None:
+            continue
+
+        anzsic_tags = {}
+        for code_entry in merger.get("anzsic_codes") or []:
+            tag = _group_level_tag(code_entry.get("code", ""))
+            if tag:
+                anzsic_tags[tag[0]] = tag[1]
+        if not anzsic_tags:
+            continue
+
+        acquirer_keys = {}
+        for party in merger.get("acquirers") or []:
+            key = _acquirer_key(party)
+            if key:
+                acquirer_keys[key[0]] = key
+
+        for group_key, canonical_id, display_name in acquirer_keys.values():
+            for anzsic_code, anzsic_name in anzsic_tags.items():
+                bucket = buckets.setdefault(
+                    (group_key, anzsic_code),
+                    {
+                        "acquirer_name": display_name,
+                        "canonical_id": canonical_id,
+                        "anzsic_code": anzsic_code,
+                        "anzsic_name": anzsic_name,
+                        "entries": {},
+                    },
+                )
+                bucket["entries"][merger_id] = (parsed_date, date_str)
+
+    records = []
+    for bucket in buckets.values():
+        entries = sorted(bucket["entries"].items(), key=lambda kv: kv[1][0])
+        if len(entries) < MIN_NOTIFICATIONS:
+            continue
+        if not _has_window_pair([parsed for _, (parsed, _) in entries]):
+            continue
+        records.append({
+            "acquirer_name": bucket["acquirer_name"],
+            "canonical_id": bucket["canonical_id"],
+            "anzsic_code": bucket["anzsic_code"],
+            "anzsic_name": bucket["anzsic_name"],
+            "merger_ids": [merger_id for merger_id, _ in entries],
+            "dates": [date_str for _, (_, date_str) in entries],
+            "count": len(entries),
+        })
+
+    records.sort(key=lambda r: (r["count"], max(r["dates"])), reverse=True)
+
+    return {"acquirers": records, "count": len(records)}

--- a/scripts/tests/test_serial_acquirers.py
+++ b/scripts/tests/test_serial_acquirers.py
@@ -1,0 +1,205 @@
+"""Tests for serial-acquirer ("creeping acquisitions") detection.
+
+See docs/repo-review-specs.md #12 for the spec this implements.
+"""
+
+import json
+import os
+import sys
+import unittest.mock
+
+# Add scripts directory to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+# Mock heavy transitive imports before importing modules that need them
+sys.modules.setdefault('pdfplumber', unittest.mock.MagicMock())
+sys.modules.setdefault('markdownify', unittest.mock.MagicMock())
+sys.modules.setdefault('requests', unittest.mock.MagicMock())
+
+from static_data.enrichment import enrich_merger, link_related_parties
+from static_data.outputs import serial_acquirers
+
+# Real ANZSIC codes used across tests: 0600 (Coal Mining, class) rolls up to
+# group 060 (also named Coal Mining); 1211 (Soft Drink Manufacturing, class)
+# rolls up to group 121 (Beverage Manufacturing) — a wholly separate industry.
+COAL_CLASS = {'code': '0600', 'name': 'Coal Mining'}
+COAL_GROUP = {'code': '060', 'name': 'Coal Mining'}
+BEVERAGE_CLASS = {'code': '1211', 'name': 'Soft Drink, Cordial and Syrup Manufacturing'}
+
+
+def _notification(merger_id, acquirer_name, date, anzsic_codes=(COAL_CLASS,), is_waiver=False):
+    return {
+        'merger_id': merger_id,
+        'merger_name': f'{acquirer_name} deal {merger_id}',
+        'is_waiver': is_waiver,
+        'effective_notification_datetime': date,
+        'anzsic_codes': list(anzsic_codes),
+        'acquirers': [{'name': acquirer_name, 'identifier': ''}],
+        'targets': [{'name': 'Target Co', 'identifier': ''}],
+        'other_parties': [],
+    }
+
+
+class TestReturnsValidShape:
+    def test_empty_input(self):
+        payload = serial_acquirers.generate([])
+        json.dumps(payload)
+        assert payload == {'acquirers': [], 'count': 0}
+
+    def test_shape(self):
+        mergers = [
+            _notification('MN-0001', 'Acme Pty Ltd', '2025-01-06T09:00:00Z'),
+            _notification('MN-0002', 'Acme Pty Ltd', '2025-04-06T09:00:00Z'),
+        ]
+        payload = serial_acquirers.generate(mergers)
+        json.dumps(payload)
+        assert payload['count'] == 1
+        record = payload['acquirers'][0]
+        assert set(record.keys()) == {
+            'acquirer_name', 'canonical_id', 'anzsic_code', 'anzsic_name',
+            'merger_ids', 'dates', 'count',
+        }
+
+
+class TestWindowDetection:
+    def test_six_months_apart_is_detected(self):
+        mergers = [
+            _notification('MN-0001', 'Acme Pty Ltd', '2025-01-06T09:00:00Z'),
+            _notification('MN-0002', 'Acme Pty Ltd', '2025-07-06T09:00:00Z'),
+        ]
+        payload = serial_acquirers.generate(mergers)
+        assert payload['count'] == 1
+        record = payload['acquirers'][0]
+        assert record['count'] == 2
+        assert set(record['merger_ids']) == {'MN-0001', 'MN-0002'}
+        assert record['anzsic_code'] == '060'
+
+    def test_eighteen_months_apart_is_not_detected(self):
+        mergers = [
+            _notification('MN-0001', 'Acme Pty Ltd', '2025-01-06T09:00:00Z'),
+            _notification('MN-0002', 'Acme Pty Ltd', '2026-07-06T09:00:00Z'),
+        ]
+        payload = serial_acquirers.generate(mergers)
+        assert payload['count'] == 0
+
+    def test_third_filing_bridges_the_gap(self):
+        # MN-0001 and MN-0003 are 18 months apart (would not qualify alone),
+        # but MN-0002 sits 9 months after MN-0001 and 9 months before
+        # MN-0003, so all three are part of the same creeping pattern.
+        mergers = [
+            _notification('MN-0001', 'Acme Pty Ltd', '2025-01-06T09:00:00Z'),
+            _notification('MN-0002', 'Acme Pty Ltd', '2025-10-06T09:00:00Z'),
+            _notification('MN-0003', 'Acme Pty Ltd', '2026-07-06T09:00:00Z'),
+        ]
+        payload = serial_acquirers.generate(mergers)
+        assert payload['count'] == 1
+        record = payload['acquirers'][0]
+        assert record['count'] == 3
+        assert set(record['merger_ids']) == {'MN-0001', 'MN-0002', 'MN-0003'}
+
+    def test_single_notification_is_not_detected(self):
+        mergers = [_notification('MN-0001', 'Acme Pty Ltd', '2025-01-06T09:00:00Z')]
+        payload = serial_acquirers.generate(mergers)
+        assert payload['count'] == 0
+
+
+class TestAnzsicRollup:
+    def test_class_and_group_tag_pair_up(self):
+        # Same acquirer, one filing tagged at the class level and the other
+        # at the parent group level — both roll up to group 060 and pair.
+        mergers = [
+            _notification('MN-0001', 'Acme Pty Ltd', '2025-01-06T09:00:00Z', anzsic_codes=(COAL_CLASS,)),
+            _notification('MN-0002', 'Acme Pty Ltd', '2025-06-06T09:00:00Z', anzsic_codes=(COAL_GROUP,)),
+        ]
+        payload = serial_acquirers.generate(mergers)
+        assert payload['count'] == 1
+        assert payload['acquirers'][0]['anzsic_code'] == '060'
+
+    def test_different_industries_do_not_pair(self):
+        mergers = [
+            _notification('MN-0001', 'Acme Pty Ltd', '2025-01-06T09:00:00Z', anzsic_codes=(COAL_CLASS,)),
+            _notification('MN-0002', 'Acme Pty Ltd', '2025-06-06T09:00:00Z', anzsic_codes=(BEVERAGE_CLASS,)),
+        ]
+        payload = serial_acquirers.generate(mergers)
+        assert payload['count'] == 0
+
+    def test_unknown_anzsic_code_is_skipped(self):
+        mergers = [
+            _notification('MN-0001', 'Acme Pty Ltd', '2025-01-06T09:00:00Z', anzsic_codes=({'code': '9999', 'name': 'Not real'},)),
+            _notification('MN-0002', 'Acme Pty Ltd', '2025-06-06T09:00:00Z', anzsic_codes=({'code': '9999', 'name': 'Not real'},)),
+        ]
+        payload = serial_acquirers.generate(mergers)
+        assert payload['count'] == 0
+
+
+class TestAcquirerMatching:
+    def test_different_acquirers_do_not_pair(self):
+        mergers = [
+            _notification('MN-0001', 'Acme Pty Ltd', '2025-01-06T09:00:00Z'),
+            _notification('MN-0002', 'Zenith Pty Ltd', '2025-06-06T09:00:00Z'),
+        ]
+        payload = serial_acquirers.generate(mergers)
+        assert payload['count'] == 0
+
+    def test_fallback_name_normalisation_matches_company_suffix_variants(self):
+        mergers = [
+            _notification('MN-0001', 'Acme Holdings Pty Ltd', '2025-01-06T09:00:00Z'),
+            _notification('MN-0002', 'ACME HOLDINGS LIMITED', '2025-06-06T09:00:00Z'),
+        ]
+        payload = serial_acquirers.generate(mergers)
+        assert payload['count'] == 1
+        assert payload['acquirers'][0]['canonical_id'] is None
+
+    def test_canonical_group_link_takes_precedence_over_name(self):
+        # Two differently-named entities matched to the same canonical group
+        # via related_parties.json should still pair.
+        groups = [{
+            'id': 'acme-group',
+            'canonical_name': 'Acme Group',
+            'members': [
+                {'name': 'Acme Trading Pty Ltd', 'identifier': ''},
+                {'name': 'Acme Subco Pty Ltd', 'identifier': ''},
+            ],
+        }]
+        mergers = [
+            enrich_merger(_notification('MN-0001', 'Acme Trading Pty Ltd', '2025-01-06T09:00:00Z')),
+            enrich_merger(_notification('MN-0002', 'Acme Subco Pty Ltd', '2025-06-06T09:00:00Z')),
+        ]
+        link_related_parties(mergers, groups)
+        payload = serial_acquirers.generate(mergers)
+        assert payload['count'] == 1
+        record = payload['acquirers'][0]
+        assert record['canonical_id'] == 'acme-group'
+        assert record['acquirer_name'] == 'Acme Group'
+
+    def test_unnamed_acquirer_is_skipped(self):
+        mergers = [
+            _notification('MN-0001', '', '2025-01-06T09:00:00Z'),
+            _notification('MN-0002', '', '2025-06-06T09:00:00Z'),
+        ]
+        payload = serial_acquirers.generate(mergers)
+        assert payload['count'] == 0
+
+
+class TestFiltersAndSorting:
+    def test_waivers_are_excluded(self):
+        mergers = [
+            _notification('MN-0001', 'Acme Pty Ltd', '2025-01-06T09:00:00Z'),
+            _notification('WA-0002', 'Acme Pty Ltd', '2025-06-06T09:00:00Z', is_waiver=True),
+        ]
+        payload = serial_acquirers.generate(mergers)
+        assert payload['count'] == 0
+
+    def test_sorted_by_count_desc_then_most_recent_date(self):
+        mergers = [
+            # Acme: 2 notifications, most recent 2025-06-06
+            _notification('MN-0001', 'Acme Pty Ltd', '2025-01-06T09:00:00Z'),
+            _notification('MN-0002', 'Acme Pty Ltd', '2025-06-06T09:00:00Z'),
+            # Zenith: 3 notifications (higher count), most recent 2025-05-01
+            _notification('MN-0003', 'Zenith Pty Ltd', '2025-01-01T09:00:00Z', anzsic_codes=(BEVERAGE_CLASS,)),
+            _notification('MN-0004', 'Zenith Pty Ltd', '2025-03-01T09:00:00Z', anzsic_codes=(BEVERAGE_CLASS,)),
+            _notification('MN-0005', 'Zenith Pty Ltd', '2025-05-01T09:00:00Z', anzsic_codes=(BEVERAGE_CLASS,)),
+        ]
+        payload = serial_acquirers.generate(mergers)
+        assert payload['count'] == 2
+        assert [r['acquirer_name'] for r in payload['acquirers']] == ['Zenith Pty Ltd', 'Acme Pty Ltd']


### PR DESCRIPTION
## Summary
Implements detection of "serial acquirers" or "creeping acquisitions" — patterns where the same acquirer makes multiple notifications within a rolling 12-month window in the same ANZSIC industry. This addresses spec requirement #12 from the repo review and generates a new `serial-acquirers.json` output file.

## Key Changes
- **New module** `scripts/static_data/outputs/serial_acquirers.py`: Core logic for detecting and reporting serial acquisition patterns
  - Groups notifications by acquirer and ANZSIC code (rolled up to group level)
  - Detects when 2+ notifications fall within a 12-month rolling window
  - Handles ANZSIC class-to-group rollup and unknown codes gracefully
  - Supports canonical acquirer group linking via `link_related_parties()`
  - Falls back to name normalization for acquirer matching when no canonical group exists
  - Sorts results by notification count (descending) then most recent date

- **New test suite** `scripts/tests/test_serial_acquirers.py`: Comprehensive test coverage (205 lines)
  - Validates output shape and JSON serialization
  - Tests 12-month window detection with edge cases (6 months, 18 months, bridging gaps)
  - Verifies ANZSIC rollup behavior and cross-industry filtering
  - Tests acquirer matching including name normalization and canonical group precedence
  - Validates filtering (waivers excluded) and sorting behavior

- **New data file** `merger-tracker/frontend/public/data/serial-acquirers.json`: Generated output containing 20 serial acquirer records with metadata (acquirer name, canonical ID, ANZSIC code/name, merger IDs, notification dates, count)

- **Integration** into `scripts/generate_static_data.py`: Added to the static data generation pipeline

## Implementation Details
- Uses `parse_iso_datetime()` for date parsing and comparison
- Leverages existing `filter_notifications()` to exclude waivers and non-notifications
- ANZSIC resolution via the `anzsic` module with proper level detection (class vs. group)
- Acquirer key generation prioritizes canonical groups over name-based matching
- Efficient window detection using consecutive-pair checking on sorted dates

https://claude.ai/code/session_01EpPwhQmaq3bzVUgtC5hSc1