### PR TITLE
Add related-party groups for five mergers

### DIFF
--- a/data/processed/related_parties.json
+++ b/data/processed/related_parties.json
@@ -1194,6 +1194,112 @@
           "identifier": "EFN  901386"
         }
       ]
+    },
+    {
+      "id": "oscars-hotels",
+      "canonical_name": "Oscars Hotels",
+      "members": [
+        {
+          "name": "OSCARS NSW OPS PTY LTD",
+          "identifier": "19 686 583 451"
+        },
+        {
+          "name": "The Trustee for THE BANKSTOWN CENTRAL PROPERTY UNIT TRUST",
+          "identifier": "35 764 968 745"
+        },
+        {
+          "name": "BANKSTOWN CENTRAL PROPERTY PTY LTD",
+          "identifier": "620 947 300"
+        },
+        {
+          "name": "OSCARS HOTELS PTY LTD",
+          "identifier": "13 100 497 765"
+        }
+      ]
+    },
+    {
+      "id": "mitsui-and-co",
+      "canonical_name": "Mitsui & Co",
+      "members": [
+        {
+          "name": "SPC BLUE PTY. LTD.",
+          "identifier": "63 676 457 444"
+        },
+        {
+          "name": "MITSUI & CO LTD",
+          "identifier": "88 001 855 465"
+        }
+      ]
+    },
+    {
+      "id": "motorola-solutions",
+      "canonical_name": "Motorola Solutions",
+      "members": [
+        {
+          "name": "Motorola Solutions Finance EMEA Limited",
+          "identifier": "05540794"
+        },
+        {
+          "name": "Motorola Solutions, Inc.",
+          "identifier": "IRS Number  361115800"
+        }
+      ]
+    },
+    {
+      "id": "nib",
+      "canonical_name": "nib",
+      "members": [
+        {
+          "name": "nib Holdings Ltd",
+          "identifier": "51 125 633 856"
+        },
+        {
+          "name": "nib Travel Pty Ltd",
+          "identifier": "48 132 902 713"
+        },
+        {
+          "name": "nib Travel Services (Australia) Pty Ltd",
+          "identifier": "81 115 932 173"
+        },
+        {
+          "name": "nib Travel Insurance Distribution Pty Ltd",
+          "identifier": "40 129 262 175"
+        },
+        {
+          "name": "nib International Assistance Pty Ltd",
+          "identifier": "72 164 763 884"
+        },
+        {
+          "name": "Suresave Pty Ltd",
+          "identifier": "82 137 885 262"
+        },
+        {
+          "name": "Travel Insurance Direct Pty Ltd",
+          "identifier": "30 121 659 470"
+        }
+      ]
+    },
+    {
+      "id": "shamrock-group",
+      "canonical_name": "Shamrock Group",
+      "members": [
+        {
+          "name": "PHOENIX INVESTMENTS QUEENSLAND PTY LTD",
+          "identifier": "85 615 285 937"
+        },
+        {
+          "name": "SHAMROCK CIVIL ENGINEERING PTY. LTD.",
+          "identifier": "68 066 655 856"
+        },
+        {
+          "name": "SHAMROCK EQUIPMENT PTY LTD",
+          "identifier": "32 631 585 718"
+        },
+        {
+          "name": "SHAMROCK BUILDING PTY LTD",
+          "identifier": "70 639 694 885"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Group same-entity parties so each links to all their register mergers:

- Oscars Hotels (WA-25031): acquirers + Oscars Hotels other party
- Mitsui & Co (WA-70025): SPC Blue acquirer + Mitsui & Co
- Motorola Solutions (MN-05032): acquirer + Motorola Solutions, Inc.
- nib (MN-80024): all nib entities plus Suresave and Travel Insurance
  Direct (nib-owned brands in the divested travel business)
- Shamrock Group (MN-50030): Shamrock targets + Shamrock Building

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GfhhQzoQkaGho32zuVvm2q