### PR TITLE
Show ceased Phase 2 assessments as completed on the Phase 2 tracker

### DIFF
--- a/merger-tracker/frontend/public/data/phase2.json
+++ b/merger-tracker/frontend/public/data/phase2.json
@@ -58,6 +58,17 @@
       "phase_2_inferred": false
     },
     {
+      "merger_id": "MN-30002",
+      "merger_name": "Peter Warren - Wakeling Automotive",
+      "referral_date": "2026-06-02T12:00:00Z",
+      "nocc_date": "2026-07-08T12:00:00Z",
+      "nocc_issued": false,
+      "end_of_determination_period": "2026-10-08T12:00:00Z",
+      "determination": "Assessment ceased",
+      "determination_date": "2026-06-15T12:00:00Z",
+      "phase_2_inferred": false
+    },
+    {
       "merger_id": "MN-01019",
       "merger_name": "Ampol \u2013 EG Australia",
       "referral_date": "2026-01-21T12:00:00Z",
@@ -71,6 +82,6 @@
   ],
   "count": {
     "current": 4,
-    "completed": 2
+    "completed": 3
   }
 }

--- a/scripts/static_data/outputs/phase2.py
+++ b/scripts/static_data/outputs/phase2.py
@@ -10,7 +10,7 @@ computed by :func:`static_data.enrichment.enrich_merger`.
 from constants import merger_status
 
 from ..enrichment import is_phase_2_referral_event
-from ..filters import exclude_for_public_output
+from ..filters import filter_notifications
 
 
 def _referral_date(merger: dict) -> str | None:
@@ -35,6 +35,16 @@ def _nocc(merger: dict) -> tuple:
 
 def _entry(merger: dict) -> dict:
     nocc_date, nocc_issued = _nocc(merger)
+
+    # A ceased assessment ends the Phase 2 review without a formal
+    # determination, so treat the cessation itself as the outcome (mirrors
+    # stats.py's "recent determinations" handling of ceased assessments).
+    determination = merger.get('phase_2_determination')
+    determination_date = merger.get('phase_2_determination_date')
+    if not determination and merger.get('status') == merger_status.ASSESSMENT_CEASED:
+        determination = merger_status.ASSESSMENT_CEASED
+        determination_date = merger.get('ceased_date')
+
     return {
         'merger_id': merger.get('merger_id'),
         'merger_name': merger.get('merger_name'),
@@ -42,8 +52,8 @@ def _entry(merger: dict) -> dict:
         'nocc_date': nocc_date,
         'nocc_issued': nocc_issued,
         'end_of_determination_period': merger.get('end_of_determination_period'),
-        'determination': merger.get('phase_2_determination'),
-        'determination_date': merger.get('phase_2_determination_date'),
+        'determination': determination,
+        'determination_date': determination_date,
         'phase_2_inferred': bool(merger.get('phase_2_inferred')),
     }
 
@@ -53,13 +63,15 @@ def generate(mergers: list) -> dict:
     current = []
     completed = []
 
-    for merger in exclude_for_public_output(mergers):
+    # Waivers are never Phase 2 matters, but ceased assessments must stay in
+    # so their cessation can surface as a completed Phase 2 outcome below.
+    for merger in filter_notifications(mergers):
         stage = merger.get('stage') or ''
         if merger_status.PHASE_2 not in stage:
             continue
 
         entry = _entry(merger)
-        if merger.get('phase_2_determination') and merger.get('phase_2_determination_date'):
+        if entry['determination'] and entry['determination_date']:
             completed.append(entry)
         else:
             current.append(entry)

--- a/scripts/tests/test_phase2.py
+++ b/scripts/tests/test_phase2.py
@@ -69,6 +69,22 @@ def _completed_phase2(merger_id, determination='Approved'):
     }
 
 
+def _ceased_phase2(merger_id, ceased_date='2026-06-15T12:00:00Z'):
+    return {
+        'merger_id': merger_id,
+        'merger_name': f'{merger_id} deal',
+        'status': 'Assessment ceased',
+        'stage': 'Phase 2 - detailed assessment',
+        'effective_notification_datetime': '2025-01-06T09:00:00Z',
+        'end_of_determination_period': '2026-10-08T12:00:00Z',
+        'events': [
+            {'title': 'Merger notified to ACCC', 'date': '2025-01-06T09:00:00Z'},
+            {'title': 'ACCC decided notification is subject to Phase 2 review', 'date': '2025-03-10T09:00:00Z'},
+            {'title': 'Consideration of Notification ceased – following written request from notifying party', 'date': ceased_date},
+        ],
+    }
+
+
 def _waiver():
     return {
         'merger_id': 'WA-0001',
@@ -127,6 +143,17 @@ class TestCurrentVsCompleted:
         mergers = [enrich_merger(_waiver())]
         payload = phase2.generate(mergers)
         assert payload['count'] == {'current': 0, 'completed': 0}
+
+    def test_ceased_phase2_matter_included_as_completed(self):
+        # A ceased assessment ends the Phase 2 review without a formal
+        # determination; it should surface as a completed matter rather
+        # than being excluded or stuck in "current" forever.
+        mergers = [enrich_merger(_ceased_phase2('MN-0003'))]
+        payload = phase2.generate(mergers)
+        assert payload['count'] == {'current': 0, 'completed': 1}
+        entry = payload['completed'][0]
+        assert entry['determination'] == 'Assessment ceased'
+        assert entry['determination_date'] == '2026-06-15T12:00:00Z'
 
 
 class TestNoccFallsBackToComputedDueDate:


### PR DESCRIPTION
phase2.json previously reused the filter_public() predicate, which
excludes ceased assessments entirely — so a matter like MN-30002 (Peter
Warren – Wakeling Automotive), whose Phase 2 review was ceased rather
than determined, vanished from the Phase 2 page instead of showing up
under "Completed Phase 2 matters". Treat the cessation event itself as
the Phase 2 outcome, mirroring how stats.py already surfaces ceased
assessments in recent determinations.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018MTJNA2Qz9rwYgUYiYnZ3W