### PR TITLE
Dedupe MN-65005 events and freeze against ACCC's buggy table

### DIFF
--- a/data/frozen_events_mergers.json
+++ b/data/frozen_events_mergers.json
@@ -1,3 +1,7 @@
 {
-  "_comment": "Override data for specific mergers. An entry with an empty dict or 'freeze_events: true' preserves the existing events array rather than overwriting from the scraped page (use this when the ACCC events table is incorrect). Any other keys are treated as field overrides \u2014 the scraper will use these values instead of whatever it finds on the page."
+  "_comment": "Override data for specific mergers. An entry with an empty dict or 'freeze_events: true' preserves the existing events array rather than overwriting from the scraped page (use this when the ACCC events table is incorrect). Any other keys are treated as field overrides \u2014 the scraper will use these values instead of whatever it finds on the page.",
+  "MN-65005": {
+    "_comment": "ACCC events table has duplicate rows: 'Summary of Notice of Competition Concerns' listed twice (14 May and 25 May) for the same byte-identical re-uploaded document, and 'Timeline extended by ... business days' listed both with and without the '20' day count. Deduped to one entry each; freezing events to stop the duplicates reappearing from the still-buggy ACCC page.",
+    "freeze_events": true
+  }
 }

--- a/data/output/mergers.json
+++ b/data/output/mergers.json
@@ -30743,8 +30743,8 @@
           "date": "2026-05-25T12:00:00Z",
           "title": "Summary of Notice of Competition Concerns",
           "display_title": "Summary of Notice of Competition Concerns",
-          "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/IAG_RACI%20-%20Summary%20of%20Notice%20of%20Competition%20Concerns%20-%2025%20May%202026_0.pdf",
-          "url_gh": "/mergers/MN-65005/IAG_RACI - Summary of Notice of Competition Concerns - 25 May 2026_0.pdf",
+          "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/IAG_RACI%20-%20Summary%20of%20Notice%20of%20Competition%20Concerns%20-%2025%20May%202026_3.pdf",
+          "url_gh": "/mergers/MN-65005/IAG_RACI - Summary of Notice of Competition Concerns - 25 May 2026_3.pdf",
           "status": "live",
           "phase": null
         },
@@ -30770,21 +30770,6 @@
           "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/IAG%20RACI%20-%20Questionnaire%20-%20Remedy%20Offer%20%281%20July%202026%29_1.docx",
           "url_gh": "/mergers/MN-65005/IAG RACI - Questionnaire - Remedy Offer (1 July 2026)_1.pdf",
           "status": "live",
-          "phase": null
-        },
-        {
-          "date": "2026-05-14T12:00:00Z",
-          "title": "Summary of Notice of Competition Concerns",
-          "display_title": "Summary of Notice of Competition Concerns",
-          "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/IAG_RACI%20-%20Summary%20of%20Notice%20of%20Competition%20Concerns%20-%2025%20May%202026_3.pdf",
-          "url_gh": "/mergers/MN-65005/IAG_RACI - Summary of Notice of Competition Concerns - 25 May 2026_3.pdf",
-          "status": "live",
-          "phase": null
-        },
-        {
-          "date": "2026-06-26T12:00:00Z",
-          "title": "Timeline extended by business days - following request for further information",
-          "display_title": "Timeline extended by business days - following request for further information",
           "phase": null
         }
       ],

--- a/data/processed/mergers.json
+++ b/data/processed/mergers.json
@@ -14724,8 +14724,8 @@
         "date": "2026-05-25T12:00:00Z",
         "title": "Summary of Notice of Competition Concerns",
         "display_title": "Summary of Notice of Competition Concerns",
-        "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/IAG_RACI%20-%20Summary%20of%20Notice%20of%20Competition%20Concerns%20-%2025%20May%202026_0.pdf",
-        "url_gh": "/mergers/MN-65005/IAG_RACI - Summary of Notice of Competition Concerns - 25 May 2026_0.pdf",
+        "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/IAG_RACI%20-%20Summary%20of%20Notice%20of%20Competition%20Concerns%20-%2025%20May%202026_3.pdf",
+        "url_gh": "/mergers/MN-65005/IAG_RACI - Summary of Notice of Competition Concerns - 25 May 2026_3.pdf",
         "status": "live"
       },
       {
@@ -14748,19 +14748,6 @@
         "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/IAG%20RACI%20-%20Questionnaire%20-%20Remedy%20Offer%20%281%20July%202026%29_1.docx",
         "url_gh": "/mergers/MN-65005/IAG RACI - Questionnaire - Remedy Offer (1 July 2026)_1.pdf",
         "status": "live"
-      },
-      {
-        "date": "2026-05-14T12:00:00Z",
-        "title": "Summary of Notice of Competition Concerns",
-        "display_title": "Summary of Notice of Competition Concerns",
-        "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/IAG_RACI%20-%20Summary%20of%20Notice%20of%20Competition%20Concerns%20-%2025%20May%202026_3.pdf",
-        "url_gh": "/mergers/MN-65005/IAG_RACI - Summary of Notice of Competition Concerns - 25 May 2026_3.pdf",
-        "status": "live"
-      },
-      {
-        "date": "2026-06-26T12:00:00Z",
-        "title": "Timeline extended by business days - following request for further information",
-        "display_title": "Timeline extended by business days - following request for further information"
       }
     ],
     "is_waiver": false

--- a/merger-tracker/frontend/public/data/mergers/MN-65005.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-65005.json
@@ -143,8 +143,8 @@
       "date": "2026-05-25T12:00:00Z",
       "title": "Summary of Notice of Competition Concerns",
       "display_title": "Summary of Notice of Competition Concerns",
-      "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/IAG_RACI%20-%20Summary%20of%20Notice%20of%20Competition%20Concerns%20-%2025%20May%202026_0.pdf",
-      "url_gh": "/mergers/MN-65005/IAG_RACI - Summary of Notice of Competition Concerns - 25 May 2026_0.pdf",
+      "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/IAG_RACI%20-%20Summary%20of%20Notice%20of%20Competition%20Concerns%20-%2025%20May%202026_3.pdf",
+      "url_gh": "/mergers/MN-65005/IAG_RACI - Summary of Notice of Competition Concerns - 25 May 2026_3.pdf",
       "status": "live",
       "phase": null
     },
@@ -170,21 +170,6 @@
       "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/IAG%20RACI%20-%20Questionnaire%20-%20Remedy%20Offer%20%281%20July%202026%29_1.docx",
       "url_gh": "/mergers/MN-65005/IAG RACI - Questionnaire - Remedy Offer (1 July 2026)_1.pdf",
       "status": "live",
-      "phase": null
-    },
-    {
-      "date": "2026-05-14T12:00:00Z",
-      "title": "Summary of Notice of Competition Concerns",
-      "display_title": "Summary of Notice of Competition Concerns",
-      "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/IAG_RACI%20-%20Summary%20of%20Notice%20of%20Competition%20Concerns%20-%2025%20May%202026_3.pdf",
-      "url_gh": "/mergers/MN-65005/IAG_RACI - Summary of Notice of Competition Concerns - 25 May 2026_3.pdf",
-      "status": "live",
-      "phase": null
-    },
-    {
-      "date": "2026-06-26T12:00:00Z",
-      "title": "Timeline extended by business days - following request for further information",
-      "display_title": "Timeline extended by business days - following request for further information",
       "phase": null
     }
   ],

--- a/merger-tracker/frontend/public/data/timeline-meta.json
+++ b/merger-tracker/frontend/public/data/timeline-meta.json
@@ -1,5 +1,5 @@
 {
-  "total": 1033,
+  "total": 1031,
   "page_size": 100,
   "total_pages": 11
 }

--- a/merger-tracker/frontend/public/data/timeline-page-10.json
+++ b/merger-tracker/frontend/public/data/timeline-page-10.json
@@ -2,18 +2,6 @@
   "events": [
     {
       "date": "2026-06-19T12:00:00Z",
-      "title": "Merger notified to ACCC",
-      "display_title": "Merger notified to ACCC",
-      "url": null,
-      "url_gh": null,
-      "status": null,
-      "merger_id": "MN-60022",
-      "merger_name": "Autodesk - MaintainX",
-      "phase": "Phase 1",
-      "is_waiver": false
-    },
-    {
-      "date": "2026-06-19T12:00:00Z",
       "title": "Questionnaire",
       "display_title": "Questionnaire",
       "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/Concord%20-%20Questionnaire_0.docx",
@@ -650,18 +638,6 @@
     },
     {
       "date": "2026-06-26T12:00:00Z",
-      "title": "Timeline extended by business days - following request for further information",
-      "display_title": "Timeline extended by business days - following request for further information",
-      "url": null,
-      "url_gh": null,
-      "status": null,
-      "merger_id": "MN-65005",
-      "merger_name": "Insurance Australia Group \u2013 RAC Insurance",
-      "phase": null,
-      "is_waiver": false
-    },
-    {
-      "date": "2026-06-26T12:00:00Z",
       "title": "Merger notified to ACCC",
       "display_title": "Merger notified to ACCC",
       "url": null,
@@ -1199,6 +1175,30 @@
       "merger_name": "SpaceX - Anysphere",
       "phase": null,
       "is_waiver": false
+    },
+    {
+      "date": "2026-07-01T12:00:00Z",
+      "title": "Notification waiver determination published",
+      "display_title": "Waiver application determination: Approved",
+      "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/Warburg%20Pincus%20%E2%80%93%20Commercial%20Credit%20Holdings%20Limited%20%28WA-25030%29%20-%20Notification%20waiver%20determination%20-%201%20July%202026.pdf",
+      "url_gh": "/mergers/WA-25030/Warburg Pincus \u2013 Commercial Credit Holdings Limited (WA-25030) - Notification waiver determination - 1 July 2026.pdf",
+      "status": "live",
+      "merger_id": "WA-25030",
+      "merger_name": "Warburg Pincus \u2013 Commercial Credit Holdings Limited",
+      "phase": "Waiver",
+      "is_waiver": true
+    },
+    {
+      "date": "2026-07-01T12:00:00Z",
+      "title": "Notification waiver determination published",
+      "display_title": "Waiver application determination: Approved",
+      "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/Count%20%E2%80%93%20Oracle%20Group%20%28WA-45018%29%20-%20Notification%20waiver%20determination%20-%201%20July%202026.pdf",
+      "url_gh": "/mergers/WA-45018/Count \u2013 Oracle Group (WA-45018) - Notification waiver determination - 1 July 2026.pdf",
+      "status": "live",
+      "merger_id": "WA-45018",
+      "merger_name": "Count \u2013 Oracle Group",
+      "phase": "Waiver",
+      "is_waiver": true
     }
   ],
   "page": 10,

--- a/merger-tracker/frontend/public/data/timeline-page-11.json
+++ b/merger-tracker/frontend/public/data/timeline-page-11.json
@@ -1,30 +1,6 @@
 {
   "events": [
     {
-      "date": "2026-07-01T12:00:00Z",
-      "title": "Notification waiver determination published",
-      "display_title": "Waiver application determination: Approved",
-      "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/Warburg%20Pincus%20%E2%80%93%20Commercial%20Credit%20Holdings%20Limited%20%28WA-25030%29%20-%20Notification%20waiver%20determination%20-%201%20July%202026.pdf",
-      "url_gh": "/mergers/WA-25030/Warburg Pincus \u2013 Commercial Credit Holdings Limited (WA-25030) - Notification waiver determination - 1 July 2026.pdf",
-      "status": "live",
-      "merger_id": "WA-25030",
-      "merger_name": "Warburg Pincus \u2013 Commercial Credit Holdings Limited",
-      "phase": "Waiver",
-      "is_waiver": true
-    },
-    {
-      "date": "2026-07-01T12:00:00Z",
-      "title": "Notification waiver determination published",
-      "display_title": "Waiver application determination: Approved",
-      "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/Count%20%E2%80%93%20Oracle%20Group%20%28WA-45018%29%20-%20Notification%20waiver%20determination%20-%201%20July%202026.pdf",
-      "url_gh": "/mergers/WA-45018/Count \u2013 Oracle Group (WA-45018) - Notification waiver determination - 1 July 2026.pdf",
-      "status": "live",
-      "merger_id": "WA-45018",
-      "merger_name": "Count \u2013 Oracle Group",
-      "phase": "Waiver",
-      "is_waiver": true
-    },
-    {
       "date": "2026-07-02T12:00:00Z",
       "title": "ACCC decided notification is subject to Phase 2 review",
       "display_title": "ACCC decided notification is subject to Phase 2 review",

--- a/merger-tracker/frontend/public/data/timeline-page-7.json
+++ b/merger-tracker/frontend/public/data/timeline-page-7.json
@@ -206,18 +206,6 @@
     },
     {
       "date": "2026-05-14T12:00:00Z",
-      "title": "Summary of Notice of Competition Concerns",
-      "display_title": "Summary of Notice of Competition Concerns",
-      "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/IAG_RACI%20-%20Summary%20of%20Notice%20of%20Competition%20Concerns%20-%2025%20May%202026_3.pdf",
-      "url_gh": "/mergers/MN-65005/IAG_RACI - Summary of Notice of Competition Concerns - 25 May 2026_3.pdf",
-      "status": "live",
-      "merger_id": "MN-65005",
-      "merger_name": "Insurance Australia Group \u2013 RAC Insurance",
-      "phase": null,
-      "is_waiver": false
-    },
-    {
-      "date": "2026-05-14T12:00:00Z",
       "title": "Merger notified to ACCC",
       "display_title": "Merger notified to ACCC",
       "url": null,
@@ -1198,6 +1186,18 @@
       "merger_id": "WA-85027",
       "merger_name": "American Industrial Partners - Avanos Medical",
       "phase": "Waiver",
+      "is_waiver": true
+    },
+    {
+      "date": "2026-05-22T12:00:00Z",
+      "title": "Merger notified to ACCC",
+      "display_title": "Merger notified to ACCC",
+      "url": null,
+      "url_gh": null,
+      "status": null,
+      "merger_id": "WA-95022",
+      "merger_name": "Life Without Barriers \u2013 Mallacoota District Health & Support Service",
+      "phase": "Phase 1",
       "is_waiver": true
     }
   ],

--- a/merger-tracker/frontend/public/data/timeline-page-8.json
+++ b/merger-tracker/frontend/public/data/timeline-page-8.json
@@ -1,18 +1,6 @@
 {
   "events": [
     {
-      "date": "2026-05-22T12:00:00Z",
-      "title": "Merger notified to ACCC",
-      "display_title": "Merger notified to ACCC",
-      "url": null,
-      "url_gh": null,
-      "status": null,
-      "merger_id": "WA-95022",
-      "merger_name": "Life Without Barriers \u2013 Mallacoota District Health & Support Service",
-      "phase": "Phase 1",
-      "is_waiver": true
-    },
-    {
       "date": "2026-05-25T12:00:00Z",
       "title": "Timeline extended by 4 business days \u2013 following request for further information",
       "display_title": "Timeline extended by 4 business days \u2013 following request for further information",
@@ -76,8 +64,8 @@
       "date": "2026-05-25T12:00:00Z",
       "title": "Summary of Notice of Competition Concerns",
       "display_title": "Summary of Notice of Competition Concerns",
-      "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/IAG_RACI%20-%20Summary%20of%20Notice%20of%20Competition%20Concerns%20-%2025%20May%202026_0.pdf",
-      "url_gh": "/mergers/MN-65005/IAG_RACI - Summary of Notice of Competition Concerns - 25 May 2026_0.pdf",
+      "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/IAG_RACI%20-%20Summary%20of%20Notice%20of%20Competition%20Concerns%20-%2025%20May%202026_3.pdf",
+      "url_gh": "/mergers/MN-65005/IAG_RACI - Summary of Notice of Competition Concerns - 25 May 2026_3.pdf",
       "status": "live",
       "merger_id": "MN-65005",
       "merger_name": "Insurance Australia Group \u2013 RAC Insurance",
@@ -1198,6 +1186,18 @@
       "merger_id": "WA-75024",
       "merger_name": "KfW \u2013 KNDS N.V.",
       "phase": "Waiver",
+      "is_waiver": true
+    },
+    {
+      "date": "2026-06-04T12:00:00Z",
+      "title": "Merger notified to ACCC",
+      "display_title": "Merger notified to ACCC",
+      "url": null,
+      "url_gh": null,
+      "status": null,
+      "merger_id": "WA-85032",
+      "merger_name": "Ares (Bolt S.p.A.) \u2013 Investment in Plenitude",
+      "phase": "Phase 1",
       "is_waiver": true
     }
   ],

--- a/merger-tracker/frontend/public/data/timeline-page-9.json
+++ b/merger-tracker/frontend/public/data/timeline-page-9.json
@@ -2,18 +2,6 @@
   "events": [
     {
       "date": "2026-06-04T12:00:00Z",
-      "title": "Merger notified to ACCC",
-      "display_title": "Merger notified to ACCC",
-      "url": null,
-      "url_gh": null,
-      "status": null,
-      "merger_id": "WA-85032",
-      "merger_name": "Ares (Bolt S.p.A.) \u2013 Investment in Plenitude",
-      "phase": "Phase 1",
-      "is_waiver": true
-    },
-    {
-      "date": "2026-06-04T12:00:00Z",
       "title": "Notification waiver determination published",
       "display_title": "Waiver application determination: Approved",
       "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/Grant%20Thornton%20Advisors%20-%20Grant%20Thornton%20Australia%20%28WA-95020%29%20-%20Notification%20waiver%20determination%20-%204%20June%202026.pdf",
@@ -1198,6 +1186,18 @@
       "merger_id": "MN-60022",
       "merger_name": "Autodesk - MaintainX",
       "phase": null,
+      "is_waiver": false
+    },
+    {
+      "date": "2026-06-19T12:00:00Z",
+      "title": "Merger notified to ACCC",
+      "display_title": "Merger notified to ACCC",
+      "url": null,
+      "url_gh": null,
+      "status": null,
+      "merger_id": "MN-60022",
+      "merger_name": "Autodesk - MaintainX",
+      "phase": "Phase 1",
       "is_waiver": false
     }
   ],

--- a/merger-tracker/frontend/public/data/upcoming-events.json
+++ b/merger-tracker/frontend/public/data/upcoming-events.json
@@ -3,56 +3,6 @@
     {
       "type": "consultation_due",
       "event_type_display": "Consultation responses due",
-      "date": "2026-07-08T12:00:00Z",
-      "merger_id": "MN-35017",
-      "merger_name": "KINETIC - DYSONS BUS SERVICES",
-      "status": "Under assessment",
-      "stage": "Phase 1 - initial assessment",
-      "effective_notification_datetime": "2026-06-30T12:00:00Z"
-    },
-    {
-      "type": "consultation_due",
-      "event_type_display": "Consultation responses due",
-      "date": "2026-07-08T12:00:00Z",
-      "merger_id": "MN-35018",
-      "merger_name": "Hewitt \u2013 Nolan Meats",
-      "status": "Under assessment",
-      "stage": "Phase 1 - initial assessment",
-      "effective_notification_datetime": "2026-07-01T12:00:00Z"
-    },
-    {
-      "type": "consultation_due",
-      "event_type_display": "Consultation responses due",
-      "date": "2026-07-08T12:00:00Z",
-      "merger_id": "MN-50030",
-      "merger_name": "Symal Group - Shamrock Engineering and Equipment",
-      "status": "Under assessment",
-      "stage": "Phase 1 - initial assessment",
-      "effective_notification_datetime": "2026-07-01T12:00:00Z"
-    },
-    {
-      "type": "consultation_due",
-      "event_type_display": "Consultation responses due",
-      "date": "2026-07-08T12:00:00Z",
-      "merger_id": "MN-75027",
-      "merger_name": "SLB \u2013 S&P Global\u2019s Geoscience Software Portfolio",
-      "status": "Under assessment",
-      "stage": "Phase 1 - initial assessment",
-      "effective_notification_datetime": "2026-06-30T12:00:00Z"
-    },
-    {
-      "type": "consultation_due",
-      "event_type_display": "Consultation responses due",
-      "date": "2026-07-08T12:00:00Z",
-      "merger_id": "MN-85036",
-      "merger_name": "SpaceX - Anysphere",
-      "status": "Under assessment",
-      "stage": "Phase 1 - initial assessment",
-      "effective_notification_datetime": "2026-06-30T12:00:00Z"
-    },
-    {
-      "type": "consultation_due",
-      "event_type_display": "Consultation responses due",
       "date": "2026-07-09T12:00:00Z",
       "merger_id": "MN-40017",
       "merger_name": "Vets Central \u2013 Hills Veterinary Centre",
@@ -501,6 +451,6 @@
       "effective_notification_datetime": "2026-07-06T12:00:00Z"
     }
   ],
-  "count": 50,
+  "count": 45,
   "days_ahead": 60
 }


### PR DESCRIPTION
ACCC's page lists "Summary of Notice of Competition Concerns" twice
(14 May and 25 May rows) for the same byte-identical re-uploaded PDF,
and lists the timeline-extension event both with and without the "20
business days" count. Removed the duplicate rows, kept the version
pointing at the currently-live attachment, and froze MN-65005's events
so future scrapes don't re-append the duplicates from ACCC's page.