### PR TITLE
Add deadline utilisation analysis to static data outputs

### DIFF
--- a/merger-tracker/frontend/public/data/analysis.json
+++ b/merger-tracker/frontend/public/data/analysis.json
@@ -3415,5 +3415,34 @@
       "median_calendar_days": 24.5,
       "count": 10
     }
-  ]
+  ],
+  "deadline_utilisation": {
+    "histogram": {
+      "15": 33,
+      "16": 22,
+      "17": 15,
+      "18": 15,
+      "19": 9,
+      "20": 5,
+      "21": 3,
+      "22": 5,
+      "24": 2,
+      "25": 3,
+      "26": 1,
+      "27": 1,
+      "28": 5
+    },
+    "last_5_bd_counts": {
+      "2": 5,
+      "3": 1,
+      "4": 1
+    },
+    "stats": {
+      "mean_used_bd": 17.9,
+      "median_used_bd": 17,
+      "pct_decided_final_3_bd": 4.2,
+      "count": 119
+    },
+    "extended_count": 2
+  }
 }

--- a/scripts/static_data/outputs/analysis.py
+++ b/scripts/static_data/outputs/analysis.py
@@ -3,10 +3,17 @@
 from collections import defaultdict
 from statistics import median as stat_median
 
+from constants import merger_status
+
 from .. import anzsic
 from ..business_days import calculate_business_days, calculate_calendar_days
 from ..durations import collect_phase_1_durations, phase_1_end_date
 from ..filters import filter_notifications, filter_waivers
+
+# A Phase 1 window longer than this is an extension (e.g. public benefit
+# applications) rather than the standard 30-business-day clock, so it's
+# reported separately rather than folded into the "% of 30-day clock" stats.
+STANDARD_WINDOW_MAX_BD = 31
 
 
 def _division_for_code(code: str):
@@ -60,6 +67,80 @@ def industry_phase1_duration(mergers: list) -> list[dict]:
 
     results.sort(key=lambda x: -x['average_business_days'])
     return results
+
+
+def deadline_utilisation(mergers: list) -> dict:
+    """How much of the Phase 1 statutory clock the ACCC uses.
+
+    For every completed (non-referred) Phase 1 notification, measures
+    ``used_bd`` = business days from notification to the Phase 1 determination,
+    and, where ``end_of_determination_period`` is known, ``slack_bd`` = business
+    days remaining before the statutory deadline when the determination was
+    made. Matters whose window exceeds :data:`STANDARD_WINDOW_MAX_BD` (an
+    extension) are excluded from the histogram and stats and only counted via
+    ``extended_count``, since folding them in would distort the "% of 30-day
+    clock" framing.
+    """
+    used_days = []
+    slack_days = []  # only for standard-window matters with a known deadline
+    extended_count = 0
+
+    for m in filter_notifications(mergers):
+        det = m.get('phase_1_determination')
+        det_date = m.get('phase_1_determination_date')
+        start = m.get('effective_notification_datetime')
+        if not det or det == merger_status.REFERRED_TO_PHASE_2 or not det_date:
+            continue
+
+        used_bd = calculate_business_days(start, det_date)
+        if used_bd is None:
+            continue
+
+        deadline = m.get('end_of_determination_period')
+        window_bd = calculate_business_days(start, deadline) if deadline else None
+
+        if window_bd is not None and window_bd > STANDARD_WINDOW_MAX_BD:
+            extended_count += 1
+            continue
+
+        used_days.append(used_bd)
+        if window_bd is not None:
+            slack_days.append(window_bd - used_bd)
+
+    histogram = defaultdict(int)
+    for bd in used_days:
+        histogram[str(bd) if bd <= 30 else '30+'] += 1
+    histogram_sorted = dict(sorted(
+        histogram.items(),
+        key=lambda kv: 31 if kv[0] == '30+' else int(kv[0]),
+    ))
+
+    # Last 5 BDs before the deadline, keyed by BDs of slack remaining (0 = the
+    # determination landed on the deadline itself, up to 4 = five BDs early).
+    last_5_bd = defaultdict(int)
+    for slack in slack_days:
+        if 0 <= slack <= 4:
+            last_5_bd[str(slack)] += 1
+    last_5_bd_sorted = dict(sorted(last_5_bd.items(), key=lambda kv: int(kv[0])))
+
+    stats = {}
+    if used_days:
+        final_3_count = sum(1 for slack in slack_days if 0 <= slack <= 2)
+        stats = {
+            "mean_used_bd": round(sum(used_days) / len(used_days), 1),
+            "median_used_bd": stat_median(used_days),
+            "pct_decided_final_3_bd": (
+                round(final_3_count / len(slack_days) * 100, 1) if slack_days else None
+            ),
+            "count": len(used_days),
+        }
+
+    return {
+        "histogram": histogram_sorted,
+        "last_5_bd_counts": last_5_bd_sorted,
+        "stats": stats,
+        "extended_count": extended_count,
+    }
 
 
 def generate(mergers: list) -> dict:
@@ -208,4 +289,5 @@ def generate(mergers: list) -> dict:
         },
         "monthly_volume": monthly_volume,
         "industry_phase1_duration": industry_phase1_duration(mergers),
+        "deadline_utilisation": deadline_utilisation(mergers),
     }

--- a/scripts/tests/test_static_data_outputs.py
+++ b/scripts/tests/test_static_data_outputs.py
@@ -498,6 +498,7 @@ class TestAnalysisGenerate:
         json.dumps(payload)
         assert set(payload.keys()) == {
             'phase1_duration', 'waiver_duration', 'monthly_volume', 'industry_phase1_duration',
+            'deadline_utilisation',
         }
         assert 'scatter_data' in payload['phase1_duration']
         assert 'scatter_data' in payload['waiver_duration']
@@ -526,6 +527,97 @@ class TestAnalysisGenerate:
         mining = divisions[0]
         assert mining['name'] == 'Mining'
         assert mining['count'] == 1
+
+
+# ---------------------------------------------------------------------------
+# deadline_utilisation
+# ---------------------------------------------------------------------------
+
+def _deadline_merger(merger_id, det_date, deadline=None, determination='Approved'):
+    """A notification merger notified 2025-06-02T09:00:00Z (a Monday).
+
+    ``det_date`` and ``deadline`` are ISO datetimes for the Phase 1
+    determination and ``end_of_determination_period`` respectively.
+    """
+    return {
+        'merger_id': merger_id,
+        'merger_name': f'{merger_id} merger',
+        'status': 'Determined' if determination != merger_status.REFERRED_TO_PHASE_2 else 'Assessment completed',
+        'accc_determination': determination if determination != merger_status.REFERRED_TO_PHASE_2 else None,
+        'stage': 'Phase 1 - preliminary assessment',
+        'effective_notification_datetime': '2025-06-02T09:00:00Z',
+        'determination_publication_date': det_date if determination != merger_status.REFERRED_TO_PHASE_2 else None,
+        'end_of_determination_period': deadline,
+        'page_modified_datetime': det_date,
+        'anzsic_codes': [],
+        'acquirers': ['Acquirer'],
+        'targets': ['Target'],
+        'other_parties': [],
+        'url': f'https://example.com/{merger_id}',
+        'events': (
+            [{'title': 'Decision to Proceed to a Phase 2 review', 'date': det_date}]
+            if determination == merger_status.REFERRED_TO_PHASE_2 else []
+        ),
+    }
+
+
+def _deadline_utilisation_fixture():
+    """Notification 2025-06-02T09:00:00Z; a standard 30-BD window (deadline
+    2025-07-15). Determinations land at used_bd 30, 28, 26, 24 (slack 0, 2, 4,
+    6 respectively), plus an extended matter (45-BD window, used_bd 40) and a
+    Phase 2 referral (excluded entirely).
+    """
+    deadline = '2025-07-15T12:00:00Z'
+    return [
+        _deadline_merger('MN-1000', '2025-07-15T12:00:00Z', deadline),  # slack 0
+        _deadline_merger('MN-1001', '2025-07-11T12:00:00Z', deadline),  # slack 2
+        _deadline_merger('MN-1002', '2025-07-09T12:00:00Z', deadline),  # slack 4
+        _deadline_merger('MN-1003', '2025-07-07T12:00:00Z', deadline),  # slack 6
+        _deadline_merger('MN-1004', '2025-07-29T12:00:00Z', '2025-08-05T12:00:00Z'),  # extended
+        _deadline_merger('MN-1005', '2025-08-01T12:00:00Z', determination=merger_status.REFERRED_TO_PHASE_2),
+    ]
+
+
+class TestDeadlineUtilisationGenerate:
+    def test_histogram_buckets_used_bd_excludes_extended_and_referred(self):
+        enriched = [enrich_merger(m) for m in _deadline_utilisation_fixture()]
+        payload = analysis.deadline_utilisation(enriched)
+        assert payload['histogram'] == {'24': 1, '26': 1, '28': 1, '30': 1}
+
+    def test_last_5_bd_counts_keyed_by_slack_remaining(self):
+        enriched = [enrich_merger(m) for m in _deadline_utilisation_fixture()]
+        payload = analysis.deadline_utilisation(enriched)
+        # slack 0, 2 and 4 fall in the last-5-BD window; slack 6 does not.
+        assert payload['last_5_bd_counts'] == {'0': 1, '2': 1, '4': 1}
+
+    def test_extended_matter_counted_separately(self):
+        enriched = [enrich_merger(m) for m in _deadline_utilisation_fixture()]
+        payload = analysis.deadline_utilisation(enriched)
+        assert payload['extended_count'] == 1
+
+    def test_referral_excluded_entirely(self):
+        enriched = [enrich_merger(m) for m in _deadline_utilisation_fixture()]
+        payload = analysis.deadline_utilisation(enriched)
+        assert payload['stats']['count'] == 4
+        assert payload['extended_count'] == 1  # not 2 — the referral isn't counted here either
+
+    def test_stats_mean_median_and_final_3_pct(self):
+        enriched = [enrich_merger(m) for m in _deadline_utilisation_fixture()]
+        payload = analysis.deadline_utilisation(enriched)
+        stats = payload['stats']
+        assert stats['mean_used_bd'] == 27.0
+        assert stats['median_used_bd'] == 27
+        # 2 of the 4 standard matters (slack 0 and 2) landed in the final 3 BDs.
+        assert stats['pct_decided_final_3_bd'] == 50.0
+
+    def test_empty_input_returns_zeroed_shape(self):
+        payload = analysis.deadline_utilisation([])
+        assert payload == {
+            'histogram': {},
+            'last_5_bd_counts': {},
+            'stats': {},
+            'extended_count': 0,
+        }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
This PR adds a new `deadline_utilisation` analysis to the static data outputs, measuring how much of the Phase 1 statutory clock the ACCC uses when making merger determinations.

## Key Changes
- **New analysis function**: Added `deadline_utilisation()` in `analysis.py` that calculates:
  - Histogram of business days used from notification to determination
  - Count of determinations made in the final 5 business days (keyed by slack remaining)
  - Statistics including mean, median, and percentage decided in final 3 business days
  - Separate count of extended matters (window > 31 business days)
  
- **Extended matter handling**: Matters with windows exceeding the standard 30-business-day clock are excluded from histogram and stats to avoid distorting the "% of 30-day clock" framing, but are tracked separately via `extended_count`

- **Phase 2 referrals excluded**: Determinations that result in referral to Phase 2 are excluded entirely from the analysis

- **Integration**: Added `deadline_utilisation` to the main `generate()` payload output alongside existing analyses

- **Test coverage**: Comprehensive test suite covering:
  - Histogram bucketing excluding extended and referred matters
  - Last 5 business day counts keyed by slack remaining
  - Extended matter counting
  - Statistics calculations (mean, median, final 3 BD percentage)
  - Empty input handling

- **Data output**: Updated `analysis.json` with real deadline utilisation data showing 119 standard Phase 1 determinations with mean 17.9 business days used and 4.2% decided in final 3 business days

## Implementation Details
- Leverages existing `calculate_business_days()` utility for accurate business day calculations
- Uses `filter_notifications()` to focus on relevant merger records
- Handles cases where deadline information may be missing
- Sorts histogram and last_5_bd_counts for consistent output ordering

https://claude.ai/code/session_01LHrrdkand5F7Eg5dJyo3Fk