### PR TITLE
Add per-IP rate limiting to signup and feedback endpoints

### DIFF
--- a/cloudflare-worker/README.md
+++ b/cloudflare-worker/README.md
@@ -19,11 +19,26 @@ npm install
 wrangler d1 create mergers-feedback
 wrangler d1 execute mergers-feedback --file=schema.sql
 
+# Create the KV namespace used for rate limiting, copy its id into wrangler.toml
+wrangler kv namespace create RATE_LIMIT_KV
+
 # Set required secrets
 wrangler secret put RESEND_API_KEY
 wrangler secret put RESEND_AUDIENCE_ID
 wrangler secret put TURNSTILE_SECRET_KEY
 ```
+
+## Rate limiting
+
+Both endpoints enforce a per-IP fixed-window limit using the `RATE_LIMIT_KV`
+namespace (keyed on `CF-Connecting-IP`), on top of Turnstile:
+
+- `POST /` (signup): 5 requests per 10 minutes per IP.
+- `POST /feedback`: 5 requests per 10 minutes per IP, plus a 20-per-day cap
+  to bound D1 row growth from a single IP.
+
+Requests over the limit get a `429` with the same `{ "error": "..." }` shape
+as other validation errors, which the frontend already renders inline.
 
 ## Develop and deploy
 

--- a/cloudflare-worker/src/index.js
+++ b/cloudflare-worker/src/index.js
@@ -13,6 +13,9 @@
  * Required D1 binding (wrangler.toml):
  *   DB  — mergers-feedback D1 database
  *
+ * Required KV binding (wrangler.toml):
+ *   RATE_LIMIT_KV  — per-IP rate limit counters
+ *
  * To view feedback: Cloudflare Dashboard → D1 → mergers-feedback → Console
  *   SELECT * FROM feedback ORDER BY created_at DESC;
  */
@@ -53,6 +56,31 @@ function jsonResponse(body, status, origin = "", env = {}) {
 }
 
 // ---------------------------------------------------------------------------
+// Rate limiting: fixed-window counter in KV, keyed by IP + route
+// ---------------------------------------------------------------------------
+
+// Returns true if the request is within the limit, false if it should be
+// rejected with 429. KV is eventually consistent, so under concurrent bursts
+// the effective limit may be exceeded slightly — acceptable for abuse
+// prevention (this isn't a billing-critical limit).
+async function checkRateLimit(env, key, limit, windowSeconds) {
+  const now = Date.now();
+  const raw = await env.RATE_LIMIT_KV.get(key);
+  let entry = raw ? JSON.parse(raw) : null;
+
+  if (!entry || entry.resetAt <= now) {
+    entry = { count: 0, resetAt: now + windowSeconds * 1000 };
+  }
+
+  entry.count += 1;
+  await env.RATE_LIMIT_KV.put(key, JSON.stringify(entry), {
+    expirationTtl: Math.ceil((entry.resetAt - now) / 1000) + 1,
+  });
+
+  return entry.count <= limit;
+}
+
+// ---------------------------------------------------------------------------
 // Shared: verify Turnstile token
 // ---------------------------------------------------------------------------
 
@@ -75,6 +103,17 @@ async function verifyTurnstile(token, remoteIp, env) {
 // ---------------------------------------------------------------------------
 
 async function handleSubscribe(request, env, origin) {
+  const ip = request.headers.get("CF-Connecting-IP") || "unknown";
+  const withinLimit = await checkRateLimit(env, `signup:${ip}`, 5, 600);
+  if (!withinLimit) {
+    return jsonResponse(
+      { error: "Too many attempts. Please try again in a few minutes." },
+      429,
+      origin,
+      env
+    );
+  }
+
   let body;
   try {
     body = await request.json();
@@ -157,6 +196,26 @@ async function handleSubscribe(request, env, origin) {
 // ---------------------------------------------------------------------------
 
 async function handleFeedback(request, env, origin) {
+  const ip = request.headers.get("CF-Connecting-IP") || "unknown";
+  const withinBurstLimit = await checkRateLimit(env, `feedback:${ip}`, 5, 600);
+  if (!withinBurstLimit) {
+    return jsonResponse(
+      { error: "Too many attempts. Please try again in a few minutes." },
+      429,
+      origin,
+      env
+    );
+  }
+  const withinDailyLimit = await checkRateLimit(env, `feedback-daily:${ip}`, 20, 86400);
+  if (!withinDailyLimit) {
+    return jsonResponse(
+      { error: "You’ve reached today’s feedback limit. Please try again tomorrow." },
+      429,
+      origin,
+      env
+    );
+  }
+
   let body;
   try {
     body = await request.json();

--- a/cloudflare-worker/wrangler.toml
+++ b/cloudflare-worker/wrangler.toml
@@ -33,6 +33,14 @@ binding = "DB"
 database_name = "mergers-feedback"
 database_id = "e3eac500-d498-4be3-b0da-d80f0fa173cd"
 
+# KV namespace for per-IP rate limit counters (signup + feedback).
+# Setup:
+#   1. wrangler kv namespace create RATE_LIMIT_KV
+#   2. Copy the id from the output and paste it below
+[[kv_namespaces]]
+binding = "RATE_LIMIT_KV"
+id = "REPLACE_WITH_KV_NAMESPACE_ID"
+
 [vars]
 ENVIRONMENT = "production"
 


### PR DESCRIPTION
## Summary
This PR adds per-IP rate limiting to both the signup (`POST /`) and feedback (`POST /feedback`) endpoints using Cloudflare KV as a fixed-window counter store. This prevents abuse while maintaining a simple, eventually-consistent approach suitable for non-billing-critical limits.

## Key Changes
- **Rate limiting implementation**: Added `checkRateLimit()` function that uses KV to track request counts in fixed-window buckets, keyed by IP address and route
- **Signup endpoint**: Limited to 5 requests per 10 minutes per IP
- **Feedback endpoint**: Limited to 5 requests per 10 minutes per IP (burst limit) plus a 20-per-day cap to bound database growth
- **KV namespace binding**: Added `RATE_LIMIT_KV` binding to `wrangler.toml` with setup instructions
- **Documentation**: Updated README with rate limiting details and KV namespace setup steps

## Implementation Details
- Rate limit checks happen before request body parsing, failing fast with `429 Too Many Requests`
- Uses `CF-Connecting-IP` header to identify client IP (falls back to "unknown" if unavailable)
- KV entries include `count` and `resetAt` timestamp; entries auto-expire via `expirationTtl`
- Acknowledges eventual consistency of KV: under concurrent bursts, the effective limit may be slightly exceeded, which is acceptable for abuse prevention
- Error responses use the same `{ "error": "..." }` shape as other validation errors for consistent frontend handling

https://claude.ai/code/session_01WDwQSeJoaoJTHvbF2bHpW8