### PR TITLE
Dedupe MN-50009 events and freeze against ACCC's buggy table

### DIFF
--- a/data/frozen_events_mergers.json
+++ b/data/frozen_events_mergers.json
@@ -4,10 +4,6 @@
     "_comment": "ACCC events table has duplicate rows: 'Summary of Notice of Competition Concerns' listed twice (14 May and 25 May) for the same byte-identical re-uploaded document, and 'Timeline extended by ... business days' listed both with and without the '20' day count. Deduped to one entry each; freezing events to stop the duplicates reappearing from the still-buggy ACCC page.",
     "freeze_events": true
   },
-  "MN-50009": {
-    "_comment": "ACCC re-uploaded the 29 June 2026 remedy offer PDF under a new filename suffix (_0 -> _1) with a reformatted title, so it didn't match the existing event and was scraped as a second entry, leaving the old one marked 'removed' alongside the new 'live' one. Dropped the duplicate 'removed' copy; freezing events to stop it reappearing from the still-buggy ACCC page.",
-    "freeze_events": true
-  },
   "MN-05032": {
     "_comment": "Event date(s) missing from ACCC page (Motorola Solutions - D-Fend Solutions - Questionnaire (8 Jul 2026)); freezing events to preserve the automatically set date(s).",
     "freeze_events": true

--- a/data/frozen_events_mergers.json
+++ b/data/frozen_events_mergers.json
@@ -4,6 +4,10 @@
     "_comment": "ACCC events table has duplicate rows: 'Summary of Notice of Competition Concerns' listed twice (14 May and 25 May) for the same byte-identical re-uploaded document, and 'Timeline extended by ... business days' listed both with and without the '20' day count. Deduped to one entry each; freezing events to stop the duplicates reappearing from the still-buggy ACCC page.",
     "freeze_events": true
   },
+  "MN-50009": {
+    "_comment": "ACCC re-uploaded the 29 June 2026 remedy offer PDF under a new filename suffix (_0 -> _1) with a reformatted title, so it didn't match the existing event and was scraped as a second entry, leaving the old one marked 'removed' alongside the new 'live' one. Dropped the duplicate 'removed' copy; freezing events to stop it reappearing from the still-buggy ACCC page.",
+    "freeze_events": true
+  },
   "MN-05032": {
     "_comment": "Event date(s) missing from ACCC page (Motorola Solutions - D-Fend Solutions - Questionnaire (8 Jul 2026)); freezing events to preserve the automatically set date(s).",
     "freeze_events": true

--- a/data/output/mergers.json
+++ b/data/output/mergers.json
@@ -24935,15 +24935,6 @@
         },
         {
           "date": "2026-06-29T12:00:00Z",
-          "title": "Heidelberg Materials Australia - Construction materials business of MAAS - Remedy offer",
-          "display_title": "Heidelberg Materials Australia - Construction materials business of MAAS - Remedy offer",
-          "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/Heidelberg%20Materials%20Australia%20%E2%80%93%20construction%20materials%20business%20of%20MAAS%20-%20Remedy%20Offer%20-%2029%20June%202026_0.pdf",
-          "url_gh": "/mergers/MN-50009/Heidelberg Materials Australia \u2013 construction materials business of MAAS - Remedy Offer - 29 June 2026_0.pdf",
-          "status": "removed",
-          "phase": null
-        },
-        {
-          "date": "2026-06-29T12:00:00Z",
           "title": "Heidelberg Materials Australia - Construction materials business of MAAS - Questionnaire - Remedy offer",
           "display_title": "Heidelberg Materials Australia - Construction materials business of MAAS - Questionnaire - Remedy offer",
           "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/HMA%20MAAS%20-%20Questionnaire%20re%3A%20Remedy%20Offer%20%2829%20June%202026%29_0.docx",

--- a/data/processed/mergers.json
+++ b/data/processed/mergers.json
@@ -12202,14 +12202,6 @@
       },
       {
         "date": "2026-06-29T12:00:00Z",
-        "title": "Heidelberg Materials Australia - Construction materials business of MAAS - Remedy offer",
-        "display_title": "Heidelberg Materials Australia - Construction materials business of MAAS - Remedy offer",
-        "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/Heidelberg%20Materials%20Australia%20%E2%80%93%20construction%20materials%20business%20of%20MAAS%20-%20Remedy%20Offer%20-%2029%20June%202026_0.pdf",
-        "url_gh": "/mergers/MN-50009/Heidelberg Materials Australia \u2013 construction materials business of MAAS - Remedy Offer - 29 June 2026_0.pdf",
-        "status": "removed"
-      },
-      {
-        "date": "2026-06-29T12:00:00Z",
         "title": "Heidelberg Materials Australia - Construction materials business of MAAS - Questionnaire - Remedy offer",
         "display_title": "Heidelberg Materials Australia - Construction materials business of MAAS - Questionnaire - Remedy offer",
         "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/HMA%20MAAS%20-%20Questionnaire%20re%3A%20Remedy%20Offer%20%2829%20June%202026%29_0.docx",

--- a/merger-tracker/frontend/public/data/mergers/MN-50009.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-50009.json
@@ -123,15 +123,6 @@
     },
     {
       "date": "2026-06-29T12:00:00Z",
-      "title": "Heidelberg Materials Australia - Construction materials business of MAAS - Remedy offer",
-      "display_title": "Heidelberg Materials Australia - Construction materials business of MAAS - Remedy offer",
-      "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/Heidelberg%20Materials%20Australia%20%E2%80%93%20construction%20materials%20business%20of%20MAAS%20-%20Remedy%20Offer%20-%2029%20June%202026_0.pdf",
-      "url_gh": "/mergers/MN-50009/Heidelberg Materials Australia \u2013 construction materials business of MAAS - Remedy Offer - 29 June 2026_0.pdf",
-      "status": "removed",
-      "phase": null
-    },
-    {
-      "date": "2026-06-29T12:00:00Z",
       "title": "Heidelberg Materials Australia - Construction materials business of MAAS - Questionnaire - Remedy offer",
       "display_title": "Heidelberg Materials Australia - Construction materials business of MAAS - Questionnaire - Remedy offer",
       "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/HMA%20MAAS%20-%20Questionnaire%20re%3A%20Remedy%20Offer%20%2829%20June%202026%29_0.docx",

--- a/merger-tracker/frontend/public/data/timeline-meta.json
+++ b/merger-tracker/frontend/public/data/timeline-meta.json
@@ -1,5 +1,5 @@
 {
-  "total": 1034,
+  "total": 1033,
   "page_size": 100,
   "total_pages": 11
 }

--- a/merger-tracker/frontend/public/data/timeline-page-10.json
+++ b/merger-tracker/frontend/public/data/timeline-page-10.json
@@ -710,18 +710,6 @@
     },
     {
       "date": "2026-06-29T12:00:00Z",
-      "title": "Heidelberg Materials Australia - Construction materials business of MAAS - Remedy offer",
-      "display_title": "Heidelberg Materials Australia - Construction materials business of MAAS - Remedy offer",
-      "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/Heidelberg%20Materials%20Australia%20%E2%80%93%20construction%20materials%20business%20of%20MAAS%20-%20Remedy%20Offer%20-%2029%20June%202026_0.pdf",
-      "url_gh": "/mergers/MN-50009/Heidelberg Materials Australia \u2013 construction materials business of MAAS - Remedy Offer - 29 June 2026_0.pdf",
-      "status": "removed",
-      "merger_id": "MN-50009",
-      "merger_name": "Heidelberg Materials Australia \u2013 construction materials business of MAAS",
-      "phase": null,
-      "is_waiver": false
-    },
-    {
-      "date": "2026-06-29T12:00:00Z",
       "title": "Heidelberg Materials Australia - Construction materials business of MAAS - Questionnaire - Remedy offer",
       "display_title": "Heidelberg Materials Australia - Construction materials business of MAAS - Questionnaire - Remedy offer",
       "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/HMA%20MAAS%20-%20Questionnaire%20re%3A%20Remedy%20Offer%20%2829%20June%202026%29_0.docx",
@@ -1197,6 +1185,18 @@
       "status": "live",
       "merger_id": "WA-25030",
       "merger_name": "Warburg Pincus \u2013 Commercial Credit Holdings Limited",
+      "phase": "Waiver",
+      "is_waiver": true
+    },
+    {
+      "date": "2026-07-01T12:00:00Z",
+      "title": "Notification waiver determination published",
+      "display_title": "Waiver application determination: Approved",
+      "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/Count%20%E2%80%93%20Oracle%20Group%20%28WA-45018%29%20-%20Notification%20waiver%20determination%20-%201%20July%202026.pdf",
+      "url_gh": "/mergers/WA-45018/Count \u2013 Oracle Group (WA-45018) - Notification waiver determination - 1 July 2026.pdf",
+      "status": "live",
+      "merger_id": "WA-45018",
+      "merger_name": "Count \u2013 Oracle Group",
       "phase": "Waiver",
       "is_waiver": true
     }

--- a/merger-tracker/frontend/public/data/timeline-page-11.json
+++ b/merger-tracker/frontend/public/data/timeline-page-11.json
@@ -1,18 +1,6 @@
 {
   "events": [
     {
-      "date": "2026-07-01T12:00:00Z",
-      "title": "Notification waiver determination published",
-      "display_title": "Waiver application determination: Approved",
-      "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/Count%20%E2%80%93%20Oracle%20Group%20%28WA-45018%29%20-%20Notification%20waiver%20determination%20-%201%20July%202026.pdf",
-      "url_gh": "/mergers/WA-45018/Count \u2013 Oracle Group (WA-45018) - Notification waiver determination - 1 July 2026.pdf",
-      "status": "live",
-      "merger_id": "WA-45018",
-      "merger_name": "Count \u2013 Oracle Group",
-      "phase": "Waiver",
-      "is_waiver": true
-    },
-    {
       "date": "2026-07-02T12:00:00Z",
       "title": "ACCC decided notification is subject to Phase 2 review",
       "display_title": "ACCC decided notification is subject to Phase 2 review",


### PR DESCRIPTION
ACCC re-uploaded the 29 June 2026 remedy offer PDF under a new filename
suffix (_0 -> _1) with a reformatted title, so it didn't match the
existing event and was scraped as a second entry, leaving the old copy
marked "removed" alongside the new "live" one. Dropped the duplicate
removed row and froze MN-50009's events so future scrapes don't
re-append it, same fix as MN-65005 (#639).