### PR TITLE
Add by_commission_division analysis to merger tracker

### DIFF
--- a/data/output/mergers.json
+++ b/data/output/mergers.json
@@ -2705,7 +2705,34 @@
           "url_gh": "/mergers/MN-01064/Carlyle BASF Coatings -Determination - 18 December 2025.pdf",
           "status": "live",
           "is_determination_event": true,
-          "phase": "Phase 1"
+          "phase": "Phase 1",
+          "determination_commission_division": "Determination made by a division of the Commission constituted by a direction issued pursuant to section 19 of the Act",
+          "determination_table_content": [
+            {
+              "item": "Notified acquisition",
+              "details": "Pursuant to section 51ABX(5) (Notifications may cover multiple\nacquisitions) of the Competition and Consumer Act 2010 (Cth), the\nACCC was notified that:\n\u2022 the Carlyle Group Inc., together with its controlled funds and\naffiliates (Carlyle), proposes to acquire sole control of BASF\nSE (the Seller)\u2019s Coatings division (BASF Coatings), through\nCarlyle\u2019s controlled entity, Bond UK Midco 4 (Carlyle\nacquisition), and\n\u2022 the Seller, through its wholly-owned direct subsidiary, BASF\nHandels- und Exportgesellschaft mbH, (BASF H&E) will\nreinvest in BASF Coatings at closing, acquiring a 40% non-\ncontrolling stake on a look-through basis (BASF acquisition),\ntogether, referred to as the Acquisition."
+            },
+            {
+              "item": "Determination",
+              "details": "The Australian Competition and Consumer Commission has\ndetermined under section 51ABZE(1) of the Competition and\nConsumer Act 2010 (Cth) that the Acquisition may be put into effect."
+            },
+            {
+              "item": "Parties to the Acquisition",
+              "details": "The Acquirers are:\n\u2022 Bond UK MidCo 4, a corporate entity ultimately owned by\ninvestment funds managed by Carlyle, and which is\ncontrolled by Carlyle. Carlyle is a global investment firm.\n\u2022 BASF H&E, a wholly owned direct subsidiary of the Seller,\nwhich is a German publicly listed chemical company.\nThe target, BASF Coatings, develops, produces and markets:\n\u2022 automotive coatings for both original equipment\nmanufacturer (OEM) and refinish applications, and\n\u2022 surface treatments for components used in various\nindustries including automotive OEM and component\nmanufacture, aerospace and construction equipment.\nBASF Coatings operates in Europe, North America, South America,\nAsia and Australia."
+            },
+            {
+              "item": "Overlap and relationship\nbetween the parties",
+              "details": "There are no horizontal overlaps or vertical relationships between\nBond UK MidCo 4 or Carlyle (including its connected entities) and\nBASF Coatings in Australia.\nBASF Coatings is currently owned and controlled by the Seller."
+            },
+            {
+              "item": "Reasons for determination",
+              "details": "When making a determination in Phase 1, the Australian Competition\nand Consumer Commission (ACCC) undertakes a competition\nassessment and considers whether it is appropriate for an\nacquisition to be approved or subject to further assessment in\nPhase 2 in accordance with section 51ABZJ of the Competition and\nConsumer Act 2010 (Cth) (the Act). In doing so, the ACCC must have\nregard to the object of the Act and all relevant matters, including the\ninterests of consumers.\nFor more information about the ACCC\u2019s approach to considering\nnotified acquisitions, see the ACCC\u2019s merger assessment guidelines\nand interim merger process guidelines.\nIn conducting its competition assessment, the ACCC has considered\nthe information and documents that were submitted with the\nnotification form. The Acquisition was notified to the ACCC as a\nsingle notification and the ACCC has assessed it as if it constituted\na single acquisition, consistent with s 51ABX(5) of the Act.\nThe ACCC has determined that the Acquisition may be put into\neffect as it considers that the Acquisition is unlikely to have the\neffect of substantially lessening competition in any market in\nAustralia. In reaching its decision, and based on the material before\nit, the ACCC makes the following findings:\n\u2022 There are no horizontal overlaps in activities or vertical\nrelationships between Carlyle (including its connected\nentities) and BASF Coatings in Australia.\n\u2022 The Seller currently owns and controls 100% of BASF\nCoatings. Following the Acquisition, the Seller will no longer\ncontrol BASF Coatings.\n\u2022 While Carlyle has investments in some overseas industrial\nbusinesses that could be viewed as complementary with\nBASF Coatings, these businesses have neither operations\nnor a material customer base in Australia. The ACCC\nconsiders that, based on the information available, the\nAcquisition is not likely to lead to conglomerate competition\nconcerns in Australia."
+            },
+            {
+              "item": "Applications for review",
+              "details": "A notifying party, or other person who has been allowed to do so by\nthe Australian Competition Tribunal, may apply for review if they are\ndissatisfied with the determination. Pursuant to section 100C of the\nAct, applications for review of the determination are to be made to\nthe Australian Competition Tribunal before the end of 14 calendar\ndays after this statement of reasons was included on the ACCC\u2019s\nAcquisitions Register. To confirm whether there has been any\napplication for review, please contact the Australian Competition\nTribunal."
+            }
+          ]
         }
       ],
       "is_waiver": false,
@@ -13587,6 +13614,7 @@
           ],
           "url_gh": "/mergers/MN-30002/Wakeling Automotive - Phase 2 notice - 2 June 2026_0.pdf",
           "status": "live",
+          "phase2_notice_commission_division": "Decision made by a division of the Commission constituted by a direction issued pursuant to section 19 of the Competition and Consumer Act 2010 (Cth)",
           "phase": "Phase 2"
         },
         {
@@ -27891,7 +27919,34 @@
           "url_gh": "/mergers/MN-75012/Phase 1 Determination - Opal HealthCare \u2013 Greenwich Place residential aged care home.pdf",
           "status": "live",
           "is_determination_event": true,
-          "phase": "Phase 1"
+          "phase": "Phase 1",
+          "determination_commission_division": "Determination made by Commissioner Philip Williams pursuant to a delegation under section 25(1) of the Act",
+          "determination_table_content": [
+            {
+              "item": "Notified acquisition",
+              "details": "DPG Services Pty Ltd (DPG) and OHCA Property Holdings Pty Ltd\n(OHCA) (being related bodies corporate, and together referred to\nas Opal Healthcare) propose to acquire the land, assets and\nbusiness comprising the Greenwich Place residential aged care\nhome located in Greenwich, Sydney (Greenwich Place) (the\nAcquisition)."
+            },
+            {
+              "item": "Determination",
+              "details": "The Australian Competition and Consumer Commission has\ndetermined under section 51ABZE(1) of the Competition and\nConsumer Act 2010 (Cth) that the Acquisition may be put into effect."
+            },
+            {
+              "item": "Parties to the Acquisition",
+              "details": "The acquirer, Opal Healthcare, owns and operates 145 residential\naged care homes across New South Wales, Victoria, Queensland,\nWestern Australia and South Australia.\nOpal Healthcare has existing facilities near Greenwich Place, being\nLandsdowne Gardens and Landsdowne Gardens on Wycombe,\nwhich are both in Neutral Bay.\nThe target, Greenwich Place, is a privately-owned, single approved\nresidential care home with 90 beds, located at 33 Greenwich Rd,\nGreenwich in New South Wales. Greenwich Place provides the\nservices required under the Aged Care Act 2024 (Cth), including\npermanent care, respite care and palliative care. The sellers are\nGreenwich Place Pty Ltd, Greenwich Care Pty Limited and Stamen\nGreenwich Property Ltd."
+            },
+            {
+              "item": "Overlap between the\nparties",
+              "details": "Opal Healthcare and Greenwich Place overlap in the supply of\nresidential aged care facilities in Sydney."
+            },
+            {
+              "item": "Reasons for determination",
+              "details": "When making a determination in Phase 1, the Australian Competition\nand Consumer Commission (ACCC) undertakes a competition\nassessment and considers whether it is appropriate for an\nacquisition to be approved or subject to further assessment in\nPhase 2 in accordance with section 51ABZJ of the Competition and\nConsumer Act 2010 (Cth) (the Act). In doing so, the ACCC must have\nregard to the object of the Act and all relevant matters, including the\ninterests of consumers.\nFor more information about the ACCC\u2019s approach to considering\nnotified acquisitions, see the ACCC\u2019s merger assessment guidelines\nand interim merger process guidelines.\nIn conducting its competition assessment, the ACCC has considered\nthe information and documents that were submitted with the\nnotification form, information from third partes, and publicly\navailable information.\nThe ACCC has determined that the Acquisition may be put into\neffect as it considers that the Acquisition is unlikely to have the\neffect of substantially lessening competition in any market. In\nreaching its decision, and based on the material before it, the ACCC\nmakes the following findings.\n\u2022 The aggregation arising from the Acquisition, and taking into\naccount previous acquisitions by Opal Healthcare within the\nsame local area in the last three years, is not significant at a\nlocal or regional level (or at the national level).\n\u2022 Opal Healthcare will likely continue to face competition from\nalternative suppliers of residential aged care facilities in the\nlocal area surrounding Greenwich Place."
+            },
+            {
+              "item": "Applications for review",
+              "details": "A notifying party, or other person who has been allowed to do so by\nthe Australian Competition Tribunal, may apply for review if they are\ndissatisfied with the determination. Pursuant to section 100C of the\nAct, applications for review of the determination are to be made to\nthe Australian Competition Tribunal before the end of 14 calendar\ndays after this statement of reasons was included on the ACCC\u2019s\nAcquisitions Register. To confirm whether there has been any\napplication for review, please contact the Australian Competition\nTribunal."
+            }
+          ]
         }
       ],
       "is_waiver": false,

--- a/data/processed/mergers.json
+++ b/data/processed/mergers.json
@@ -1972,7 +1972,34 @@
         "url_gh": "/mergers/MN-01064/Carlyle BASF Coatings -Determination - 18 December 2025.pdf",
         "status": "live",
         "is_determination_event": true,
-        "phase": "Phase 1"
+        "phase": "Phase 1",
+        "determination_commission_division": "Determination made by a division of the Commission constituted by a direction issued pursuant to section 19 of the Act",
+        "determination_table_content": [
+          {
+            "item": "Notified acquisition",
+            "details": "Pursuant to section 51ABX(5) (Notifications may cover multiple\nacquisitions) of the Competition and Consumer Act 2010 (Cth), the\nACCC was notified that:\n\u2022 the Carlyle Group Inc., together with its controlled funds and\naffiliates (Carlyle), proposes to acquire sole control of BASF\nSE (the Seller)\u2019s Coatings division (BASF Coatings), through\nCarlyle\u2019s controlled entity, Bond UK Midco 4 (Carlyle\nacquisition), and\n\u2022 the Seller, through its wholly-owned direct subsidiary, BASF\nHandels- und Exportgesellschaft mbH, (BASF H&E) will\nreinvest in BASF Coatings at closing, acquiring a 40% non-\ncontrolling stake on a look-through basis (BASF acquisition),\ntogether, referred to as the Acquisition."
+          },
+          {
+            "item": "Determination",
+            "details": "The Australian Competition and Consumer Commission has\ndetermined under section 51ABZE(1) of the Competition and\nConsumer Act 2010 (Cth) that the Acquisition may be put into effect."
+          },
+          {
+            "item": "Parties to the Acquisition",
+            "details": "The Acquirers are:\n\u2022 Bond UK MidCo 4, a corporate entity ultimately owned by\ninvestment funds managed by Carlyle, and which is\ncontrolled by Carlyle. Carlyle is a global investment firm.\n\u2022 BASF H&E, a wholly owned direct subsidiary of the Seller,\nwhich is a German publicly listed chemical company.\nThe target, BASF Coatings, develops, produces and markets:\n\u2022 automotive coatings for both original equipment\nmanufacturer (OEM) and refinish applications, and\n\u2022 surface treatments for components used in various\nindustries including automotive OEM and component\nmanufacture, aerospace and construction equipment.\nBASF Coatings operates in Europe, North America, South America,\nAsia and Australia."
+          },
+          {
+            "item": "Overlap and relationship\nbetween the parties",
+            "details": "There are no horizontal overlaps or vertical relationships between\nBond UK MidCo 4 or Carlyle (including its connected entities) and\nBASF Coatings in Australia.\nBASF Coatings is currently owned and controlled by the Seller."
+          },
+          {
+            "item": "Reasons for determination",
+            "details": "When making a determination in Phase 1, the Australian Competition\nand Consumer Commission (ACCC) undertakes a competition\nassessment and considers whether it is appropriate for an\nacquisition to be approved or subject to further assessment in\nPhase 2 in accordance with section 51ABZJ of the Competition and\nConsumer Act 2010 (Cth) (the Act). In doing so, the ACCC must have\nregard to the object of the Act and all relevant matters, including the\ninterests of consumers.\nFor more information about the ACCC\u2019s approach to considering\nnotified acquisitions, see the ACCC\u2019s merger assessment guidelines\nand interim merger process guidelines.\nIn conducting its competition assessment, the ACCC has considered\nthe information and documents that were submitted with the\nnotification form. The Acquisition was notified to the ACCC as a\nsingle notification and the ACCC has assessed it as if it constituted\na single acquisition, consistent with s 51ABX(5) of the Act.\nThe ACCC has determined that the Acquisition may be put into\neffect as it considers that the Acquisition is unlikely to have the\neffect of substantially lessening competition in any market in\nAustralia. In reaching its decision, and based on the material before\nit, the ACCC makes the following findings:\n\u2022 There are no horizontal overlaps in activities or vertical\nrelationships between Carlyle (including its connected\nentities) and BASF Coatings in Australia.\n\u2022 The Seller currently owns and controls 100% of BASF\nCoatings. Following the Acquisition, the Seller will no longer\ncontrol BASF Coatings.\n\u2022 While Carlyle has investments in some overseas industrial\nbusinesses that could be viewed as complementary with\nBASF Coatings, these businesses have neither operations\nnor a material customer base in Australia. The ACCC\nconsiders that, based on the information available, the\nAcquisition is not likely to lead to conglomerate competition\nconcerns in Australia."
+          },
+          {
+            "item": "Applications for review",
+            "details": "A notifying party, or other person who has been allowed to do so by\nthe Australian Competition Tribunal, may apply for review if they are\ndissatisfied with the determination. Pursuant to section 100C of the\nAct, applications for review of the determination are to be made to\nthe Australian Competition Tribunal before the end of 14 calendar\ndays after this statement of reasons was included on the ACCC\u2019s\nAcquisitions Register. To confirm whether there has been any\napplication for review, please contact the Australian Competition\nTribunal."
+          }
+        ]
       }
     ],
     "is_waiver": false
@@ -8346,7 +8373,8 @@
           }
         ],
         "url_gh": "/mergers/MN-30002/Wakeling Automotive - Phase 2 notice - 2 June 2026_0.pdf",
-        "status": "live"
+        "status": "live",
+        "phase2_notice_commission_division": "Decision made by a division of the Commission constituted by a direction issued pursuant to section 19 of the Competition and Consumer Act 2010 (Cth)"
       },
       {
         "date": "2026-06-15T12:00:00Z",
@@ -16383,7 +16411,34 @@
         "url_gh": "/mergers/MN-75012/Phase 1 Determination - Opal HealthCare \u2013 Greenwich Place residential aged care home.pdf",
         "status": "live",
         "is_determination_event": true,
-        "phase": "Phase 1"
+        "phase": "Phase 1",
+        "determination_commission_division": "Determination made by Commissioner Philip Williams pursuant to a delegation under section 25(1) of the Act",
+        "determination_table_content": [
+          {
+            "item": "Notified acquisition",
+            "details": "DPG Services Pty Ltd (DPG) and OHCA Property Holdings Pty Ltd\n(OHCA) (being related bodies corporate, and together referred to\nas Opal Healthcare) propose to acquire the land, assets and\nbusiness comprising the Greenwich Place residential aged care\nhome located in Greenwich, Sydney (Greenwich Place) (the\nAcquisition)."
+          },
+          {
+            "item": "Determination",
+            "details": "The Australian Competition and Consumer Commission has\ndetermined under section 51ABZE(1) of the Competition and\nConsumer Act 2010 (Cth) that the Acquisition may be put into effect."
+          },
+          {
+            "item": "Parties to the Acquisition",
+            "details": "The acquirer, Opal Healthcare, owns and operates 145 residential\naged care homes across New South Wales, Victoria, Queensland,\nWestern Australia and South Australia.\nOpal Healthcare has existing facilities near Greenwich Place, being\nLandsdowne Gardens and Landsdowne Gardens on Wycombe,\nwhich are both in Neutral Bay.\nThe target, Greenwich Place, is a privately-owned, single approved\nresidential care home with 90 beds, located at 33 Greenwich Rd,\nGreenwich in New South Wales. Greenwich Place provides the\nservices required under the Aged Care Act 2024 (Cth), including\npermanent care, respite care and palliative care. The sellers are\nGreenwich Place Pty Ltd, Greenwich Care Pty Limited and Stamen\nGreenwich Property Ltd."
+          },
+          {
+            "item": "Overlap between the\nparties",
+            "details": "Opal Healthcare and Greenwich Place overlap in the supply of\nresidential aged care facilities in Sydney."
+          },
+          {
+            "item": "Reasons for determination",
+            "details": "When making a determination in Phase 1, the Australian Competition\nand Consumer Commission (ACCC) undertakes a competition\nassessment and considers whether it is appropriate for an\nacquisition to be approved or subject to further assessment in\nPhase 2 in accordance with section 51ABZJ of the Competition and\nConsumer Act 2010 (Cth) (the Act). In doing so, the ACCC must have\nregard to the object of the Act and all relevant matters, including the\ninterests of consumers.\nFor more information about the ACCC\u2019s approach to considering\nnotified acquisitions, see the ACCC\u2019s merger assessment guidelines\nand interim merger process guidelines.\nIn conducting its competition assessment, the ACCC has considered\nthe information and documents that were submitted with the\nnotification form, information from third partes, and publicly\navailable information.\nThe ACCC has determined that the Acquisition may be put into\neffect as it considers that the Acquisition is unlikely to have the\neffect of substantially lessening competition in any market. In\nreaching its decision, and based on the material before it, the ACCC\nmakes the following findings.\n\u2022 The aggregation arising from the Acquisition, and taking into\naccount previous acquisitions by Opal Healthcare within the\nsame local area in the last three years, is not significant at a\nlocal or regional level (or at the national level).\n\u2022 Opal Healthcare will likely continue to face competition from\nalternative suppliers of residential aged care facilities in the\nlocal area surrounding Greenwich Place."
+          },
+          {
+            "item": "Applications for review",
+            "details": "A notifying party, or other person who has been allowed to do so by\nthe Australian Competition Tribunal, may apply for review if they are\ndissatisfied with the determination. Pursuant to section 100C of the\nAct, applications for review of the determination are to be made to\nthe Australian Competition Tribunal before the end of 14 calendar\ndays after this statement of reasons was included on the ACCC\u2019s\nAcquisitions Register. To confirm whether there has been any\napplication for review, please contact the Australian Competition\nTribunal."
+          }
+        ]
       }
     ],
     "is_waiver": false

--- a/merger-tracker/frontend/public/data/analysis.json
+++ b/merger-tracker/frontend/public/data/analysis.json
@@ -3436,10 +3436,9 @@
       "median_phase_1_business_days": 18
     },
     {
-      "division": "Unknown",
-      "count": 43,
+      "division": "Not yet determined",
+      "count": 41,
       "outcome_mix": {
-        "Approved": 2,
         "Unknown": 41
       },
       "median_phase_1_business_days": 37.5
@@ -3460,6 +3459,14 @@
         "Approved": 2
       },
       "median_phase_1_business_days": null
+    },
+    {
+      "division": "Unknown",
+      "count": 2,
+      "outcome_mix": {
+        "Approved": 2
+      },
+      "median_phase_1_business_days": 40.0
     }
   ],
   "deadline_utilisation": {

--- a/merger-tracker/frontend/public/data/analysis.json
+++ b/merger-tracker/frontend/public/data/analysis.json
@@ -3418,12 +3418,12 @@
   ],
   "by_commission_division": [
     {
-      "division": "Determination made by Commissioner Williams pursuant to a delegation under section 25(1) of the Act",
-      "count": 245,
+      "division": "Commissioner Williams",
+      "count": 271,
       "outcome_mix": {
-        "Approved": 245
+        "Approved": 271
       },
-      "median_phase_1_business_days": 16.0
+      "median_phase_1_business_days": 16
     },
     {
       "division": "Determination made by a division of the Commission constituted by a direction issued pursuant to section 19 of the Act",
@@ -3444,43 +3444,19 @@
       "median_phase_1_business_days": 29
     },
     {
-      "division": "Determination made by Commissioner Philip Williams pursuant to a delegation under section 25(1) of the Act",
-      "count": 23,
+      "division": "Commissioner Woodward",
+      "count": 24,
       "outcome_mix": {
-        "Approved": 23
-      },
-      "median_phase_1_business_days": 16.5
-    },
-    {
-      "division": "Determination made by Commissioner Woodward pursuant to a delegation under section 25(1) of the Act",
-      "count": 23,
-      "outcome_mix": {
-        "Approved": 22,
+        "Approved": 23,
         "Not approved": 1
       },
       "median_phase_1_business_days": 18
     },
     {
-      "division": "Determination made by Commissioner Williams pursuant to a delegation under section 25(1)",
-      "count": 3,
-      "outcome_mix": {
-        "Approved": 3
-      },
-      "median_phase_1_business_days": 16
-    },
-    {
-      "division": "Determination made by Chair Cass-Gottlieb pursuant to a delegation under section 25(1) of the Act",
+      "division": "Chair Cass-Gottlieb",
       "count": 2,
       "outcome_mix": {
         "Approved": 2
-      },
-      "median_phase_1_business_days": null
-    },
-    {
-      "division": "Determination made by Commissioner Luke Woodward pursuant to a delegation under section 25(1) of the Act",
-      "count": 1,
-      "outcome_mix": {
-        "Approved": 1
       },
       "median_phase_1_business_days": null
     }

--- a/merger-tracker/frontend/public/data/analysis.json
+++ b/merger-tracker/frontend/public/data/analysis.json
@@ -3415,5 +3415,74 @@
       "median_calendar_days": 24.5,
       "count": 10
     }
+  ],
+  "by_commission_division": [
+    {
+      "division": "Determination made by Commissioner Williams pursuant to a delegation under section 25(1) of the Act",
+      "count": 245,
+      "outcome_mix": {
+        "Approved": 245
+      },
+      "median_phase_1_business_days": 16.0
+    },
+    {
+      "division": "Determination made by a division of the Commission constituted by a direction issued pursuant to section 19 of the Act",
+      "count": 75,
+      "outcome_mix": {
+        "Approved": 61,
+        "Not approved": 14
+      },
+      "median_phase_1_business_days": 18
+    },
+    {
+      "division": "Unknown",
+      "count": 46,
+      "outcome_mix": {
+        "Approved": 4,
+        "Unknown": 42
+      },
+      "median_phase_1_business_days": 29
+    },
+    {
+      "division": "Determination made by Commissioner Philip Williams pursuant to a delegation under section 25(1) of the Act",
+      "count": 23,
+      "outcome_mix": {
+        "Approved": 23
+      },
+      "median_phase_1_business_days": 16.5
+    },
+    {
+      "division": "Determination made by Commissioner Woodward pursuant to a delegation under section 25(1) of the Act",
+      "count": 23,
+      "outcome_mix": {
+        "Approved": 22,
+        "Not approved": 1
+      },
+      "median_phase_1_business_days": 18
+    },
+    {
+      "division": "Determination made by Commissioner Williams pursuant to a delegation under section 25(1)",
+      "count": 3,
+      "outcome_mix": {
+        "Approved": 3
+      },
+      "median_phase_1_business_days": 16
+    },
+    {
+      "division": "Determination made by Chair Cass-Gottlieb pursuant to a delegation under section 25(1) of the Act",
+      "count": 2,
+      "outcome_mix": {
+        "Approved": 2
+      },
+      "median_phase_1_business_days": null
+    },
+    {
+      "division": "Determination made by Commissioner Luke Woodward pursuant to a delegation under section 25(1) of the Act",
+      "count": 1,
+      "outcome_mix": {
+        "Approved": 1
+      },
+      "median_phase_1_business_days": null
+    }
   ]
 }

--- a/merger-tracker/frontend/public/data/analysis.json
+++ b/merger-tracker/frontend/public/data/analysis.json
@@ -3419,29 +3419,30 @@
   "by_commission_division": [
     {
       "division": "Commissioner Williams",
-      "count": 271,
+      "count": 272,
       "outcome_mix": {
-        "Approved": 271
+        "Approved": 272
       },
-      "median_phase_1_business_days": 16
+      "median_phase_1_business_days": 16.0
     },
     {
-      "division": "Determination made by a division of the Commission constituted by a direction issued pursuant to section 19 of the Act",
-      "count": 75,
+      "division": "A division of the Commission (s19 direction)",
+      "count": 77,
       "outcome_mix": {
-        "Approved": 61,
-        "Not approved": 14
+        "Approved": 62,
+        "Not approved": 14,
+        "Unknown": 1
       },
       "median_phase_1_business_days": 18
     },
     {
       "division": "Unknown",
-      "count": 46,
+      "count": 43,
       "outcome_mix": {
-        "Approved": 4,
-        "Unknown": 42
+        "Approved": 2,
+        "Unknown": 41
       },
-      "median_phase_1_business_days": 29
+      "median_phase_1_business_days": 37.5
     },
     {
       "division": "Commissioner Woodward",

--- a/merger-tracker/frontend/public/data/mergers/MN-01064.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-01064.json
@@ -62,7 +62,34 @@
       "url_gh": "/mergers/MN-01064/Carlyle BASF Coatings -Determination - 18 December 2025.pdf",
       "status": "live",
       "is_determination_event": true,
-      "phase": "Phase 1"
+      "phase": "Phase 1",
+      "determination_commission_division": "Determination made by a division of the Commission constituted by a direction issued pursuant to section 19 of the Act",
+      "determination_table_content": [
+        {
+          "item": "Notified acquisition",
+          "details": "Pursuant to section 51ABX(5) (Notifications may cover multiple\nacquisitions) of the Competition and Consumer Act 2010 (Cth), the\nACCC was notified that:\n\u2022 the Carlyle Group Inc., together with its controlled funds and\naffiliates (Carlyle), proposes to acquire sole control of BASF\nSE (the Seller)\u2019s Coatings division (BASF Coatings), through\nCarlyle\u2019s controlled entity, Bond UK Midco 4 (Carlyle\nacquisition), and\n\u2022 the Seller, through its wholly-owned direct subsidiary, BASF\nHandels- und Exportgesellschaft mbH, (BASF H&E) will\nreinvest in BASF Coatings at closing, acquiring a 40% non-\ncontrolling stake on a look-through basis (BASF acquisition),\ntogether, referred to as the Acquisition."
+        },
+        {
+          "item": "Determination",
+          "details": "The Australian Competition and Consumer Commission has\ndetermined under section 51ABZE(1) of the Competition and\nConsumer Act 2010 (Cth) that the Acquisition may be put into effect."
+        },
+        {
+          "item": "Parties to the Acquisition",
+          "details": "The Acquirers are:\n\u2022 Bond UK MidCo 4, a corporate entity ultimately owned by\ninvestment funds managed by Carlyle, and which is\ncontrolled by Carlyle. Carlyle is a global investment firm.\n\u2022 BASF H&E, a wholly owned direct subsidiary of the Seller,\nwhich is a German publicly listed chemical company.\nThe target, BASF Coatings, develops, produces and markets:\n\u2022 automotive coatings for both original equipment\nmanufacturer (OEM) and refinish applications, and\n\u2022 surface treatments for components used in various\nindustries including automotive OEM and component\nmanufacture, aerospace and construction equipment.\nBASF Coatings operates in Europe, North America, South America,\nAsia and Australia."
+        },
+        {
+          "item": "Overlap and relationship\nbetween the parties",
+          "details": "There are no horizontal overlaps or vertical relationships between\nBond UK MidCo 4 or Carlyle (including its connected entities) and\nBASF Coatings in Australia.\nBASF Coatings is currently owned and controlled by the Seller."
+        },
+        {
+          "item": "Reasons for determination",
+          "details": "When making a determination in Phase 1, the Australian Competition\nand Consumer Commission (ACCC) undertakes a competition\nassessment and considers whether it is appropriate for an\nacquisition to be approved or subject to further assessment in\nPhase 2 in accordance with section 51ABZJ of the Competition and\nConsumer Act 2010 (Cth) (the Act). In doing so, the ACCC must have\nregard to the object of the Act and all relevant matters, including the\ninterests of consumers.\nFor more information about the ACCC\u2019s approach to considering\nnotified acquisitions, see the ACCC\u2019s merger assessment guidelines\nand interim merger process guidelines.\nIn conducting its competition assessment, the ACCC has considered\nthe information and documents that were submitted with the\nnotification form. The Acquisition was notified to the ACCC as a\nsingle notification and the ACCC has assessed it as if it constituted\na single acquisition, consistent with s 51ABX(5) of the Act.\nThe ACCC has determined that the Acquisition may be put into\neffect as it considers that the Acquisition is unlikely to have the\neffect of substantially lessening competition in any market in\nAustralia. In reaching its decision, and based on the material before\nit, the ACCC makes the following findings:\n\u2022 There are no horizontal overlaps in activities or vertical\nrelationships between Carlyle (including its connected\nentities) and BASF Coatings in Australia.\n\u2022 The Seller currently owns and controls 100% of BASF\nCoatings. Following the Acquisition, the Seller will no longer\ncontrol BASF Coatings.\n\u2022 While Carlyle has investments in some overseas industrial\nbusinesses that could be viewed as complementary with\nBASF Coatings, these businesses have neither operations\nnor a material customer base in Australia. The ACCC\nconsiders that, based on the information available, the\nAcquisition is not likely to lead to conglomerate competition\nconcerns in Australia."
+        },
+        {
+          "item": "Applications for review",
+          "details": "A notifying party, or other person who has been allowed to do so by\nthe Australian Competition Tribunal, may apply for review if they are\ndissatisfied with the determination. Pursuant to section 100C of the\nAct, applications for review of the determination are to be made to\nthe Australian Competition Tribunal before the end of 14 calendar\ndays after this statement of reasons was included on the ACCC\u2019s\nAcquisitions Register. To confirm whether there has been any\napplication for review, please contact the Australian Competition\nTribunal."
+        }
+      ]
     }
   ],
   "is_waiver": false,

--- a/merger-tracker/frontend/public/data/mergers/MN-30002.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-30002.json
@@ -131,6 +131,7 @@
       ],
       "url_gh": "/mergers/MN-30002/Wakeling Automotive - Phase 2 notice - 2 June 2026_0.pdf",
       "status": "live",
+      "phase2_notice_commission_division": "Decision made by a division of the Commission constituted by a direction issued pursuant to section 19 of the Competition and Consumer Act 2010 (Cth)",
       "phase": "Phase 2"
     },
     {

--- a/merger-tracker/frontend/public/data/mergers/MN-75012.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-75012.json
@@ -73,7 +73,34 @@
       "url_gh": "/mergers/MN-75012/Phase 1 Determination - Opal HealthCare \u2013 Greenwich Place residential aged care home.pdf",
       "status": "live",
       "is_determination_event": true,
-      "phase": "Phase 1"
+      "phase": "Phase 1",
+      "determination_commission_division": "Determination made by Commissioner Philip Williams pursuant to a delegation under section 25(1) of the Act",
+      "determination_table_content": [
+        {
+          "item": "Notified acquisition",
+          "details": "DPG Services Pty Ltd (DPG) and OHCA Property Holdings Pty Ltd\n(OHCA) (being related bodies corporate, and together referred to\nas Opal Healthcare) propose to acquire the land, assets and\nbusiness comprising the Greenwich Place residential aged care\nhome located in Greenwich, Sydney (Greenwich Place) (the\nAcquisition)."
+        },
+        {
+          "item": "Determination",
+          "details": "The Australian Competition and Consumer Commission has\ndetermined under section 51ABZE(1) of the Competition and\nConsumer Act 2010 (Cth) that the Acquisition may be put into effect."
+        },
+        {
+          "item": "Parties to the Acquisition",
+          "details": "The acquirer, Opal Healthcare, owns and operates 145 residential\naged care homes across New South Wales, Victoria, Queensland,\nWestern Australia and South Australia.\nOpal Healthcare has existing facilities near Greenwich Place, being\nLandsdowne Gardens and Landsdowne Gardens on Wycombe,\nwhich are both in Neutral Bay.\nThe target, Greenwich Place, is a privately-owned, single approved\nresidential care home with 90 beds, located at 33 Greenwich Rd,\nGreenwich in New South Wales. Greenwich Place provides the\nservices required under the Aged Care Act 2024 (Cth), including\npermanent care, respite care and palliative care. The sellers are\nGreenwich Place Pty Ltd, Greenwich Care Pty Limited and Stamen\nGreenwich Property Ltd."
+        },
+        {
+          "item": "Overlap between the\nparties",
+          "details": "Opal Healthcare and Greenwich Place overlap in the supply of\nresidential aged care facilities in Sydney."
+        },
+        {
+          "item": "Reasons for determination",
+          "details": "When making a determination in Phase 1, the Australian Competition\nand Consumer Commission (ACCC) undertakes a competition\nassessment and considers whether it is appropriate for an\nacquisition to be approved or subject to further assessment in\nPhase 2 in accordance with section 51ABZJ of the Competition and\nConsumer Act 2010 (Cth) (the Act). In doing so, the ACCC must have\nregard to the object of the Act and all relevant matters, including the\ninterests of consumers.\nFor more information about the ACCC\u2019s approach to considering\nnotified acquisitions, see the ACCC\u2019s merger assessment guidelines\nand interim merger process guidelines.\nIn conducting its competition assessment, the ACCC has considered\nthe information and documents that were submitted with the\nnotification form, information from third partes, and publicly\navailable information.\nThe ACCC has determined that the Acquisition may be put into\neffect as it considers that the Acquisition is unlikely to have the\neffect of substantially lessening competition in any market. In\nreaching its decision, and based on the material before it, the ACCC\nmakes the following findings.\n\u2022 The aggregation arising from the Acquisition, and taking into\naccount previous acquisitions by Opal Healthcare within the\nsame local area in the last three years, is not significant at a\nlocal or regional level (or at the national level).\n\u2022 Opal Healthcare will likely continue to face competition from\nalternative suppliers of residential aged care facilities in the\nlocal area surrounding Greenwich Place."
+        },
+        {
+          "item": "Applications for review",
+          "details": "A notifying party, or other person who has been allowed to do so by\nthe Australian Competition Tribunal, may apply for review if they are\ndissatisfied with the determination. Pursuant to section 100C of the\nAct, applications for review of the determination are to be made to\nthe Australian Competition Tribunal before the end of 14 calendar\ndays after this statement of reasons was included on the ACCC\u2019s\nAcquisitions Register. To confirm whether there has been any\napplication for review, please contact the Australian Competition\nTribunal."
+        }
+      ]
     }
   ],
   "is_waiver": false,

--- a/scripts/extract_mergers.py
+++ b/scripts/extract_mergers.py
@@ -128,6 +128,23 @@ def is_safe_url(url):
             and (hostname == 'accc.gov.au' or hostname.endswith('.accc.gov.au')))
 
 
+def _is_determination_attachment(event_title: str | None, filename: str) -> bool:
+    """Whether an attachment is a determination PDF worth parsing for a
+    commission-division sentence and table content.
+
+    The event title doesn't always say "determination" — some are titled
+    with just the merger name (e.g. "Carlyle - BASF Coatings") even though
+    the attached PDF plainly is one — so this also falls back to the
+    attachment's own filename, which reliably does (e.g. "Foo -
+    Determination - 1 Jan 2026.pdf").
+    """
+    if not filename.lower().endswith('.pdf'):
+        return False
+    if event_title and 'determination' in event_title.lower():
+        return True
+    return 'determination' in filename.lower()
+
+
 def download_attachment(merger_id, attachment_url, event_title=None, cached_determination_data=None):
     """
     Downloads an attachment if it doesn't already exist locally.
@@ -192,12 +209,8 @@ def download_attachment(merger_id, attachment_url, event_title=None, cached_dete
                 for chunk in response.iter_content(chunk_size=8192):
                     f_out.write(chunk)
 
-        # Check if this is a determination PDF and parse it
-        is_determination = (
-            event_title and
-            'determination' in event_title.lower() and
-            filename.lower().endswith('.pdf')
-        )
+        # Check if this is a determination PDF and parse it.
+        is_determination = _is_determination_attachment(event_title, filename)
 
         if is_determination and os.path.exists(local_filepath):
             if cached_determination_data is not None:
@@ -483,7 +496,10 @@ def _scrape_events(soup, merger_id, existing_merger_data=None):
             # as an empty list) once extract_phase2_notice_data has parsed
             # this event, so use its presence as the cache signal.
             if 'phase2_notice_matters_to_investigate' in existing_event:
-                cached_phase2_notice_by_url[url] = existing_event['phase2_notice_matters_to_investigate']
+                cached_phase2_notice_by_url[url] = {
+                    'matters_to_investigate': existing_event['phase2_notice_matters_to_investigate'],
+                    'commission_division': existing_event.get('phase2_notice_commission_division'),
+                }
 
     scraped_events = []
     attachment_tables = soup.find_all('div', class_='table-responsive')
@@ -521,7 +537,9 @@ def _scrape_events(soup, merger_id, existing_merger_data=None):
                         event['determination_statement_of_reasons'] = statement
 
                 if url in cached_phase2_notice_by_url:
-                    event['phase2_notice_matters_to_investigate'] = cached_phase2_notice_by_url[url]
+                    cached_notice = cached_phase2_notice_by_url[url]
+                    event['phase2_notice_matters_to_investigate'] = cached_notice['matters_to_investigate']
+                    event['phase2_notice_commission_division'] = cached_notice['commission_division']
 
                 parsed_url = urlparse(url)
                 original_filename = unquote(os.path.basename(parsed_url.path)).strip()
@@ -1328,7 +1346,17 @@ def find_pending_phase2_notice_events(all_mergers_data):
 
 def extract_phase2_notice_data(all_mergers_data):
     """Parse pending Phase 2 Notice PDFs and attach their "matters the ACCC
-    intends to investigate" boxes to the corresponding event in place.
+    intends to investigate" boxes, and their decision-attribution sentence,
+    to the corresponding event in place.
+
+    The decision-attribution sentence is stored as
+    ``phase2_notice_commission_division`` — deliberately not
+    ``determination_commission_division`` — since a matter that reaches a
+    final determination gets its *own* (possibly different) attribution
+    from that later determination PDF, which should take precedence; this
+    field only matters as a fallback for matters whose assessment is ceased
+    (or otherwise never reaches a determination) after being referred to
+    Phase 2.
 
     Run in the enrich phase (after DOCX conversion) rather than inline
     during download: some notices redact individual paragraphs by
@@ -1349,6 +1377,7 @@ def extract_phase2_notice_data(all_mergers_data):
         try:
             data = parse_phase2_notice_pdf(local_path)
             event['phase2_notice_matters_to_investigate'] = data.get('matters_to_investigate', [])
+            event['phase2_notice_commission_division'] = data.get('commission_division')
             parsed_count += 1
         except Exception as e:
             print(f"Error parsing Phase 2 Notice PDF for {merger_id}: {e}", file=sys.stderr)

--- a/scripts/parse_determination.py
+++ b/scripts/parse_determination.py
@@ -12,22 +12,33 @@ from pathlib import Path
 
 def extract_commission_division(text: str) -> Optional[str]:
     """
-    Extract the commission division information from the last sentence of the determination.
+    Extract the commission/decision-division attribution sentence from the
+    end of a determination (or Phase 2 Notice) PDF.
 
     Examples:
     - "Determination made by a division of the Commission constituted by a direction issued pursuant to section 19 of the Act"
     - "Determination made by Commissioner Williams pursuant to a delegation under section 25(1) of the Act"
+    - "Decision made by a division of the Commission constituted by a direction issued pursuant to section 19 of the Competition and Consumer Act 2010 (Cth)"
+      (the equivalent sentence on a Phase 2 Notice, which decides a referral
+      rather than a final determination)
 
     Args:
-        text: Full text of the determination PDF
+        text: Full text of the PDF
 
     Returns:
-        The commission division sentence, or None if not found
+        The attribution sentence, or None if not found
     """
-    # Look for sentences that start with "Determination made by"
-    # This should typically be at the end of the document
-    # The sentence may span multiple lines, so use DOTALL and look for "of the Act" as the ending
-    pattern = r'Determination made by.+?(?:of the Act|under section \d+\(\d+\)(?:\s+of the Act)?)'
+    # Look for sentences that start with "Determination made by" or "Decision
+    # made by" (the Phase 2 Notice equivalent). This should typically be at
+    # the end of the document. The sentence may span multiple lines, so use
+    # DOTALL and look for "of the Act" (or the Phase 2 Notice's fuller
+    # "Competition and Consumer Act <year> (Cth)" reference) as the ending.
+    pattern = (
+        r'(?:Determination|Decision) made by.+?'
+        r'(?:of the Act'
+        r'|under section \d+\(\d+\)(?:\s+of the Act)?'
+        r'|of the Competition and Consumer Act \d{4}\s*\(Cth\))'
+    )
     matches = re.findall(pattern, text, re.IGNORECASE | re.DOTALL)
 
     if matches:

--- a/scripts/parse_phase2_notice.py
+++ b/scripts/parse_phase2_notice.py
@@ -25,7 +25,7 @@ from typing import Dict, List, Optional, Tuple
 
 import pdfplumber
 
-from parse_determination import _group_chars_into_lines
+from parse_determination import _group_chars_into_lines, extract_commission_division
 
 _MATTERS_HEADING_NORM = 'matters the accc intends to investigate in phase 2'
 
@@ -297,24 +297,33 @@ def _feed_ocr_lines(builder: _MattersBoxBuilder, lines: List[Dict]):
 
 
 def parse_phase2_notice_pdf(pdf_path: str) -> Dict[str, object]:
-    """Parse a Phase 2 Notice PDF and return its "matters to investigate" boxes.
+    """Parse a Phase 2 Notice PDF and return its "matters to investigate" boxes
+    and its decision-attribution sentence.
 
     Returns ``{'matters_to_investigate': [{'heading': str | None, 'items':
-    [str, ...]}, ...]}``. Pages with no text layer (see module docstring) are
-    OCR'd as a best-effort fallback; if that still yields nothing the list is
-    simply shorter, not an error.
+    [str, ...]}, ...], 'commission_division': str | None}``.
+    ``commission_division`` is the notice's "Decision made by ..." footer
+    (see :func:`parse_determination.extract_commission_division`) — the
+    Phase 2-referral equivalent of a determination's commission-division
+    sentence, useful for matters whose assessment is later ceased and so
+    never reach a final determination. Pages with no text layer (see module
+    docstring) are OCR'd as a best-effort fallback; if that still yields
+    nothing the matters list is simply shorter, not an error.
     """
     with pdfplumber.open(pdf_path) as pdf:
         if not pdf.pages:
             raise ValueError(f"PDF has no pages: {pdf_path}")
 
         builder = _MattersBoxBuilder()
+        raw_text_parts: List[str] = []
         for page_idx, page in enumerate(pdf.pages):
             if page_idx == 0:
                 continue  # cover page
             if _page_needs_ocr(page):
                 try:
-                    _feed_ocr_lines(builder, _ocr_page_lines(page))
+                    ocr_lines = _ocr_page_lines(page)
+                    _feed_ocr_lines(builder, ocr_lines)
+                    raw_text_parts.append('\n'.join(line['text'] for line in ocr_lines))
                 except Exception as e:
                     # e.g. Tesseract isn't installed. Skip just this page
                     # rather than losing boxes already collected from
@@ -322,5 +331,9 @@ def parse_phase2_notice_pdf(pdf_path: str) -> Dict[str, object]:
                     print(f"Warning: OCR failed for page {page_idx} of {pdf_path}: {e}", file=sys.stderr)
             else:
                 _feed_vector_lines(builder, _collect_page_lines(page))
+                raw_text_parts.append(page.extract_text() or '')
 
-    return {'matters_to_investigate': builder.finish()}
+    return {
+        'matters_to_investigate': builder.finish(),
+        'commission_division': extract_commission_division('\n'.join(raw_text_parts)),
+    }

--- a/scripts/static_data/outputs/analysis.py
+++ b/scripts/static_data/outputs/analysis.py
@@ -1,5 +1,18 @@
-"""Pre-computed analysis data for the Analysis page — ``analysis.json``."""
+"""Pre-computed analysis data for the Analysis page — ``analysis.json``.
 
+Label normalisation for ``by_commission_division`` (see that function):
+whitespace runs are collapsed and grouping is case-insensitive (via
+``str.casefold``), with the first-seen spelling for a group used as its
+display label. A merger with no parsed ``determination_commission_division``
+on any event, or with a corrupted value, is grouped under "Unknown". A
+label longer than ``_MAX_DIVISION_LABEL_LENGTH`` is treated as corrupted:
+real division sentences top out around 120 characters, but the extractor's
+"...of the Act" end-of-sentence marker can occasionally be missing nearby in
+a determination PDF (e.g. within a lengthy s87B undertaking), causing it to
+capture the rest of the document instead of just the division sentence.
+"""
+
+import re
 from collections import defaultdict
 from statistics import median as stat_median
 
@@ -7,6 +20,8 @@ from .. import anzsic
 from ..business_days import calculate_business_days, calculate_calendar_days
 from ..durations import collect_phase_1_durations, phase_1_end_date
 from ..filters import filter_notifications, filter_waivers
+
+_MAX_DIVISION_LABEL_LENGTH = 200
 
 
 def _division_for_code(code: str):
@@ -59,6 +74,72 @@ def industry_phase1_duration(mergers: list) -> list[dict]:
         })
 
     results.sort(key=lambda x: -x['average_business_days'])
+    return results
+
+
+def _normalise_division(raw: str | None) -> str | None:
+    """Collapse whitespace in a raw division sentence; ``None`` if unusable.
+
+    Returns ``None`` (rather than "Unknown" directly) so callers can still
+    distinguish "no value parsed" from "value parsed but corrupted" if
+    needed; both fold into "Unknown" in :func:`by_commission_division`.
+    """
+    if not raw:
+        return None
+    label = re.sub(r'\s+', ' ', raw).strip()
+    if not label or len(label) > _MAX_DIVISION_LABEL_LENGTH:
+        return None
+    return label
+
+
+def _commission_division_for(merger: dict) -> str | None:
+    """The normalised ``determination_commission_division`` label for ``merger``.
+
+    This is parsed onto whichever event carries the determination PDF — at
+    most one event per merger has it set — not onto the merger itself.
+    """
+    for event in merger.get('events') or []:
+        raw = event.get('determination_commission_division')
+        if raw is not None:
+            return _normalise_division(raw)
+    return None
+
+
+def by_commission_division(mergers: list) -> list[dict]:
+    """Determination counts, outcome mix, and Phase 1 duration per commission division.
+
+    See the module docstring for the label normalisation rules. Divisions are
+    sorted by determination count, descending.
+    """
+    groups: dict[str, dict] = {}
+    unknown = []
+    for m in mergers:
+        label = _commission_division_for(m)
+        if label is None:
+            unknown.append(m)
+            continue
+        bucket = groups.setdefault(label.casefold(), {"label": label, "mergers": []})
+        bucket["mergers"].append(m)
+
+    buckets = list(groups.values())
+    if unknown:
+        buckets.append({"label": "Unknown", "mergers": unknown})
+
+    results = []
+    for bucket in buckets:
+        group = bucket["mergers"]
+        outcome_mix = defaultdict(int)
+        for m in group:
+            outcome_mix[m.get('accc_determination') or 'Unknown'] += 1
+        _, business_days = collect_phase_1_durations(group)
+        results.append({
+            "division": bucket["label"],
+            "count": len(group),
+            "outcome_mix": dict(outcome_mix),
+            "median_phase_1_business_days": stat_median(business_days) if business_days else None,
+        })
+
+    results.sort(key=lambda x: -x['count'])
     return results
 
 
@@ -208,4 +289,5 @@ def generate(mergers: list) -> dict:
         },
         "monthly_volume": monthly_volume,
         "industry_phase1_duration": industry_phase1_duration(mergers),
+        "by_commission_division": by_commission_division(mergers),
     }

--- a/scripts/static_data/outputs/analysis.py
+++ b/scripts/static_data/outputs/analysis.py
@@ -17,18 +17,24 @@ Label normalisation for ``by_commission_division`` (see that function):
 - Grouping is case-insensitive (via ``str.casefold``), with the first-seen
   spelling for a group used as its display label.
 - A merger with no parsed ``determination_commission_division`` on any
-  event, or with a corrupted value, is grouped under "Unknown" — except that
-  a Phase 2 Notice's own "Decision made by..." sentence
-  (``phase2_notice_commission_division``) is used as a fallback first: a
-  matter whose assessment is ceased after referral to Phase 2 never gets a
-  final determination PDF to parse, but its Phase 2 Notice still says who
-  decided the referral.
+  event, or with a corrupted value, falls back to a Phase 2 Notice's own
+  "Decision made by..." sentence (``phase2_notice_commission_division``)
+  first: a matter whose assessment is ceased after referral to Phase 2 never
+  gets a final determination PDF to parse, but its Phase 2 Notice still says
+  who decided the referral.
 - A label longer than ``_MAX_DIVISION_LABEL_LENGTH`` is treated as corrupted:
   real division sentences top out around 120 characters, but the
   extractor's "...of the Act" end-of-sentence marker can occasionally be
   missing nearby in a determination PDF (e.g. within a lengthy s87B
   undertaking), causing it to capture the rest of the document instead of
   just the division sentence.
+- If still nothing is recoverable, the merger is split between two buckets
+  rather than one blanket "Unknown" (see ``_PENDING_STATUSES`` and
+  :func:`by_commission_division`): "Not yet determined" for matters still
+  under assessment/suspended (there's simply no decision yet), and "Unknown"
+  for matters that did reach or abandon an outcome but whose division
+  genuinely couldn't be identified — a data gap worth investigating, unlike
+  the former.
 """
 
 import re
@@ -174,23 +180,41 @@ def _commission_division_for(merger: dict) -> str | None:
     return None
 
 
+# Statuses that mean a merger hasn't reached (and may never reach, if
+# suspended pending information) a determination yet, as opposed to one that
+# has but whose division couldn't be identified. See by_commission_division.
+_PENDING_STATUSES = {merger_status.UNDER_ASSESSMENT, merger_status.ASSESSMENT_SUSPENDED}
+
+
 def by_commission_division(mergers: list) -> list[dict]:
     """Determination counts, outcome mix, and Phase 1 duration per commission division.
 
     See the module docstring for the label normalisation rules. Divisions are
-    sorted by determination count, descending.
+    sorted by determination count, descending. Mergers with no recoverable
+    division are split into two buckets rather than one blanket "Unknown":
+    "Not yet determined" for those still under assessment (or suspended) —
+    there's simply no decision yet to attribute — and "Unknown" for those
+    that reached (or abandoned) an outcome but whose division genuinely
+    couldn't be identified (a data gap worth investigating, not an absence
+    of data).
     """
     groups: dict[str, dict] = {}
+    pending = []
     unknown = []
     for m in mergers:
         label = _commission_division_for(m)
         if label is None:
-            unknown.append(m)
+            if m.get('status') in _PENDING_STATUSES:
+                pending.append(m)
+            else:
+                unknown.append(m)
             continue
         bucket = groups.setdefault(label.casefold(), {"label": label, "mergers": []})
         bucket["mergers"].append(m)
 
     buckets = list(groups.values())
+    if pending:
+        buckets.append({"label": "Not yet determined", "mergers": pending})
     if unknown:
         buckets.append({"label": "Unknown", "mergers": unknown})
 

--- a/scripts/static_data/outputs/analysis.py
+++ b/scripts/static_data/outputs/analysis.py
@@ -2,23 +2,33 @@
 
 Label normalisation for ``by_commission_division`` (see that function):
 - Whitespace runs are collapsed.
-- A delegate sentence ("Determination made by <person> pursuant to a
-  delegation...") is canonicalised to "<title> <surname>" (e.g. "Commissioner
-  Philip Williams" and "Commissioner Williams" both collapse to "Commissioner
-  Williams") so the same delegate isn't split across buckets depending on
-  whether their first name happened to be spelled out. Non-delegate
-  sentences (e.g. "a division of the Commission constituted by a direction
-  ...") are left as-is; there's only ever one such phrasing per determination
-  type in practice.
+- A delegate sentence ("Determination/Decision made by <person> pursuant to
+  a delegation...") is canonicalised to "<title> <surname>" (e.g.
+  "Commissioner Philip Williams" and "Commissioner Williams" both collapse to
+  "Commissioner Williams") so the same delegate isn't split across buckets
+  depending on whether their first name happened to be spelled out.
+- A "division of the Commission" sentence ("Determination/Decision made by a
+  division of the Commission constituted by a direction issued pursuant to
+  section <n>...") is canonicalised to "A division of the Commission (s<n>
+  direction)", collapsing the "Determination"/"Decision" wording difference
+  and the trailing Act-reference wording difference (a Phase 2 Notice cites
+  "the Competition and Consumer Act 2010 (Cth)" in full; a determination just
+  says "of the Act") — both describe the same kind of body.
 - Grouping is case-insensitive (via ``str.casefold``), with the first-seen
   spelling for a group used as its display label.
 - A merger with no parsed ``determination_commission_division`` on any
-  event, or with a corrupted value, is grouped under "Unknown". A label
-  longer than ``_MAX_DIVISION_LABEL_LENGTH`` is treated as corrupted: real
-  division sentences top out around 120 characters, but the extractor's
-  "...of the Act" end-of-sentence marker can occasionally be missing nearby
-  in a determination PDF (e.g. within a lengthy s87B undertaking), causing it
-  to capture the rest of the document instead of just the division sentence.
+  event, or with a corrupted value, is grouped under "Unknown" — except that
+  a Phase 2 Notice's own "Decision made by..." sentence
+  (``phase2_notice_commission_division``) is used as a fallback first: a
+  matter whose assessment is ceased after referral to Phase 2 never gets a
+  final determination PDF to parse, but its Phase 2 Notice still says who
+  decided the referral.
+- A label longer than ``_MAX_DIVISION_LABEL_LENGTH`` is treated as corrupted:
+  real division sentences top out around 120 characters, but the
+  extractor's "...of the Act" end-of-sentence marker can occasionally be
+  missing nearby in a determination PDF (e.g. within a lengthy s87B
+  undertaking), causing it to capture the rest of the document instead of
+  just the division sentence.
 """
 
 import re
@@ -34,12 +44,22 @@ from ..filters import filter_notifications, filter_waivers
 
 _MAX_DIVISION_LABEL_LENGTH = 200
 
-# Matches "Determination made by <person> pursuant to a delegation ..." so the
-# delegate's name can be canonicalised to "<title> <surname>", collapsing
-# variants that do/don't spell out a first name (e.g. "Commissioner Philip
-# Williams" vs "Commissioner Williams").
+# Matches "Determination/Decision made by <person> pursuant to a delegation
+# ..." so the delegate's name can be canonicalised to "<title> <surname>",
+# collapsing variants that do/don't spell out a first name (e.g.
+# "Commissioner Philip Williams" vs "Commissioner Williams").
 _DELEGATE_PATTERN = re.compile(
-    r'^Determination made by (?P<person>.+?) pursuant to a delegation\b',
+    r'^(?:Determination|Decision) made by (?P<person>.+?) pursuant to a delegation\b',
+    re.IGNORECASE,
+)
+
+# Matches "Determination/Decision made by a division of the Commission
+# constituted by a direction issued pursuant to section <n> ..." so it can be
+# canonicalised regardless of the "Determination"/"Decision" wording and the
+# trailing Act-reference wording (see module docstring).
+_DIVISION_PATTERN = re.compile(
+    r'^(?:Determination|Decision) made by a division of the Commission '
+    r'constituted by a direction issued pursuant to section (?P<section>\d+)\b',
     re.IGNORECASE,
 )
 
@@ -122,19 +142,35 @@ def _normalise_division(raw: str | None) -> str | None:
             return f'{words[0]} {words[-1]}'
         return match.group('person')
 
+    match = _DIVISION_PATTERN.match(label)
+    if match:
+        return f"A division of the Commission (s{match.group('section')} direction)"
+
     return label
 
 
 def _commission_division_for(merger: dict) -> str | None:
-    """The normalised ``determination_commission_division`` label for ``merger``.
+    """The normalised commission-division label for ``merger``.
 
-    This is parsed onto whichever event carries the determination PDF — at
-    most one event per merger has it set — not onto the merger itself.
+    Prefers ``determination_commission_division`` — parsed onto whichever
+    event carries the determination PDF, at most one event per merger — over
+    ``phase2_notice_commission_division``, used as a fallback only when no
+    determination was ever reached (e.g. assessment ceased after a Phase 2
+    referral), since the final determination's attribution should win when
+    both exist.
     """
-    for event in merger.get('events') or []:
+    events = merger.get('events') or []
+
+    for event in events:
         raw = event.get('determination_commission_division')
         if raw is not None:
             return _normalise_division(raw)
+
+    for event in events:
+        raw = event.get('phase2_notice_commission_division')
+        if raw is not None:
+            return _normalise_division(raw)
+
     return None
 
 

--- a/scripts/static_data/outputs/analysis.py
+++ b/scripts/static_data/outputs/analysis.py
@@ -1,15 +1,24 @@
 """Pre-computed analysis data for the Analysis page — ``analysis.json``.
 
 Label normalisation for ``by_commission_division`` (see that function):
-whitespace runs are collapsed and grouping is case-insensitive (via
-``str.casefold``), with the first-seen spelling for a group used as its
-display label. A merger with no parsed ``determination_commission_division``
-on any event, or with a corrupted value, is grouped under "Unknown". A
-label longer than ``_MAX_DIVISION_LABEL_LENGTH`` is treated as corrupted:
-real division sentences top out around 120 characters, but the extractor's
-"...of the Act" end-of-sentence marker can occasionally be missing nearby in
-a determination PDF (e.g. within a lengthy s87B undertaking), causing it to
-capture the rest of the document instead of just the division sentence.
+- Whitespace runs are collapsed.
+- A delegate sentence ("Determination made by <person> pursuant to a
+  delegation...") is canonicalised to "<title> <surname>" (e.g. "Commissioner
+  Philip Williams" and "Commissioner Williams" both collapse to "Commissioner
+  Williams") so the same delegate isn't split across buckets depending on
+  whether their first name happened to be spelled out. Non-delegate
+  sentences (e.g. "a division of the Commission constituted by a direction
+  ...") are left as-is; there's only ever one such phrasing per determination
+  type in practice.
+- Grouping is case-insensitive (via ``str.casefold``), with the first-seen
+  spelling for a group used as its display label.
+- A merger with no parsed ``determination_commission_division`` on any
+  event, or with a corrupted value, is grouped under "Unknown". A label
+  longer than ``_MAX_DIVISION_LABEL_LENGTH`` is treated as corrupted: real
+  division sentences top out around 120 characters, but the extractor's
+  "...of the Act" end-of-sentence marker can occasionally be missing nearby
+  in a determination PDF (e.g. within a lengthy s87B undertaking), causing it
+  to capture the rest of the document instead of just the division sentence.
 """
 
 import re
@@ -22,6 +31,15 @@ from ..durations import collect_phase_1_durations, phase_1_end_date
 from ..filters import filter_notifications, filter_waivers
 
 _MAX_DIVISION_LABEL_LENGTH = 200
+
+# Matches "Determination made by <person> pursuant to a delegation ..." so the
+# delegate's name can be canonicalised to "<title> <surname>", collapsing
+# variants that do/don't spell out a first name (e.g. "Commissioner Philip
+# Williams" vs "Commissioner Williams").
+_DELEGATE_PATTERN = re.compile(
+    r'^Determination made by (?P<person>.+?) pursuant to a delegation\b',
+    re.IGNORECASE,
+)
 
 
 def _division_for_code(code: str):
@@ -89,6 +107,14 @@ def _normalise_division(raw: str | None) -> str | None:
     label = re.sub(r'\s+', ' ', raw).strip()
     if not label or len(label) > _MAX_DIVISION_LABEL_LENGTH:
         return None
+
+    match = _DELEGATE_PATTERN.match(label)
+    if match:
+        words = match.group('person').split()
+        if len(words) >= 2:
+            return f'{words[0]} {words[-1]}'
+        return match.group('person')
+
     return label
 
 

--- a/scripts/tests/test_pipeline.py
+++ b/scripts/tests/test_pipeline.py
@@ -34,6 +34,7 @@ from extract_mergers import (
     find_pending_phase2_notice_events,
     extract_phase2_notice_data,
     _calculate_missing_end_of_determination_period,
+    _is_determination_attachment,
 )
 from static_data.business_days import calculate_business_days
 import extract_mergers
@@ -361,6 +362,47 @@ class TestExtractCommissionDivision:
         )
         result = extract_commission_division(text)
         assert "Commissioner B" in result
+
+    def test_phase2_notice_decision_sentence(self):
+        # Phase 2 Notices attribute a "Decision", not a "Determination", and
+        # cite the Act by its full name rather than "of the Act".
+        text = (
+            "Matters the ACCC intends to investigate in Phase 2\n"
+            "Decision made by a division of the Commission constituted by a "
+            "direction issued pursuant to section 19 of the Competition and "
+            "Consumer Act 2010 (Cth)"
+        )
+        result = extract_commission_division(text)
+        assert result is not None
+        assert result.startswith("Decision made by")
+        assert "Competition and Consumer Act 2010 (Cth)" in result
+
+
+# ---------------------------------------------------------------------------
+# extract_mergers: _is_determination_attachment
+# ---------------------------------------------------------------------------
+
+class TestIsDeterminationAttachment:
+    def test_true_when_title_says_determination(self):
+        assert _is_determination_attachment('Phase 1 - Determination', 'Foo.pdf') is True
+
+    def test_true_when_only_filename_says_determination(self):
+        # Regression case: some events are titled with just the merger name
+        # (e.g. "Carlyle - BASF Coatings"), even though the attached PDF is a
+        # determination — the filename ("...-Determination-...pdf") still
+        # says so and previously wasn't checked.
+        assert _is_determination_attachment(
+            'Carlyle - BASF Coatings', 'Carlyle BASF Coatings -Determination - 18 December 2025.pdf',
+        ) is True
+
+    def test_false_for_non_determination_pdf(self):
+        assert _is_determination_attachment('Merger notified to ACCC', 'Notification.pdf') is False
+
+    def test_false_for_non_pdf_even_if_title_says_determination(self):
+        assert _is_determination_attachment('Phase 1 - Determination', 'Foo.docx') is False
+
+    def test_false_when_title_is_none(self):
+        assert _is_determination_attachment(None, 'Notification.pdf') is False
 
 
 # ---------------------------------------------------------------------------
@@ -1877,6 +1919,31 @@ class TestExtractPhase2NoticeData:
         count = extract_phase2_notice_data(mergers)
         assert count == 1
         assert event['phase2_notice_matters_to_investigate'] == boxes
+        # No 'commission_division' key returned by the mock -> stored as None,
+        # not left unset, so the field's presence stays a reliable cache signal.
+        assert event['phase2_notice_commission_division'] is None
+
+    def test_attaches_decision_commission_division(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(extract_mergers, 'MATTERS_DIR', str(tmp_path))
+        matter_dir = tmp_path / 'MN-30002'
+        matter_dir.mkdir()
+        (matter_dir / 'Notice.pdf').write_bytes(b'%PDF-1.4 fake')
+
+        division = (
+            'Decision made by a division of the Commission constituted by a '
+            'direction issued pursuant to section 19 of the Competition and '
+            'Consumer Act 2010 (Cth)'
+        )
+        monkeypatch.setattr(
+            extract_mergers, 'parse_phase2_notice_pdf',
+            lambda path: {'matters_to_investigate': [], 'commission_division': division},
+        )
+
+        event = {'title': 'X - Phase 2 Notice', 'url_gh': '/mergers/MN-30002/Notice.pdf'}
+        mergers = [{'merger_id': 'MN-30002', 'events': [event]}]
+
+        extract_phase2_notice_data(mergers)
+        assert event['phase2_notice_commission_division'] == division
 
     def test_leaves_already_parsed_events_untouched(self, tmp_path, monkeypatch):
         # Ampol-EG Australia's regression case: once an event has a result

--- a/scripts/tests/test_static_data_outputs.py
+++ b/scripts/tests/test_static_data_outputs.py
@@ -534,9 +534,11 @@ class TestAnalysisGenerate:
 # ---------------------------------------------------------------------------
 
 def _commission_division_fixture():
-    """Four determined mergers exercising the by_commission_division normalisation:
-    same division split across two spellings (whitespace + case), a corrupted
-    over-length extraction, and a determination with no division parsed."""
+    """Five mergers exercising the by_commission_division normalisation: the
+    same delegate spelled two ways (with/without a first name, plus
+    whitespace/case noise), a corrupted over-length extraction, a
+    determination with no division parsed, and a waiver decided by a delegate
+    who otherwise only appears on notifications."""
     raw = [
         {
             'merger_id': 'MN-1001',
@@ -555,7 +557,7 @@ def _commission_division_fixture():
                 'date': '2025-02-05T12:00:00Z',
                 'url': 'e1',
                 'determination_commission_division': (
-                    'Determination made by Commissioner  Williams pursuant to a\n'
+                    'Determination made by Commissioner  Philip Williams pursuant to a\n'
                     'delegation under section 25(1) of the Act'
                 ),
             }],
@@ -576,7 +578,8 @@ def _commission_division_fixture():
                 'title': 'Phase 1 - Determination',
                 'date': '2025-03-12T12:00:00Z',
                 'url': 'e2',
-                # Same division as MN-1001's, differing only in case/whitespace.
+                # Same delegate as MN-1001's, but without the first name, and
+                # differing in case/whitespace too.
                 'determination_commission_division': (
                     'determination made by commissioner williams pursuant to a '
                     'delegation under section 25(1) of the act'
@@ -621,21 +624,45 @@ def _commission_division_fixture():
                 {'title': 'Phase 1 - Determination', 'date': '2025-03-31T12:00:00Z', 'url': 'e4'},
             ],
         },
+        {
+            'merger_id': 'WA-1005',
+            'merger_name': 'Rho waiver',
+            'status': 'Determined',
+            'accc_determination': 'Approved',
+            'stage': 'Waiver',
+            'effective_notification_datetime': '2025-04-01T09:00:00Z',
+            'determination_publication_date': '2025-04-15T12:00:00Z',
+            'page_modified_datetime': '2025-04-15T12:30:00Z',
+            'anzsic_codes': [],
+            'acquirers': [], 'targets': [], 'other_parties': [],
+            'url': 'https://example.com/WA-1005',
+            'events': [{
+                'title': 'Waiver determination',
+                'date': '2025-04-15T12:00:00Z',
+                'url': 'e5',
+                # Same delegate as MN-1001/MN-1002, but this merger is a
+                # waiver, so it has no Phase 1 review to measure.
+                'determination_commission_division': (
+                    'Determination made by Commissioner Williams pursuant to a '
+                    'delegation under section 25(1) of the Act'
+                ),
+            }],
+        },
     ]
     return [enrich_merger(m) for m in raw]
 
 
 class TestByCommissionDivision:
-    def test_groups_case_and_whitespace_insensitively(self):
+    def test_collapses_delegate_name_variants(self):
         divisions = analysis.generate(_commission_division_fixture())['by_commission_division']
         williams = next(d for d in divisions if 'Williams' in d['division'])
-        assert williams['count'] == 2
-        # Display label keeps the first-seen spelling.
-        assert williams['division'] == (
-            'Determination made by Commissioner Williams pursuant to a '
-            'delegation under section 25(1) of the Act'
-        )
-        assert williams['outcome_mix'] == {'Approved': 1, 'Not opposed': 1}
+        # MN-1001 ("Philip Williams"), MN-1002 ("Williams", different
+        # case/whitespace) and WA-1005 ("Williams") all collapse to one
+        # delegate.
+        assert williams['count'] == 3
+        # Display label is canonicalised to "<title> <surname>", not the raw sentence.
+        assert williams['division'] == 'Commissioner Williams'
+        assert williams['outcome_mix'] == {'Approved': 2, 'Not opposed': 1}
 
     def test_corrupted_and_missing_values_fold_into_unknown(self):
         divisions = analysis.generate(_commission_division_fixture())['by_commission_division']
@@ -645,7 +672,40 @@ class TestByCommissionDivision:
     def test_median_phase_1_business_days_uses_the_subset(self):
         divisions = analysis.generate(_commission_division_fixture())['by_commission_division']
         williams = next(d for d in divisions if 'Williams' in d['division'])
+        # WA-1005 is a waiver and contributes no Phase 1 duration, but
+        # MN-1001/MN-1002 do, so the bucket's median isn't null just because
+        # one contributing merger has no Phase 1 review.
         assert williams['median_phase_1_business_days'] is not None
+
+    def test_waiver_only_division_has_null_median(self):
+        # A delegate whose only determinations in this fixture are waivers
+        # has no Phase 1 duration to report — expected, not a bug, since
+        # collect_phase_1_durations only measures notifications.
+        raw = [{
+            'merger_id': 'WA-2001',
+            'merger_name': 'Sigma waiver',
+            'status': 'Determined',
+            'accc_determination': 'Approved',
+            'stage': 'Waiver',
+            'effective_notification_datetime': '2025-05-01T09:00:00Z',
+            'determination_publication_date': '2025-05-15T12:00:00Z',
+            'page_modified_datetime': '2025-05-15T12:30:00Z',
+            'anzsic_codes': [],
+            'acquirers': [], 'targets': [], 'other_parties': [],
+            'url': 'https://example.com/WA-2001',
+            'events': [{
+                'title': 'Waiver determination',
+                'date': '2025-05-15T12:00:00Z',
+                'url': 'e6',
+                'determination_commission_division': (
+                    'Determination made by Chair Cass-Gottlieb pursuant to a '
+                    'delegation under section 25(1) of the Act'
+                ),
+            }],
+        }]
+        divisions = analysis.generate([enrich_merger(m) for m in raw])['by_commission_division']
+        assert divisions[0]['division'] == 'Chair Cass-Gottlieb'
+        assert divisions[0]['median_phase_1_business_days'] is None
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_static_data_outputs.py
+++ b/scripts/tests/test_static_data_outputs.py
@@ -1039,6 +1039,33 @@ class TestByCommissionDivision:
         unknown = next(d for d in divisions if d['division'] == 'Unknown')
         assert unknown['count'] == 2
 
+    def test_still_under_assessment_is_separated_from_unknown(self):
+        # A merger with no division parsed because it simply hasn't been
+        # determined yet shouldn't be lumped in with genuine data gaps
+        # (corrupted/missing extraction on an already-determined merger).
+        raw = [{
+            'merger_id': 'MN-4001',
+            'merger_name': 'Alpha Two acquires Beta Two',
+            'status': 'Under assessment',
+            'accc_determination': None,
+            'stage': 'Phase 1 - preliminary assessment',
+            'effective_notification_datetime': '2025-08-01T09:00:00Z',
+            'determination_publication_date': None,
+            'anzsic_codes': [],
+            'acquirers': [], 'targets': [], 'other_parties': [],
+            'url': 'https://example.com/MN-4001',
+            'events': [{'title': 'Merger notified to ACCC', 'date': '2025-08-01T09:00:00Z', 'url': 'e11'}],
+        }]
+        fixture = _commission_division_fixture() + [enrich_merger(m) for m in raw]
+        divisions = analysis.generate(fixture)['by_commission_division']
+
+        pending = next(d for d in divisions if d['division'] == 'Not yet determined')
+        assert pending['count'] == 1
+        # The genuinely corrupted/missing-extraction cases from the base
+        # fixture (both already "Determined") stay in "Unknown", unaffected.
+        unknown = next(d for d in divisions if d['division'] == 'Unknown')
+        assert unknown['count'] == 2
+
     def test_median_phase_1_business_days_uses_the_subset(self):
         divisions = analysis.generate(_commission_division_fixture())['by_commission_division']
         williams = next(d for d in divisions if 'Williams' in d['division'])

--- a/scripts/tests/test_static_data_outputs.py
+++ b/scripts/tests/test_static_data_outputs.py
@@ -498,6 +498,7 @@ class TestAnalysisGenerate:
         json.dumps(payload)
         assert set(payload.keys()) == {
             'phase1_duration', 'waiver_duration', 'monthly_volume', 'industry_phase1_duration',
+            'by_commission_division',
         }
         assert 'scatter_data' in payload['phase1_duration']
         assert 'scatter_data' in payload['waiver_duration']
@@ -526,6 +527,125 @@ class TestAnalysisGenerate:
         mining = divisions[0]
         assert mining['name'] == 'Mining'
         assert mining['count'] == 1
+
+
+# ---------------------------------------------------------------------------
+# analysis.by_commission_division
+# ---------------------------------------------------------------------------
+
+def _commission_division_fixture():
+    """Four determined mergers exercising the by_commission_division normalisation:
+    same division split across two spellings (whitespace + case), a corrupted
+    over-length extraction, and a determination with no division parsed."""
+    raw = [
+        {
+            'merger_id': 'MN-1001',
+            'merger_name': 'Iota acquires Kappa',
+            'status': 'Determined',
+            'accc_determination': 'Approved',
+            'stage': 'Phase 1 - preliminary assessment',
+            'effective_notification_datetime': '2025-01-06T09:00:00Z',
+            'determination_publication_date': '2025-02-05T12:00:00Z',
+            'page_modified_datetime': '2025-02-05T12:30:00Z',
+            'anzsic_codes': [],
+            'acquirers': [], 'targets': [], 'other_parties': [],
+            'url': 'https://example.com/MN-1001',
+            'events': [{
+                'title': 'Phase 1 - Determination',
+                'date': '2025-02-05T12:00:00Z',
+                'url': 'e1',
+                'determination_commission_division': (
+                    'Determination made by Commissioner  Williams pursuant to a\n'
+                    'delegation under section 25(1) of the Act'
+                ),
+            }],
+        },
+        {
+            'merger_id': 'MN-1002',
+            'merger_name': 'Lambda acquires Mu',
+            'status': 'Determined',
+            'accc_determination': 'Not opposed',
+            'stage': 'Phase 1 - preliminary assessment',
+            'effective_notification_datetime': '2025-02-10T09:00:00Z',
+            'determination_publication_date': '2025-03-12T12:00:00Z',
+            'page_modified_datetime': '2025-03-12T12:30:00Z',
+            'anzsic_codes': [],
+            'acquirers': [], 'targets': [], 'other_parties': [],
+            'url': 'https://example.com/MN-1002',
+            'events': [{
+                'title': 'Phase 1 - Determination',
+                'date': '2025-03-12T12:00:00Z',
+                'url': 'e2',
+                # Same division as MN-1001's, differing only in case/whitespace.
+                'determination_commission_division': (
+                    'determination made by commissioner williams pursuant to a '
+                    'delegation under section 25(1) of the act'
+                ),
+            }],
+        },
+        {
+            'merger_id': 'MN-1003',
+            'merger_name': 'Nu acquires Xi',
+            'status': 'Determined',
+            'accc_determination': 'Approved',
+            'stage': 'Phase 1 - preliminary assessment',
+            'effective_notification_datetime': '2025-01-20T09:00:00Z',
+            'determination_publication_date': '2025-02-19T12:00:00Z',
+            'page_modified_datetime': '2025-02-19T12:30:00Z',
+            'anzsic_codes': [],
+            'acquirers': [], 'targets': [], 'other_parties': [],
+            'url': 'https://example.com/MN-1003',
+            'events': [{
+                'title': 'Phase 1 - Determination',
+                'date': '2025-02-19T12:00:00Z',
+                'url': 'e3',
+                # A corrupted extraction (no "of the Act" marker nearby) that
+                # captured far more than the division sentence.
+                'determination_commission_division': 'Determination made by the Commission ' + 'x' * 300,
+            }],
+        },
+        {
+            'merger_id': 'MN-1004',
+            'merger_name': 'Omicron acquires Pi',
+            'status': 'Determined',
+            'accc_determination': 'Approved',
+            'stage': 'Phase 1 - preliminary assessment',
+            'effective_notification_datetime': '2025-03-01T09:00:00Z',
+            'determination_publication_date': '2025-03-31T12:00:00Z',
+            'page_modified_datetime': '2025-03-31T12:30:00Z',
+            'anzsic_codes': [],
+            'acquirers': [], 'targets': [], 'other_parties': [],
+            'url': 'https://example.com/MN-1004',
+            'events': [
+                # No determination_commission_division parsed at all.
+                {'title': 'Phase 1 - Determination', 'date': '2025-03-31T12:00:00Z', 'url': 'e4'},
+            ],
+        },
+    ]
+    return [enrich_merger(m) for m in raw]
+
+
+class TestByCommissionDivision:
+    def test_groups_case_and_whitespace_insensitively(self):
+        divisions = analysis.generate(_commission_division_fixture())['by_commission_division']
+        williams = next(d for d in divisions if 'Williams' in d['division'])
+        assert williams['count'] == 2
+        # Display label keeps the first-seen spelling.
+        assert williams['division'] == (
+            'Determination made by Commissioner Williams pursuant to a '
+            'delegation under section 25(1) of the Act'
+        )
+        assert williams['outcome_mix'] == {'Approved': 1, 'Not opposed': 1}
+
+    def test_corrupted_and_missing_values_fold_into_unknown(self):
+        divisions = analysis.generate(_commission_division_fixture())['by_commission_division']
+        unknown = next(d for d in divisions if d['division'] == 'Unknown')
+        assert unknown['count'] == 2
+
+    def test_median_phase_1_business_days_uses_the_subset(self):
+        divisions = analysis.generate(_commission_division_fixture())['by_commission_division']
+        williams = next(d for d in divisions if 'Williams' in d['division'])
+        assert williams['median_phase_1_business_days'] is not None
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_static_data_outputs.py
+++ b/scripts/tests/test_static_data_outputs.py
@@ -1077,6 +1077,106 @@ class TestByCommissionDivision:
         assert divisions[0]['division'] == 'Chair Cass-Gottlieb'
         assert divisions[0]['median_phase_1_business_days'] is None
 
+    def test_collapses_division_of_commission_wording_variants(self):
+        # A determination says "Determination made by ... of the Act"; a
+        # Phase 2 Notice says "Decision made by ... of the Competition and
+        # Consumer Act 2010 (Cth)" for the same kind of body. Both should
+        # collapse to one canonical bucket.
+        raw = [
+            {
+                'merger_id': 'MN-3001',
+                'merger_name': 'Tau acquires Upsilon',
+                'status': 'Determined',
+                'accc_determination': 'Approved',
+                'stage': 'Phase 1 - preliminary assessment',
+                'effective_notification_datetime': '2025-06-01T09:00:00Z',
+                'determination_publication_date': '2025-06-30T12:00:00Z',
+                'page_modified_datetime': '2025-06-30T12:30:00Z',
+                'anzsic_codes': [],
+                'acquirers': [], 'targets': [], 'other_parties': [],
+                'url': 'https://example.com/MN-3001',
+                'events': [{
+                    'title': 'Phase 1 - Determination',
+                    'date': '2025-06-30T12:00:00Z',
+                    'url': 'e7',
+                    'determination_commission_division': (
+                        'Determination made by a division of the Commission '
+                        'constituted by a direction issued pursuant to section 19 of the Act'
+                    ),
+                }],
+            },
+            {
+                'merger_id': 'MN-3002',
+                'merger_name': 'Phi acquires Chi',
+                'status': 'Assessment ceased',
+                'accc_determination': None,
+                'stage': 'Phase 2 - detailed assessment',
+                'effective_notification_datetime': '2025-06-05T09:00:00Z',
+                'determination_publication_date': None,
+                'page_modified_datetime': '2025-07-01T09:30:00Z',
+                'anzsic_codes': [],
+                'acquirers': [], 'targets': [], 'other_parties': [],
+                'url': 'https://example.com/MN-3002',
+                'events': [{
+                    'title': 'Phi - Chi - Phase 2 Notice',
+                    'date': '2025-07-01T09:00:00Z',
+                    'url': 'e8',
+                    'phase2_notice_matters_to_investigate': [],
+                    'phase2_notice_commission_division': (
+                        'Decision made by a division of the Commission constituted by a '
+                        'direction issued pursuant to section 19 of the Competition and '
+                        'Consumer Act 2010 (Cth)'
+                    ),
+                }],
+            },
+        ]
+        divisions = analysis.generate([enrich_merger(m) for m in raw])['by_commission_division']
+        assert len(divisions) == 1
+        assert divisions[0]['division'] == 'A division of the Commission (s19 direction)'
+        assert divisions[0]['count'] == 2
+
+    def test_final_determination_takes_precedence_over_phase2_notice(self):
+        # A matter referred to Phase 2 and later determined by a named
+        # delegate shouldn't have its bucket overridden by the earlier Phase
+        # 2 Notice's division event.
+        raw = [{
+            'merger_id': 'MN-3003',
+            'merger_name': 'Psi acquires Omega',
+            'status': 'Determined',
+            'accc_determination': 'Approved',
+            'stage': 'Phase 2 - detailed assessment',
+            'effective_notification_datetime': '2025-06-05T09:00:00Z',
+            'determination_publication_date': '2025-09-01T12:00:00Z',
+            'page_modified_datetime': '2025-09-01T12:30:00Z',
+            'anzsic_codes': [],
+            'acquirers': [], 'targets': [], 'other_parties': [],
+            'url': 'https://example.com/MN-3003',
+            'events': [
+                {
+                    'title': 'Psi - Omega - Phase 2 Notice',
+                    'date': '2025-07-01T09:00:00Z',
+                    'url': 'e9',
+                    'phase2_notice_matters_to_investigate': [],
+                    'phase2_notice_commission_division': (
+                        'Decision made by a division of the Commission constituted by a '
+                        'direction issued pursuant to section 19 of the Competition and '
+                        'Consumer Act 2010 (Cth)'
+                    ),
+                },
+                {
+                    'title': 'Phase 2 - Determination',
+                    'date': '2025-09-01T12:00:00Z',
+                    'url': 'e10',
+                    'determination_commission_division': (
+                        'Determination made by Commissioner Woodward pursuant to a '
+                        'delegation under section 25(1) of the Act'
+                    ),
+                },
+            ],
+        }]
+        divisions = analysis.generate([enrich_merger(m) for m in raw])['by_commission_division']
+        assert divisions[0]['division'] == 'Commissioner Woodward'
+
 
 # ---------------------------------------------------------------------------
 # individual


### PR DESCRIPTION
## Summary
This PR adds a new `by_commission_division` analysis section to the merger tracker that groups merger determinations by the commission division that made them, with outcome statistics and Phase 1 duration metrics.

## Key Changes
- **New analysis function** (`by_commission_division`): Groups mergers by their determination commission division with case-insensitive and whitespace-normalized matching
- **Label normalization**: Implements `_normalise_division()` to collapse whitespace and filter out corrupted/oversized labels (>200 chars), with a maximum length check to catch extraction errors
- **Division extraction**: Added `_commission_division_for()` helper to extract the normalized division label from merger events
- **Outcome tracking**: Captures outcome mix (Approved/Not approved/Unknown) and median Phase 1 business days per division
- **Sorting**: Results sorted by determination count in descending order
- **Test coverage**: Comprehensive test suite covering case/whitespace normalization, corrupted value handling, and missing division scenarios
- **Data output**: Updated `analysis.json` with 8 distinct commission divisions and their statistics (418 total determinations)

## Implementation Details
- Divisions are grouped using `str.casefold()` for case-insensitive comparison while preserving the first-seen spelling for display labels
- Mergers with missing or corrupted `determination_commission_division` values are grouped under "Unknown"
- The `_MAX_DIVISION_LABEL_LENGTH` constant (200 chars) prevents inclusion of corrupted extractions where the PDF parser failed to find the "of the Act" sentence boundary
- Phase 1 duration statistics use the existing `collect_phase_1_durations()` utility to calculate medians per division

https://claude.ai/code/session_016a2hX9cpwh6GTqAkUcxKjT