### PR TITLE
Dedupe party page merger listings across acquirer/target/other roles

### DIFF
--- a/merger-tracker/frontend/public/data/parties/accenture-plc.json
+++ b/merger-tracker/frontend/public/data/parties/accenture-plc.json
@@ -31,17 +31,7 @@
       }
     ],
     "target": [],
-    "other": [
-      {
-        "merger_id": "MN-10013",
-        "merger_name": "Accenture - Ziff Davis' connectivity business",
-        "is_waiver": false,
-        "status": "Assessment completed",
-        "phase": "Phase 1",
-        "notification_date": "2026-04-17T12:00:00Z",
-        "determination_date": "2026-05-14T12:00:00Z"
-      }
-    ]
+    "other": []
   },
   "merger_count": 1,
   "phase_1_count": 1,

--- a/merger-tracker/frontend/public/data/parties/actigraph-llc.json
+++ b/merger-tracker/frontend/public/data/parties/actigraph-llc.json
@@ -26,17 +26,7 @@
         "determination_date": "2026-04-16T12:00:00Z"
       }
     ],
-    "other": [
-      {
-        "merger_id": "WA-45011",
-        "merger_name": "Signant - ActiGraph",
-        "is_waiver": true,
-        "status": "Assessment completed",
-        "phase": "Waiver",
-        "notification_date": "2026-04-10T12:00:00Z",
-        "determination_date": "2026-04-16T12:00:00Z"
-      }
-    ]
+    "other": []
   },
   "merger_count": 1,
   "phase_1_count": 0,

--- a/merger-tracker/frontend/public/data/parties/australian-meat-group-inc.json
+++ b/merger-tracker/frontend/public/data/parties/australian-meat-group-inc.json
@@ -26,17 +26,7 @@
       }
     ],
     "target": [],
-    "other": [
-      {
-        "merger_id": "MN-20012",
-        "merger_name": "Australian Meat Group - Killara Feedlot",
-        "is_waiver": false,
-        "status": "Assessment completed",
-        "phase": "Phase 1",
-        "notification_date": "2026-04-24T12:00:00Z",
-        "determination_date": "2026-05-22T12:00:00Z"
-      }
-    ]
+    "other": []
   },
   "merger_count": 1,
   "phase_1_count": 1,

--- a/merger-tracker/frontend/public/data/parties/avanos-medical-inc.json
+++ b/merger-tracker/frontend/public/data/parties/avanos-medical-inc.json
@@ -26,17 +26,7 @@
         "determination_date": "2026-05-22T12:00:00Z"
       }
     ],
-    "other": [
-      {
-        "merger_id": "WA-85027",
-        "merger_name": "American Industrial Partners - Avanos Medical",
-        "is_waiver": true,
-        "status": "Assessment completed",
-        "phase": "Waiver",
-        "notification_date": "2026-05-12T12:00:00Z",
-        "determination_date": "2026-05-22T12:00:00Z"
-      }
-    ]
+    "other": []
   },
   "merger_count": 1,
   "phase_1_count": 0,

--- a/merger-tracker/frontend/public/data/parties/awp-australia-pty-ltd.json
+++ b/merger-tracker/frontend/public/data/parties/awp-australia-pty-ltd.json
@@ -26,17 +26,7 @@
       }
     ],
     "target": [],
-    "other": [
-      {
-        "merger_id": "MN-80024",
-        "merger_name": "Allianz \u2013 certain assets of nib\u2019s Australian travel insurance business",
-        "is_waiver": false,
-        "status": "Under assessment",
-        "phase": "Phase 1",
-        "notification_date": "2026-07-03T12:00:00Z",
-        "determination_date": null
-      }
-    ]
+    "other": []
   },
   "merger_count": 1,
   "phase_1_count": 1,

--- a/merger-tracker/frontend/public/data/parties/axalta-coating-systems-ltd.json
+++ b/merger-tracker/frontend/public/data/parties/axalta-coating-systems-ltd.json
@@ -26,17 +26,7 @@
         "determination_date": null
       }
     ],
-    "other": [
-      {
-        "merger_id": "MN-50024",
-        "merger_name": "AkzoNobel - Axalta",
-        "is_waiver": false,
-        "status": "Under assessment",
-        "phase": "Phase 1",
-        "notification_date": "2026-06-24T12:00:00Z",
-        "determination_date": null
-      }
-    ]
+    "other": []
   },
   "merger_count": 1,
   "phase_1_count": 1,

--- a/merger-tracker/frontend/public/data/parties/bcwf-2-pty-limited.json
+++ b/merger-tracker/frontend/public/data/parties/bcwf-2-pty-limited.json
@@ -25,17 +25,7 @@
         "determination_date": "2026-06-24T12:00:00Z"
       }
     ],
-    "target": [
-      {
-        "merger_id": "WA-70021",
-        "merger_name": "Aula Energy \u2013 Additional interest in the Boulder Creek Wind Farm",
-        "is_waiver": true,
-        "status": "Assessment completed",
-        "phase": "Waiver",
-        "notification_date": "2026-05-26T12:00:00Z",
-        "determination_date": "2026-06-24T12:00:00Z"
-      }
-    ],
+    "target": [],
     "other": []
   },
   "merger_count": 1,

--- a/merger-tracker/frontend/public/data/parties/blackline-safety-corp.json
+++ b/merger-tracker/frontend/public/data/parties/blackline-safety-corp.json
@@ -26,17 +26,7 @@
         "determination_date": "2026-05-06T12:00:00Z"
       }
     ],
-    "other": [
-      {
-        "merger_id": "WA-85025",
-        "merger_name": "Francisco Partners - Blackline Safety",
-        "is_waiver": true,
-        "status": "Assessment completed",
-        "phase": "Waiver",
-        "notification_date": "2026-04-24T12:00:00Z",
-        "determination_date": "2026-05-06T12:00:00Z"
-      }
-    ]
+    "other": []
   },
   "merger_count": 1,
   "phase_1_count": 0,

--- a/merger-tracker/frontend/public/data/parties/clearwater-analytics-llc.json
+++ b/merger-tracker/frontend/public/data/parties/clearwater-analytics-llc.json
@@ -26,17 +26,7 @@
         "determination_date": "2026-04-01T12:00:00Z"
       }
     ],
-    "other": [
-      {
-        "merger_id": "WA-40010",
-        "merger_name": "Permira and Warburg Pincus - Clearwater Analytics",
-        "is_waiver": true,
-        "status": "Assessment completed",
-        "phase": "Waiver",
-        "notification_date": "2026-03-11T12:00:00Z",
-        "determination_date": "2026-04-01T12:00:00Z"
-      }
-    ]
+    "other": []
   },
   "merger_count": 1,
   "phase_1_count": 0,

--- a/merger-tracker/frontend/public/data/parties/coles.json
+++ b/merger-tracker/frontend/public/data/parties/coles.json
@@ -99,17 +99,7 @@
       }
     ],
     "target": [],
-    "other": [
-      {
-        "merger_id": "WA-60012",
-        "merger_name": "Coles \u2013 land around supermarket site in Balaclava, VIC",
-        "is_waiver": true,
-        "status": "Assessment completed",
-        "phase": "Waiver",
-        "notification_date": "2026-03-25T12:00:00Z",
-        "determination_date": "2026-04-23T12:00:00Z"
-      }
-    ]
+    "other": []
   },
   "merger_count": 8,
   "phase_1_count": 4,

--- a/merger-tracker/frontend/public/data/parties/derbysoft-inc.json
+++ b/merger-tracker/frontend/public/data/parties/derbysoft-inc.json
@@ -26,17 +26,7 @@
         "determination_date": "2026-05-15T12:00:00Z"
       }
     ],
-    "other": [
-      {
-        "merger_id": "WA-90014",
-        "merger_name": "Constellation Software - DerbySoft Holdings",
-        "is_waiver": true,
-        "status": "Assessment completed",
-        "phase": "Waiver",
-        "notification_date": "2026-04-29T12:00:00Z",
-        "determination_date": "2026-05-15T12:00:00Z"
-      }
-    ]
+    "other": []
   },
   "merger_count": 1,
   "phase_1_count": 0,

--- a/merger-tracker/frontend/public/data/parties/excellergy-inc.json
+++ b/merger-tracker/frontend/public/data/parties/excellergy-inc.json
@@ -26,17 +26,7 @@
         "determination_date": "2026-06-04T12:00:00Z"
       }
     ],
-    "other": [
-      {
-        "merger_id": "MN-40019",
-        "merger_name": "Novartis - Excellergy",
-        "is_waiver": false,
-        "status": "Assessment completed",
-        "phase": "Phase 1",
-        "notification_date": "2026-05-12T12:00:00Z",
-        "determination_date": "2026-06-04T12:00:00Z"
-      }
-    ]
+    "other": []
   },
   "merger_count": 1,
   "phase_1_count": 1,

--- a/merger-tracker/frontend/public/data/parties/freudenberg-home-and-cleaning-solutions-gmbh.json
+++ b/merger-tracker/frontend/public/data/parties/freudenberg-home-and-cleaning-solutions-gmbh.json
@@ -26,17 +26,7 @@
       }
     ],
     "target": [],
-    "other": [
-      {
-        "merger_id": "MN-70005",
-        "merger_name": "Freudenberg Home and Cleaning Solutions \u2013 Nilfisk",
-        "is_waiver": false,
-        "status": "Assessment completed",
-        "phase": "Phase 1",
-        "notification_date": "2026-02-09T12:00:00Z",
-        "determination_date": "2026-03-12T12:00:00Z"
-      }
-    ]
+    "other": []
   },
   "merger_count": 1,
   "phase_1_count": 1,

--- a/merger-tracker/frontend/public/data/parties/gitpod-gmbh.json
+++ b/merger-tracker/frontend/public/data/parties/gitpod-gmbh.json
@@ -26,17 +26,7 @@
         "determination_date": null
       }
     ],
-    "other": [
-      {
-        "merger_id": "MN-90020",
-        "merger_name": "OpenAI - Ona",
-        "is_waiver": false,
-        "status": "Under assessment",
-        "phase": "Phase 1",
-        "notification_date": "2026-06-26T12:00:00Z",
-        "determination_date": null
-      }
-    ]
+    "other": []
   },
   "merger_count": 1,
   "phase_1_count": 1,

--- a/merger-tracker/frontend/public/data/parties/hermes-bidco-limited.json
+++ b/merger-tracker/frontend/public/data/parties/hermes-bidco-limited.json
@@ -26,17 +26,7 @@
       }
     ],
     "target": [],
-    "other": [
-      {
-        "merger_id": "WA-75021",
-        "merger_name": "Hillhouse - KMC Solutions",
-        "is_waiver": true,
-        "status": "Assessment completed",
-        "phase": "Waiver",
-        "notification_date": "2026-04-28T12:00:00Z",
-        "determination_date": "2026-05-25T12:00:00Z"
-      }
-    ]
+    "other": []
   },
   "merger_count": 1,
   "phase_1_count": 0,

--- a/merger-tracker/frontend/public/data/parties/highspot-inc.json
+++ b/merger-tracker/frontend/public/data/parties/highspot-inc.json
@@ -26,17 +26,7 @@
         "determination_date": "2026-06-04T12:00:00Z"
       }
     ],
-    "other": [
-      {
-        "merger_id": "MN-75014",
-        "merger_name": "Seismic \u2013 Highspot",
-        "is_waiver": false,
-        "status": "Assessment completed",
-        "phase": "Phase 1",
-        "notification_date": "2026-05-12T12:00:00Z",
-        "determination_date": "2026-06-04T12:00:00Z"
-      }
-    ]
+    "other": []
   },
   "merger_count": 1,
   "phase_1_count": 1,

--- a/merger-tracker/frontend/public/data/parties/rocket-software-inc.json
+++ b/merger-tracker/frontend/public/data/parties/rocket-software-inc.json
@@ -26,17 +26,7 @@
       }
     ],
     "target": [],
-    "other": [
-      {
-        "merger_id": "MN-20009",
-        "merger_name": "Rocket Software \u2013 Vertica",
-        "is_waiver": false,
-        "status": "Assessment completed",
-        "phase": "Phase 1",
-        "notification_date": "2026-03-11T12:00:00Z",
-        "determination_date": "2026-04-01T12:00:00Z"
-      }
-    ]
+    "other": []
   },
   "merger_count": 1,
   "phase_1_count": 1,

--- a/merger-tracker/frontend/public/data/parties/seismic-software-inc.json
+++ b/merger-tracker/frontend/public/data/parties/seismic-software-inc.json
@@ -26,17 +26,7 @@
       }
     ],
     "target": [],
-    "other": [
-      {
-        "merger_id": "MN-75014",
-        "merger_name": "Seismic \u2013 Highspot",
-        "is_waiver": false,
-        "status": "Assessment completed",
-        "phase": "Phase 1",
-        "notification_date": "2026-05-12T12:00:00Z",
-        "determination_date": "2026-06-04T12:00:00Z"
-      }
-    ]
+    "other": []
   },
   "merger_count": 1,
   "phase_1_count": 1,

--- a/merger-tracker/frontend/public/data/parties/servicenow-inc.json
+++ b/merger-tracker/frontend/public/data/parties/servicenow-inc.json
@@ -35,17 +35,7 @@
       }
     ],
     "target": [],
-    "other": [
-      {
-        "merger_id": "MN-25004",
-        "merger_name": "ServiceNow - Armis",
-        "is_waiver": false,
-        "status": "Assessment completed",
-        "phase": "Phase 1",
-        "notification_date": "2026-02-13T12:00:00Z",
-        "determination_date": "2026-03-12T12:00:00Z"
-      }
-    ]
+    "other": []
   },
   "merger_count": 2,
   "phase_1_count": 2,

--- a/merger-tracker/frontend/public/data/parties/shrika-pty-ltd.json
+++ b/merger-tracker/frontend/public/data/parties/shrika-pty-ltd.json
@@ -26,17 +26,7 @@
         "determination_date": "2026-06-20T12:00:00Z"
       }
     ],
-    "other": [
-      {
-        "merger_id": "MN-05014",
-        "merger_name": "Smile Partners Australia \u2013 Mehta Orthodontics",
-        "is_waiver": false,
-        "status": "Assessment completed",
-        "phase": "Phase 1",
-        "notification_date": "2026-05-26T12:00:00Z",
-        "determination_date": "2026-06-20T12:00:00Z"
-      }
-    ]
+    "other": []
   },
   "merger_count": 1,
   "phase_1_count": 1,

--- a/merger-tracker/frontend/public/data/parties/stonepeak-motion-poolingco-limited.json
+++ b/merger-tracker/frontend/public/data/parties/stonepeak-motion-poolingco-limited.json
@@ -25,17 +25,7 @@
         "determination_date": "2026-06-18T12:00:00Z"
       }
     ],
-    "target": [
-      {
-        "merger_id": "MN-60015",
-        "merger_name": "Stonepeak \u2013 Castrol",
-        "is_waiver": false,
-        "status": "Assessment completed",
-        "phase": "Phase 1",
-        "notification_date": "2026-05-21T12:00:00Z",
-        "determination_date": "2026-06-18T12:00:00Z"
-      }
-    ],
+    "target": [],
     "other": []
   },
   "merger_count": 1,

--- a/merger-tracker/frontend/public/data/parties/tetra-tech-inc.json
+++ b/merger-tracker/frontend/public/data/parties/tetra-tech-inc.json
@@ -31,17 +31,7 @@
       }
     ],
     "target": [],
-    "other": [
-      {
-        "merger_id": "WA-70008",
-        "merger_name": "Tetra Tech \u2013 Providence Consulting",
-        "is_waiver": true,
-        "status": "Assessment completed",
-        "phase": "Waiver",
-        "notification_date": "2026-02-27T12:00:00Z",
-        "determination_date": "2026-04-01T12:00:00Z"
-      }
-    ]
+    "other": []
   },
   "merger_count": 1,
   "phase_1_count": 0,

--- a/merger-tracker/frontend/public/data/parties/vets-central-holdings-pty-ltd.json
+++ b/merger-tracker/frontend/public/data/parties/vets-central-holdings-pty-ltd.json
@@ -109,62 +109,7 @@
       }
     ],
     "target": [],
-    "other": [
-      {
-        "merger_id": "WA-55026",
-        "merger_name": "Vets Central - Gold Coast Veterinary Surgery",
-        "is_waiver": true,
-        "status": "Assessment completed",
-        "phase": "Waiver",
-        "notification_date": "2026-06-23T12:00:00Z",
-        "determination_date": "2026-07-03T12:00:00Z"
-      },
-      {
-        "merger_id": "WA-15022",
-        "merger_name": "Vets Central - Morley Veterinary Hospital",
-        "is_waiver": true,
-        "status": "Assessment completed",
-        "phase": "Waiver",
-        "notification_date": "2026-05-27T12:00:00Z",
-        "determination_date": "2026-06-18T12:00:00Z"
-      },
-      {
-        "merger_id": "WA-55023",
-        "merger_name": "Vets Central - Claremont Veterinary Surgery",
-        "is_waiver": true,
-        "status": "Assessment completed",
-        "phase": "Waiver",
-        "notification_date": "2026-05-22T12:00:00Z",
-        "determination_date": "2026-06-04T12:00:00Z"
-      },
-      {
-        "merger_id": "WA-85016",
-        "merger_name": "Vets Central \u2013 Hills Veterinary Centre",
-        "is_waiver": true,
-        "status": "Assessment completed",
-        "phase": "Waiver",
-        "notification_date": "2026-03-16T12:00:00Z",
-        "determination_date": "2026-04-14T12:00:00Z"
-      },
-      {
-        "merger_id": "WA-75017",
-        "merger_name": "Vets Central - Drovers Vet Hospital",
-        "is_waiver": true,
-        "status": "Assessment completed",
-        "phase": "Waiver",
-        "notification_date": "2026-03-31T12:00:00Z",
-        "determination_date": "2026-04-07T12:00:00Z"
-      },
-      {
-        "merger_id": "WA-95008",
-        "merger_name": "Vets Central \u2013 West Toowoomba Veterinary Surgery in QLD",
-        "is_waiver": true,
-        "status": "Assessment completed",
-        "phase": "Waiver",
-        "notification_date": "2026-03-04T12:00:00Z",
-        "determination_date": "2026-03-10T12:00:00Z"
-      }
-    ]
+    "other": []
   },
   "merger_count": 8,
   "phase_1_count": 1,

--- a/merger-tracker/frontend/public/data/parties/wsp-australia-pty-limited.json
+++ b/merger-tracker/frontend/public/data/parties/wsp-australia-pty-limited.json
@@ -40,17 +40,7 @@
       }
     ],
     "target": [],
-    "other": [
-      {
-        "merger_id": "MN-01107",
-        "merger_name": "WSP - Geotechnical Testing and Interpretation",
-        "is_waiver": false,
-        "status": "Under assessment",
-        "phase": "Phase 1",
-        "notification_date": "2026-06-26T12:00:00Z",
-        "determination_date": null
-      }
-    ]
+    "other": []
   },
   "merger_count": 2,
   "phase_1_count": 1,

--- a/merger-tracker/frontend/public/data/parties/zen-energy-retail-pty-ltd.json
+++ b/merger-tracker/frontend/public/data/parties/zen-energy-retail-pty-ltd.json
@@ -26,17 +26,7 @@
         "determination_date": "2026-06-24T12:00:00Z"
       }
     ],
-    "other": [
-      {
-        "merger_id": "WA-15025",
-        "merger_name": "Gunvor Group \u2013 ZEN Energy Retail Holdings",
-        "is_waiver": true,
-        "status": "Assessment completed",
-        "phase": "Waiver",
-        "notification_date": "2026-06-10T12:00:00Z",
-        "determination_date": "2026-06-24T12:00:00Z"
-      }
-    ]
+    "other": []
   },
   "merger_count": 1,
   "phase_1_count": 0,

--- a/scripts/static_data/outputs/parties.py
+++ b/scripts/static_data/outputs/parties.py
@@ -113,11 +113,21 @@ def build_party_pages(mergers: list, party_groups: list) -> list:
             {(name, identifier, id_type) for name, identifier, id_type in entry['members'] if name}
         )
 
+        # A party can be listed under more than one role on the same merger
+        # (e.g. named as both an applicant and an "other party" in the ACCC's
+        # own register). Only show it once per merger on its party page,
+        # preferring acquirer/target over other — PARTY_ROLE_FIELDS order
+        # ("acquirers", "targets", "other_parties") gives us that priority
+        # since appearances for a given merger are processed in that order.
         mergers_by_role: dict[str, dict] = {'acquirer': {}, 'target': {}, 'other': {}}
+        assigned_role_by_merger: dict = {}
         for merger, field, party in entry['appearances']:
             party['party_page'] = {'id': group_id, 'name': canonical_name}
             role = ROLE_LABELS[field]
             merger_id = merger.get('merger_id')
+            if merger_id in assigned_role_by_merger:
+                continue
+            assigned_role_by_merger[merger_id] = role
             mergers_by_role[role][merger_id] = merger
 
         groups.append({

--- a/scripts/tests/test_static_data_outputs.py
+++ b/scripts/tests/test_static_data_outputs.py
@@ -1728,6 +1728,20 @@ class TestBuildPartyPages:
         assert member_names == {'COLES GROUP LIMITED', 'COLES SUPERMARKETS AUSTRALIA PTY LTD'}
         assert set(coles['mergers_by_role']['acquirer'].keys()) == {'MN-1001', 'MN-1002'}
 
+    def test_party_listed_in_two_roles_on_same_merger_only_counted_once(self):
+        # ACCC's own register sometimes lists the same entity as both an
+        # applicant and an "other party" on one matter. The party page
+        # should show that merger once, under the higher-priority role
+        # (acquirer/target), not duplicated under "other" too.
+        mergers = _party_mergers_fixture()
+        mergers[0]['other_parties'] = [
+            {'name': 'COLES GROUP LIMITED', 'identifier': '11 004 089 936', 'identifier_type': 'ABN'}
+        ]
+        groups = parties.build_party_pages(mergers, [_COLES_GROUP])
+        coles = next(g for g in groups if g['id'] == 'coles')
+        assert set(coles['mergers_by_role']['acquirer'].keys()) == {'MN-1001', 'MN-1002'}
+        assert 'MN-1001' not in coles['mergers_by_role']['other']
+
     def test_unlisted_party_gets_a_synthesized_group_of_one(self):
         # Depot Holdings has no canonical group entry but recurs (same ABN)
         # as a target in MN-1002 and an acquirer in MN-1003 — both appearances


### PR DESCRIPTION
A party listed both as an applicant and as an "other party" on the same
matter (as the ACCC's register sometimes does) was showing up twice on
its party page — once under "As acquirer"/"As target" and again under
"As other party". Prioritize acquirer/target over other so each merger
appears once, under its most substantive role.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KP8AhS54bGmjt6777T9fJu