### PR TITLE
Remove Refiled link from navbar and unfreeze S&P merger events

### DIFF
--- a/data/frozen_events_mergers.json
+++ b/data/frozen_events_mergers.json
@@ -1,7 +1,3 @@
 {
-  "_comment": "Override data for specific mergers. An entry with an empty dict or 'freeze_events: true' preserves the existing events array rather than overwriting from the scraped page (use this when the ACCC events table is incorrect). Any other keys are treated as field overrides \u2014 the scraper will use these values instead of whatever it finds on the page.",
-  "MN-75027": {
-    "_comment": "Event date(s) missing from ACCC page (SLB - S&P Global's Geoscience Software Portfolio - Questionnaire (1 Jul 2026)); freezing events to preserve the automatically set date(s).",
-    "freeze_events": true
-  }
+  "_comment": "Override data for specific mergers. An entry with an empty dict or 'freeze_events: true' preserves the existing events array rather than overwriting from the scraped page (use this when the ACCC events table is incorrect). Any other keys are treated as field overrides \u2014 the scraper will use these values instead of whatever it finds on the page."
 }

--- a/merger-tracker/frontend/src/components/Navbar.jsx
+++ b/merger-tracker/frontend/src/components/Navbar.jsx
@@ -11,7 +11,6 @@ const navLinks = [
   { path: '/', label: 'Dashboard', shortcut: 'd' },
   { path: '/mergers', label: 'Mergers', shortcut: 'm' },
   { path: '/phase-2', label: 'Phase 2' },
-  { path: '/refiled-notifications', label: 'Refiled' },
   { path: '/industries', label: 'Industries', shortcut: 'i' },
   { path: '/commentary', label: 'Commentary', shortcut: 'c' },
   { path: '/analysis', label: 'Analysis', shortcut: 'a' },


### PR DESCRIPTION
The Refiled Notifications page stays reachable at /refiled-notifications,
it's just no longer linked from the navbar. Also removes the frozen_events
override for MN-75027 (SLB - S&P Global's Geoscience Software Portfolio)
so its events resume tracking the ACCC page normally.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PuVzCfvmHN2Row5gJ1ZAYX