### PR TITLE
Add command palette for global search and navigation

### DIFF
--- a/merger-tracker/frontend/src/App.jsx
+++ b/merger-tracker/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import Navbar from './components/Navbar';
 import Footer from './components/Footer';
 import ErrorBoundary from './components/ErrorBoundary';
 import KeyboardShortcutsHelp from './components/KeyboardShortcutsHelp';
+import CommandPalette from './components/CommandPalette';
 import FeedbackPopup from './components/FeedbackPopup';
 import { TrackingProvider } from './context/TrackingContext';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
@@ -27,9 +28,11 @@ import NotFound from './pages/NotFound';
 
 function AppContent() {
   const [showShortcuts, setShowShortcuts] = useState(false);
+  const [showCommandPalette, setShowCommandPalette] = useState(false);
   const toggleShortcuts = useCallback(() => setShowShortcuts(prev => !prev), []);
+  const togglePalette = useCallback(() => setShowCommandPalette(prev => !prev), []);
 
-  useKeyboardShortcuts({ onToggleHelp: toggleShortcuts });
+  useKeyboardShortcuts({ onToggleHelp: toggleShortcuts, onTogglePalette: togglePalette });
 
   return (
     <>
@@ -63,6 +66,10 @@ function AppContent() {
       <KeyboardShortcutsHelp
         isOpen={showShortcuts}
         onClose={() => setShowShortcuts(false)}
+      />
+      <CommandPalette
+        isOpen={showCommandPalette}
+        onClose={() => setShowCommandPalette(false)}
       />
       <FeedbackPopup />
     </>

--- a/merger-tracker/frontend/src/components/CommandPalette.jsx
+++ b/merger-tracker/frontend/src/components/CommandPalette.jsx
@@ -1,0 +1,275 @@
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { FaSearch } from 'react-icons/fa';
+import { dataCache } from '../utils/dataCache';
+import { buildSearchIndex, searchMergers } from '../utils/searchIndex';
+import { fetchAllMergers } from '../utils/fetchAllMergers';
+import { mergerPath } from '../utils/slug';
+
+const PAGES = [
+  { label: 'Dashboard', path: '/' },
+  { label: 'Mergers', path: '/mergers' },
+  { label: 'Timeline', path: '/timeline' },
+  { label: 'Industries', path: '/industries' },
+  { label: 'Analysis', path: '/analysis' },
+  { label: 'Commentary', path: '/commentary' },
+  { label: 'Digest', path: '/digest' },
+];
+
+const MAX_MERGER_RESULTS = 8;
+
+export default function CommandPalette({ isOpen, onClose }) {
+  const navigate = useNavigate();
+  const inputRef = useRef(null);
+  const dialogRef = useRef(null);
+  const listRef = useRef(null);
+  const previouslyFocusedRef = useRef(null);
+
+  const [query, setQuery] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [mergers, setMergers] = useState(() => dataCache.get('mergers-list') || []);
+  const [searchIndex, setSearchIndex] = useState(() => {
+    const cached = dataCache.get('mergers-list');
+    return cached?.length ? buildSearchIndex(cached) : null;
+  });
+  const [mergersLoading, setMergersLoading] = useState(false);
+
+  // Reset state on open (adjusting state during render rather than in an
+  // effect, per https://react.dev/learn/you-might-not-need-an-effect).
+  const [prevIsOpen, setPrevIsOpen] = useState(false);
+  if (isOpen !== prevIsOpen) {
+    setPrevIsOpen(isOpen);
+    if (isOpen) {
+      setQuery('');
+      setSelectedIndex(0);
+      const cached = dataCache.get('mergers-list');
+      if (cached?.length) {
+        setMergers(cached);
+        setSearchIndex(buildSearchIndex(cached));
+      } else {
+        setMergersLoading(true);
+      }
+    }
+  }
+
+  // Lazily fetch the full merger list if it isn't cached yet (e.g. a cold
+  // visit that opened the palette before Mergers ever loaded).
+  useEffect(() => {
+    if (!isOpen || dataCache.has('mergers-list')) return;
+    fetchAllMergers()
+      .then(({ mergers: allMergers, searchIndex: index }) => {
+        setMergers(allMergers);
+        setSearchIndex(index);
+      })
+      .catch((err) => console.error('Command palette failed to load mergers:', err))
+      .finally(() => setMergersLoading(false));
+  }, [isOpen]);
+
+  const trimmedQuery = query.trim();
+
+  const pageResults = useMemo(() => {
+    if (!trimmedQuery) return PAGES;
+    const q = trimmedQuery.toLowerCase();
+    return PAGES.filter((p) => p.label.toLowerCase().includes(q));
+  }, [trimmedQuery]);
+
+  const mergerResults = useMemo(() => {
+    if (!trimmedQuery || !searchIndex) return [];
+    return searchMergers(mergers, trimmedQuery, searchIndex).slice(0, MAX_MERGER_RESULTS);
+  }, [trimmedQuery, mergers, searchIndex]);
+
+  const showMergersGroup = trimmedQuery && (mergersLoading || mergerResults.length > 0);
+  const noResults = trimmedQuery && !mergersLoading && pageResults.length === 0 && mergerResults.length === 0;
+
+  // Flattened list of selectable rows, in display order, so arrow keys can
+  // move through both groups without caring which one an index belongs to.
+  const items = useMemo(() => {
+    const list = pageResults.map((p) => ({ type: 'page', path: p.path, key: `page:${p.path}` }));
+    mergerResults.forEach((m) => {
+      list.push({
+        type: 'merger',
+        path: mergerPath(m.merger_id, m.merger_name),
+        key: `merger:${m.merger_id}`,
+      });
+    });
+    return list;
+  }, [pageResults, mergerResults]);
+
+  // Clamp selection when the result set shrinks (e.g. typing narrows results).
+  const [prevItemsLength, setPrevItemsLength] = useState(items.length);
+  if (items.length !== prevItemsLength) {
+    setPrevItemsLength(items.length);
+    setSelectedIndex((i) => Math.min(i, Math.max(items.length - 1, 0)));
+  }
+
+  const goTo = useCallback(
+    (path) => {
+      onClose();
+      navigate(path);
+    },
+    [navigate, onClose]
+  );
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (items.length) setSelectedIndex((i) => (i + 1) % items.length);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (items.length) setSelectedIndex((i) => (i - 1 + items.length) % items.length);
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const item = items[selectedIndex];
+      if (item) goTo(item.path);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      onClose();
+    }
+  };
+
+  // Focus the input, lock body scroll, and restore focus to whatever was
+  // focused before the palette opened.
+  useEffect(() => {
+    if (!isOpen) return;
+    previouslyFocusedRef.current = document.activeElement;
+    inputRef.current?.focus();
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      previouslyFocusedRef.current?.focus?.();
+    };
+  }, [isOpen]);
+
+  // Keep the highlighted row scrolled into view when navigating by keyboard.
+  useEffect(() => {
+    const selected = listRef.current?.querySelector('[data-selected="true"]');
+    selected?.scrollIntoView?.({ block: 'nearest' });
+  }, [selectedIndex]);
+
+  if (!isOpen) return null;
+
+  const selectedKey = items[selectedIndex]?.key;
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-start justify-center pt-[12vh] p-4"
+      onClick={onClose}
+    >
+      <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" />
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Command palette"
+        className="relative bg-white rounded-2xl shadow-xl border border-gray-100 max-w-lg w-full overflow-hidden animate-slide-up"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-100">
+          <FaSearch className="w-4 h-4 text-gray-400 shrink-0" aria-hidden="true" />
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Search pages and mergers…"
+            className="flex-1 bg-transparent text-sm text-gray-900 placeholder-gray-400 focus:outline-none"
+            role="combobox"
+            aria-expanded="true"
+            aria-controls="command-palette-listbox"
+            aria-activedescendant={selectedKey}
+            autoComplete="off"
+          />
+          <kbd className="hidden sm:inline-flex items-center justify-center px-1.5 h-5 rounded bg-gray-100 border border-gray-200 text-[10px] font-mono font-medium text-gray-500">
+            Esc
+          </kbd>
+        </div>
+
+        <ul
+          ref={listRef}
+          id="command-palette-listbox"
+          role="listbox"
+          aria-label="Command palette results"
+          className="max-h-80 overflow-y-auto py-2"
+        >
+          {noResults && (
+            <li className="px-4 py-6 text-sm text-gray-400 text-center" role="presentation">
+              No results for &ldquo;{trimmedQuery}&rdquo;
+            </li>
+          )}
+
+          {pageResults.length > 0 && (
+            <>
+              <li
+                className="px-4 pt-1 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wide"
+                role="presentation"
+              >
+                Pages
+              </li>
+              {pageResults.map((p) => {
+                const key = `page:${p.path}`;
+                const selected = key === selectedKey;
+                return (
+                  <li
+                    key={key}
+                    id={key}
+                    role="option"
+                    aria-selected={selected}
+                    data-selected={selected}
+                    onMouseEnter={() => setSelectedIndex(items.findIndex((i) => i.key === key))}
+                    onClick={() => goTo(p.path)}
+                    className={`px-4 py-2 text-sm cursor-pointer ${
+                      selected ? 'bg-primary/10 text-primary' : 'text-gray-700'
+                    }`}
+                  >
+                    {p.label}
+                  </li>
+                );
+              })}
+            </>
+          )}
+
+          {showMergersGroup && (
+            <>
+              <li
+                className="px-4 pt-3 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wide"
+                role="presentation"
+              >
+                Mergers
+              </li>
+              {mergersLoading && mergerResults.length === 0 && (
+                <li className="px-4 py-2 text-sm text-gray-400" role="presentation">
+                  Loading mergers…
+                </li>
+              )}
+              {mergerResults.map((m) => {
+                const key = `merger:${m.merger_id}`;
+                const selected = key === selectedKey;
+                const path = mergerPath(m.merger_id, m.merger_name);
+                return (
+                  <li
+                    key={key}
+                    id={key}
+                    role="option"
+                    aria-selected={selected}
+                    data-selected={selected}
+                    onMouseEnter={() => setSelectedIndex(items.findIndex((i) => i.key === key))}
+                    onClick={() => goTo(path)}
+                    className={`px-4 py-2 text-sm cursor-pointer truncate ${
+                      selected ? 'bg-primary/10 text-primary' : 'text-gray-700'
+                    }`}
+                  >
+                    {m.merger_name}
+                  </li>
+                );
+              })}
+            </>
+          )}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/merger-tracker/frontend/src/components/KeyboardShortcutsHelp.jsx
+++ b/merger-tracker/frontend/src/components/KeyboardShortcutsHelp.jsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { FaTimes } from 'react-icons/fa';
 
 const shortcuts = [
+  { keys: ['⌘K'], description: 'Open command palette' },
   { keys: ['/'], description: 'Focus search' },
   { keys: ['g', 'd'], description: 'Go to Dashboard' },
   { keys: ['g', 'm'], description: 'Go to Mergers' },

--- a/merger-tracker/frontend/src/components/Navbar.jsx
+++ b/merger-tracker/frontend/src/components/Navbar.jsx
@@ -120,22 +120,6 @@ function Navbar() {
   }, [searchOpen]);
 
   useEffect(() => {
-    const handleFocusNavbarSearch = () => {
-      if (navMode !== 'mobile') {
-        setSearchOpen(true);
-        if (searchInputRef.current) {
-          searchInputRef.current.focus();
-        }
-      } else {
-        focusMobileSearchRef.current = true;
-        setMobileMenuOpen(true);
-      }
-    };
-    window.addEventListener('focus-navbar-search', handleFocusNavbarSearch);
-    return () => window.removeEventListener('focus-navbar-search', handleFocusNavbarSearch);
-  }, [navMode]);
-
-  useEffect(() => {
     if (mobileMenuOpen && focusMobileSearchRef.current && mobileSearchInputRef.current) {
       mobileSearchInputRef.current.focus();
       focusMobileSearchRef.current = false;

--- a/merger-tracker/frontend/src/components/__tests__/CommandPalette.test.jsx
+++ b/merger-tracker/frontend/src/components/__tests__/CommandPalette.test.jsx
@@ -1,0 +1,126 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import CommandPalette from '../CommandPalette';
+import { dataCache } from '../../utils/dataCache';
+
+function ok(json) {
+  return { ok: true, status: 200, json: () => Promise.resolve(json) };
+}
+
+const mergerFixture = [
+  { merger_id: 'MN-01019', merger_name: 'Ampol / Z Energy' },
+  { merger_id: 'MN-01020', merger_name: 'Woolworths / Some Target' },
+];
+
+function renderPalette(props) {
+  return render(
+    <MemoryRouter>
+      <CommandPalette isOpen onClose={() => {}} {...props} />
+    </MemoryRouter>
+  );
+}
+
+describe('CommandPalette', () => {
+  beforeEach(() => {
+    dataCache.clear();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    dataCache.clear();
+  });
+
+  it('renders nothing when closed', () => {
+    render(
+      <MemoryRouter>
+        <CommandPalette isOpen={false} onClose={() => {}} />
+      </MemoryRouter>
+    );
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('opens as a dialog listing the static pages by default', () => {
+    renderPalette();
+    expect(screen.getByRole('dialog', { name: 'Command palette' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Mergers' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Dashboard' })).toBeInTheDocument();
+  });
+
+  it('closes on Escape', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    renderPalette({ onClose });
+    await user.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('calls onClose on click-outside (backdrop click)', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    renderPalette({ onClose });
+    // Clicking the overlay outside the panel (but inside the fixed wrapper) should close.
+    await user.click(screen.getByRole('dialog').parentElement);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('filters pages by query and searches cached mergers', async () => {
+    dataCache.set('mergers-list', mergerFixture);
+    const user = userEvent.setup();
+    renderPalette();
+
+    const input = screen.getByRole('combobox');
+    await user.type(input, 'ampol');
+
+    expect(screen.queryByRole('option', { name: 'Dashboard' })).not.toBeInTheDocument();
+    expect(await screen.findByRole('option', { name: 'Ampol / Z Energy' })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'Woolworths / Some Target' })).not.toBeInTheDocument();
+  });
+
+  it('navigates arrow keys through results and opens the selected item on Enter', async () => {
+    dataCache.set('mergers-list', mergerFixture);
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    renderPalette({ onClose });
+
+    const input = screen.getByRole('combobox');
+    await user.type(input, 'mergers');
+    // Only the "Mergers" page matches this query.
+    expect(await screen.findByRole('option', { name: 'Mergers' })).toHaveAttribute('aria-selected', 'true');
+
+    await user.keyboard('{Enter}');
+    // Selecting a result navigates and closes the palette.
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('lazily fetches the merger list on a cold cache and shows a loading row', async () => {
+    let resolveMeta;
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      if (url.includes('list-meta.json')) {
+        return new Promise((resolve) => {
+          resolveMeta = () => resolve(ok({ total_pages: 1 }));
+        });
+      }
+      if (url.includes('list-page-1.json')) {
+        return Promise.resolve(ok({ mergers: mergerFixture }));
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
+
+    const user = userEvent.setup();
+    renderPalette();
+
+    const input = screen.getByRole('combobox');
+    await user.type(input, 'ampol');
+
+    expect(screen.getByText('Loading mergers…')).toBeInTheDocument();
+
+    resolveMeta();
+
+    expect(await screen.findByRole('option', { name: 'Ampol / Z Energy' })).toBeInTheDocument();
+    expect(dataCache.get('mergers-list')).toEqual(mergerFixture);
+    fetchSpy.mockRestore();
+  });
+});

--- a/merger-tracker/frontend/src/hooks/useKeyboardShortcuts.js
+++ b/merger-tracker/frontend/src/hooks/useKeyboardShortcuts.js
@@ -5,7 +5,9 @@ import { useNavigate, useLocation } from 'react-router-dom';
  * Keyboard shortcuts for power users.
  *
  * Global shortcuts (work from any page):
- *   /        Focus the search input on the current page (if one exists)
+ *   ⌘K/Ctrl-K Open the command palette (works even while typing in an input)
+ *   /        Focus the search input on the current page if one exists,
+ *            otherwise open the command palette
  *   g then d Go to Dashboard
  *   g then m Go to Mergers
  *   g then t Go to Timeline
@@ -19,7 +21,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
  *   k        Move selection up
  *   Enter    Open selected merger
  */
-export function useKeyboardShortcuts({ onToggleHelp } = {}) {
+export function useKeyboardShortcuts({ onToggleHelp, onTogglePalette } = {}) {
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -28,6 +30,13 @@ export function useKeyboardShortcuts({ onToggleHelp } = {}) {
     let gTimer = null;
 
     const handleKeyDown = (e) => {
+      // ⌘K/Ctrl-K opens the command palette from anywhere, including inputs.
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        onTogglePalette?.();
+        return;
+      }
+
       // Don't capture shortcuts when typing in inputs, textareas, or contenteditable
       const tag = e.target.tagName;
       const isInput = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || e.target.isContentEditable;
@@ -72,14 +81,14 @@ export function useKeyboardShortcuts({ onToggleHelp } = {}) {
       }
 
       // "/" to focus search — prefer an in-page search input if the page has
-      // one (Mergers, Industries); otherwise fall back to the navbar search.
+      // one (Mergers, Industries); otherwise open the command palette.
       if (e.key === '/') {
         e.preventDefault();
         const searchInput = document.getElementById('search');
         if (searchInput) {
           searchInput.focus();
         } else {
-          window.dispatchEvent(new CustomEvent('focus-navbar-search'));
+          onTogglePalette?.();
         }
         return;
       }
@@ -97,5 +106,5 @@ export function useKeyboardShortcuts({ onToggleHelp } = {}) {
       window.removeEventListener('keydown', handleKeyDown);
       clearTimeout(gTimer);
     };
-  }, [navigate, location.pathname, onToggleHelp]);
+  }, [navigate, location.pathname, onToggleHelp, onTogglePalette]);
 }

--- a/merger-tracker/frontend/src/utils/fetchAllMergers.js
+++ b/merger-tracker/frontend/src/utils/fetchAllMergers.js
@@ -1,0 +1,54 @@
+import { API_ENDPOINTS } from '../config';
+import { dataCache } from './dataCache';
+import { buildSearchIndex, clearSearchIndex } from './searchIndex';
+
+const MERGERS_LIST_KEY = 'mergers-list';
+// Max concurrent page fetches to avoid saturating the connection pool
+const FETCH_BATCH_SIZE = 4;
+
+/**
+ * Fetch every page of the merger list, cache it, and rebuild the search
+ * index over the full result. Shared by any UI that needs the complete
+ * cached merger list (the Mergers page, the command palette).
+ *
+ * @returns {Promise<{ mergers: Array, searchIndex: Map }>}
+ */
+export async function fetchAllMergers() {
+  const metaResponse = await fetch(API_ENDPOINTS.mergersListMeta);
+  if (!metaResponse.ok) throw new Error('Failed to fetch merger list metadata');
+
+  const meta = await metaResponse.json();
+  const totalPages = meta.total_pages;
+
+  // Fetch pages in batches to avoid saturating the browser's connection pool.
+  // Promise.all within each batch still parallelises those requests.
+  const allResponses = [];
+  for (let i = 1; i <= totalPages; i += FETCH_BATCH_SIZE) {
+    const batch = [];
+    for (let j = i; j < i + FETCH_BATCH_SIZE && j <= totalPages; j++) {
+      batch.push(fetch(API_ENDPOINTS.mergersListPage(j)));
+    }
+    const batchResponses = await Promise.all(batch);
+    allResponses.push(...batchResponses);
+  }
+
+  const pagesResults = await Promise.allSettled(
+    allResponses.map((r) => {
+      if (!r.ok) throw new Error('Failed to fetch merger page');
+      return r.json();
+    })
+  );
+
+  const allMergers = pagesResults
+    .filter((r) => r.status === 'fulfilled')
+    .flatMap((r) => r.value.mergers);
+
+  dataCache.set(MERGERS_LIST_KEY, allMergers);
+
+  // Clear the session-cached index so it is rebuilt from the freshly fetched
+  // data rather than returning a stale index from a previous navigation.
+  clearSearchIndex();
+  const searchIndex = buildSearchIndex(allMergers);
+
+  return { mergers: allMergers, searchIndex };
+}


### PR DESCRIPTION
## Summary
Introduces a command palette (⌘K/Ctrl-K) that provides global search and navigation across the application. Users can now quickly search for merger records and navigate to main pages from anywhere in the app.

## Key Changes

- **New CommandPalette component** (`CommandPalette.jsx`): A modal dialog that enables:
  - Searching through all merger records with fuzzy matching
  - Quick navigation to main application pages (Dashboard, Mergers, Timeline, etc.)
  - Keyboard navigation (arrow keys, Enter to select, Escape to close)
  - Lazy loading of merger data on cold cache
  - Accessible implementation with proper ARIA attributes and focus management

- **New fetchAllMergers utility** (`fetchAllMergers.js`): Extracted merger fetching logic into a reusable function that:
  - Fetches all pages of the merger list with batched requests (max 4 concurrent)
  - Caches results in dataCache
  - Builds and returns a search index for efficient querying
  - Shared by both the Mergers page and CommandPalette

- **Updated keyboard shortcuts** (`useKeyboardShortcuts.js`):
  - Added ⌘K/Ctrl-K global shortcut to open command palette (works even while typing)
  - Updated "/" shortcut to fall back to opening command palette if no in-page search exists
  - Added `onTogglePalette` callback support

- **Integrated CommandPalette into App** (`App.jsx`):
  - Added state management for palette visibility
  - Wired up keyboard shortcut callbacks

- **Refactored Mergers page** (`Mergers.jsx`):
  - Replaced inline merger fetching logic with `fetchAllMergers()` call
  - Removed duplicate batching and caching logic

- **Updated KeyboardShortcutsHelp** (`KeyboardShortcutsHelp.jsx`):
  - Added documentation for ⌘K shortcut

- **Cleaned up Navbar** (`Navbar.jsx`):
  - Removed custom event listener for search focus (now handled by keyboard shortcuts)

## Notable Implementation Details

- The command palette uses a flattened item list to support seamless keyboard navigation across both pages and merger results
- Selection index is clamped when result sets shrink to prevent out-of-bounds errors
- Merger data is lazily fetched on first palette open if not already cached
- Focus is properly managed: input is focused on open, previous focus is restored on close
- Body scroll is locked while palette is open
- Search results are limited to 8 mergers to keep the UI responsive
- Comprehensive test coverage included for all major interactions

https://claude.ai/code/session_01GaGHMmvossdGZdUzJ2a1N1