### PR TITLE
Add parties to command palette search

### DIFF
--- a/merger-tracker/frontend/src/components/CommandPalette.jsx
+++ b/merger-tracker/frontend/src/components/CommandPalette.jsx
@@ -21,7 +21,7 @@ const PAGES = [
 // Mergers and parties share one combined budget of rows. By default it's
 // split evenly, but each group can borrow the other's unused capacity — so
 // two party matches leaves room for six mergers, and vice versa.
-const MAX_ENTITY_RESULTS = 8;
+const MAX_ENTITY_RESULTS = 6;
 const HALF_ENTITY_RESULTS = MAX_ENTITY_RESULTS / 2;
 
 // The parties list is cached as the whole `parties.json` payload

--- a/merger-tracker/frontend/src/components/CommandPalette.jsx
+++ b/merger-tracker/frontend/src/components/CommandPalette.jsx
@@ -1,10 +1,11 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { FaSearch } from 'react-icons/fa';
+import { API_ENDPOINTS } from '../config';
 import { dataCache } from '../utils/dataCache';
 import { buildSearchIndex, searchMergers } from '../utils/searchIndex';
 import { fetchAllMergers } from '../utils/fetchAllMergers';
-import { mergerPath } from '../utils/slug';
+import { mergerPath, partyPath } from '../utils/slug';
 
 const PAGES = [
   { label: 'Dashboard', path: '/' },
@@ -18,6 +19,15 @@ const PAGES = [
 ];
 
 const MAX_MERGER_RESULTS = 8;
+const MAX_PARTY_RESULTS = 6;
+
+// The parties list is cached as the whole `parties.json` payload
+// ({ parties, total_parties }) under this key by the Parties page.
+const PARTIES_CACHE_KEY = 'parties-list';
+
+function cachedParties() {
+  return dataCache.get(PARTIES_CACHE_KEY)?.parties || [];
+}
 
 export default function CommandPalette({ isOpen, onClose }) {
   const navigate = useNavigate();
@@ -34,6 +44,8 @@ export default function CommandPalette({ isOpen, onClose }) {
     return cached?.length ? buildSearchIndex(cached) : null;
   });
   const [mergersLoading, setMergersLoading] = useState(false);
+  const [parties, setParties] = useState(() => cachedParties());
+  const [partiesLoading, setPartiesLoading] = useState(false);
 
   // Reset state on open (adjusting state during render rather than in an
   // effect, per https://react.dev/learn/you-might-not-need-an-effect).
@@ -49,6 +61,12 @@ export default function CommandPalette({ isOpen, onClose }) {
         setSearchIndex(buildSearchIndex(cached));
       } else {
         setMergersLoading(true);
+      }
+      const cachedPartyList = cachedParties();
+      if (cachedPartyList.length) {
+        setParties(cachedPartyList);
+      } else {
+        setPartiesLoading(true);
       }
     }
   }
@@ -66,6 +84,24 @@ export default function CommandPalette({ isOpen, onClose }) {
       .finally(() => setMergersLoading(false));
   }, [isOpen]);
 
+  // Lazily fetch the parties list if it isn't cached yet, mirroring the merger
+  // load above. The whole payload is cached under the same key the Parties
+  // page uses so the two share one fetch.
+  useEffect(() => {
+    if (!isOpen || dataCache.has(PARTIES_CACHE_KEY)) return;
+    fetch(API_ENDPOINTS.parties)
+      .then((res) => {
+        if (!res.ok) throw new Error('Failed to fetch parties');
+        return res.json();
+      })
+      .then((json) => {
+        dataCache.set(PARTIES_CACHE_KEY, json);
+        setParties(json?.parties || []);
+      })
+      .catch((err) => console.error('Command palette failed to load parties:', err))
+      .finally(() => setPartiesLoading(false));
+  }, [isOpen]);
+
   const trimmedQuery = query.trim();
 
   const pageResults = useMemo(() => {
@@ -79,8 +115,24 @@ export default function CommandPalette({ isOpen, onClose }) {
     return searchMergers(mergers, trimmedQuery, searchIndex).slice(0, MAX_MERGER_RESULTS);
   }, [trimmedQuery, mergers, searchIndex]);
 
+  const partyResults = useMemo(() => {
+    if (!trimmedQuery) return [];
+    const q = trimmedQuery.toLowerCase();
+    return parties
+      .filter((p) => p.name.toLowerCase().includes(q))
+      .sort((a, b) => b.merger_count - a.merger_count || a.name.localeCompare(b.name))
+      .slice(0, MAX_PARTY_RESULTS);
+  }, [trimmedQuery, parties]);
+
   const showMergersGroup = trimmedQuery && (mergersLoading || mergerResults.length > 0);
-  const noResults = trimmedQuery && !mergersLoading && pageResults.length === 0 && mergerResults.length === 0;
+  const showPartiesGroup = trimmedQuery && (partiesLoading || partyResults.length > 0);
+  const noResults =
+    trimmedQuery &&
+    !mergersLoading &&
+    !partiesLoading &&
+    pageResults.length === 0 &&
+    mergerResults.length === 0 &&
+    partyResults.length === 0;
 
   // Flattened list of selectable rows, in display order, so arrow keys can
   // move through both groups without caring which one an index belongs to.
@@ -93,8 +145,15 @@ export default function CommandPalette({ isOpen, onClose }) {
         key: `merger:${m.merger_id}`,
       });
     });
+    partyResults.forEach((p) => {
+      list.push({
+        type: 'party',
+        path: partyPath(p.id, p.name),
+        key: `party:${p.id}`,
+      });
+    });
     return list;
-  }, [pageResults, mergerResults]);
+  }, [pageResults, mergerResults, partyResults]);
 
   // Clamp selection when the result set shrinks (e.g. typing narrows results).
   const [prevItemsLength, setPrevItemsLength] = useState(items.length);
@@ -176,7 +235,7 @@ export default function CommandPalette({ isOpen, onClose }) {
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder="Search pages and mergers…"
+            placeholder="Search pages, mergers and parties…"
             className="flex-1 bg-transparent text-sm text-gray-900 placeholder-gray-400 focus:outline-none"
             role="combobox"
             aria-expanded="true"
@@ -264,6 +323,43 @@ export default function CommandPalette({ isOpen, onClose }) {
                     }`}
                   >
                     {m.merger_name}
+                  </li>
+                );
+              })}
+            </>
+          )}
+
+          {showPartiesGroup && (
+            <>
+              <li
+                className="px-4 pt-3 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wide"
+                role="presentation"
+              >
+                Parties
+              </li>
+              {partiesLoading && partyResults.length === 0 && (
+                <li className="px-4 py-2 text-sm text-gray-400" role="presentation">
+                  Loading parties…
+                </li>
+              )}
+              {partyResults.map((p) => {
+                const key = `party:${p.id}`;
+                const selected = key === selectedKey;
+                const path = partyPath(p.id, p.name);
+                return (
+                  <li
+                    key={key}
+                    id={key}
+                    role="option"
+                    aria-selected={selected}
+                    data-selected={selected}
+                    onMouseEnter={() => setSelectedIndex(items.findIndex((i) => i.key === key))}
+                    onClick={() => goTo(path)}
+                    className={`px-4 py-2 text-sm cursor-pointer truncate ${
+                      selected ? 'bg-primary/10 text-primary' : 'text-gray-700'
+                    }`}
+                  >
+                    {p.name}
                   </li>
                 );
               })}

--- a/merger-tracker/frontend/src/components/CommandPalette.jsx
+++ b/merger-tracker/frontend/src/components/CommandPalette.jsx
@@ -18,8 +18,11 @@ const PAGES = [
   { label: 'Digest', path: '/digest' },
 ];
 
-const MAX_MERGER_RESULTS = 8;
-const MAX_PARTY_RESULTS = 6;
+// Mergers and parties share one combined budget of rows. By default it's
+// split evenly, but each group can borrow the other's unused capacity — so
+// two party matches leaves room for six mergers, and vice versa.
+const MAX_ENTITY_RESULTS = 8;
+const HALF_ENTITY_RESULTS = MAX_ENTITY_RESULTS / 2;
 
 // The parties list is cached as the whole `parties.json` payload
 // ({ parties, total_parties }) under this key by the Parties page.
@@ -110,19 +113,36 @@ export default function CommandPalette({ isOpen, onClose }) {
     return PAGES.filter((p) => p.label.toLowerCase().includes(q));
   }, [trimmedQuery]);
 
-  const mergerResults = useMemo(() => {
+  // Full match sets, each capped at the combined budget (no single group can
+  // ever show more than that). The final per-group slice happens below once
+  // both counts are known, so they can share the budget.
+  const mergerMatches = useMemo(() => {
     if (!trimmedQuery || !searchIndex) return [];
-    return searchMergers(mergers, trimmedQuery, searchIndex).slice(0, MAX_MERGER_RESULTS);
+    return searchMergers(mergers, trimmedQuery, searchIndex).slice(0, MAX_ENTITY_RESULTS);
   }, [trimmedQuery, mergers, searchIndex]);
 
-  const partyResults = useMemo(() => {
+  const partyMatches = useMemo(() => {
     if (!trimmedQuery) return [];
     const q = trimmedQuery.toLowerCase();
     return parties
       .filter((p) => p.name.toLowerCase().includes(q))
       .sort((a, b) => b.merger_count - a.merger_count || a.name.localeCompare(b.name))
-      .slice(0, MAX_PARTY_RESULTS);
+      .slice(0, MAX_ENTITY_RESULTS);
   }, [trimmedQuery, parties]);
+
+  // Divide the shared budget: each group is guaranteed its even half, and may
+  // grow into whatever the other group leaves unused.
+  const [mergerResults, partyResults] = useMemo(() => {
+    const mergerLimit = Math.min(
+      mergerMatches.length,
+      Math.max(HALF_ENTITY_RESULTS, MAX_ENTITY_RESULTS - partyMatches.length)
+    );
+    const partyLimit = Math.min(
+      partyMatches.length,
+      Math.max(HALF_ENTITY_RESULTS, MAX_ENTITY_RESULTS - mergerMatches.length)
+    );
+    return [mergerMatches.slice(0, mergerLimit), partyMatches.slice(0, partyLimit)];
+  }, [mergerMatches, partyMatches]);
 
   const showMergersGroup = trimmedQuery && (mergersLoading || mergerResults.length > 0);
   const showPartiesGroup = trimmedQuery && (partiesLoading || partyResults.length > 0);

--- a/merger-tracker/frontend/src/components/__tests__/CommandPalette.test.jsx
+++ b/merger-tracker/frontend/src/components/__tests__/CommandPalette.test.jsx
@@ -125,6 +125,41 @@ describe('CommandPalette', () => {
     fetchSpy.mockRestore();
   });
 
+  it('shares the result budget so few parties leave room for more mergers', async () => {
+    // 20 mergers and 2 parties all match "acme". The combined budget is 8, so
+    // the two parties should leave room for six mergers (rather than capping
+    // mergers at the even half of four).
+    const manyMergers = Array.from({ length: 20 }, (_, i) => ({
+      merger_id: `MN-${1000 + i}`,
+      merger_name: `Acme Deal ${i}`,
+    }));
+    const twoParties = {
+      parties: [
+        { id: 'acme-one', name: 'Acme One', merger_count: 2 },
+        { id: 'acme-two', name: 'Acme Two', merger_count: 1 },
+      ],
+      total_parties: 2,
+    };
+    dataCache.set('mergers-list', manyMergers);
+    dataCache.set('parties-list', twoParties);
+
+    const user = userEvent.setup();
+    renderPalette();
+
+    const input = screen.getByRole('combobox');
+    await user.type(input, 'acme');
+
+    await screen.findByText('Parties');
+    // Two party rows...
+    expect(screen.getByRole('option', { name: 'Acme One' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Acme Two' })).toBeInTheDocument();
+    // ...and six merger rows (borrowing the two the parties didn't use).
+    const mergerRows = screen
+      .getAllByRole('option')
+      .filter((el) => /^Acme Deal /.test(el.textContent));
+    expect(mergerRows).toHaveLength(6);
+  });
+
   it('navigates arrow keys through results and opens the selected item on Enter', async () => {
     dataCache.set('mergers-list', mergerFixture);
     const onClose = vi.fn();

--- a/merger-tracker/frontend/src/components/__tests__/CommandPalette.test.jsx
+++ b/merger-tracker/frontend/src/components/__tests__/CommandPalette.test.jsx
@@ -126,9 +126,9 @@ describe('CommandPalette', () => {
   });
 
   it('shares the result budget so few parties leave room for more mergers', async () => {
-    // 20 mergers and 2 parties all match "acme". The combined budget is 8, so
-    // the two parties should leave room for six mergers (rather than capping
-    // mergers at the even half of four).
+    // 20 mergers and 2 parties all match "acme". The combined budget is 6, so
+    // the two parties should leave room for four mergers (rather than capping
+    // mergers at the even half of three).
     const manyMergers = Array.from({ length: 20 }, (_, i) => ({
       merger_id: `MN-${1000 + i}`,
       merger_name: `Acme Deal ${i}`,
@@ -153,11 +153,11 @@ describe('CommandPalette', () => {
     // Two party rows...
     expect(screen.getByRole('option', { name: 'Acme One' })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: 'Acme Two' })).toBeInTheDocument();
-    // ...and six merger rows (borrowing the two the parties didn't use).
+    // ...and four merger rows (borrowing the one the parties didn't use).
     const mergerRows = screen
       .getAllByRole('option')
       .filter((el) => /^Acme Deal /.test(el.textContent));
-    expect(mergerRows).toHaveLength(6);
+    expect(mergerRows).toHaveLength(4);
   });
 
   it('navigates arrow keys through results and opens the selected item on Enter', async () => {

--- a/merger-tracker/frontend/src/components/__tests__/CommandPalette.test.jsx
+++ b/merger-tracker/frontend/src/components/__tests__/CommandPalette.test.jsx
@@ -14,6 +14,14 @@ const mergerFixture = [
   { merger_id: 'MN-01020', merger_name: 'Woolworths / Some Target' },
 ];
 
+const partiesFixture = {
+  parties: [
+    { id: 'coles', name: 'Coles Group', merger_count: 9 },
+    { id: 'ampol-limited', name: 'Ampol Limited', merger_count: 3 },
+  ],
+  total_parties: 2,
+};
+
 function renderPalette(props) {
   return render(
     <MemoryRouter>
@@ -77,6 +85,44 @@ describe('CommandPalette', () => {
     expect(screen.queryByRole('option', { name: 'Dashboard' })).not.toBeInTheDocument();
     expect(await screen.findByRole('option', { name: 'Ampol / Z Energy' })).toBeInTheDocument();
     expect(screen.queryByRole('option', { name: 'Woolworths / Some Target' })).not.toBeInTheDocument();
+  });
+
+  it('searches cached parties and lists them in a Parties group', async () => {
+    dataCache.set('parties-list', partiesFixture);
+    const user = userEvent.setup();
+    renderPalette();
+
+    const input = screen.getByRole('combobox');
+    await user.type(input, 'coles');
+
+    expect(await screen.findByRole('option', { name: 'Coles Group' })).toBeInTheDocument();
+    expect(screen.getByText('Parties')).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'Ampol Limited' })).not.toBeInTheDocument();
+  });
+
+  it('lazily fetches the parties list on a cold cache', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      if (url.includes('parties.json')) {
+        return Promise.resolve(ok(partiesFixture));
+      }
+      if (url.includes('list-meta.json')) {
+        return Promise.resolve(ok({ total_pages: 1 }));
+      }
+      if (url.includes('list-page-1.json')) {
+        return Promise.resolve(ok({ mergers: mergerFixture }));
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
+
+    const user = userEvent.setup();
+    renderPalette();
+
+    const input = screen.getByRole('combobox');
+    await user.type(input, 'coles');
+
+    expect(await screen.findByRole('option', { name: 'Coles Group' })).toBeInTheDocument();
+    expect(dataCache.get('parties-list')).toEqual(partiesFixture);
+    fetchSpy.mockRestore();
   });
 
   it('navigates arrow keys through results and opens the selected item on Enter', async () => {


### PR DESCRIPTION
Extend the Ctrl/Cmd-K command palette so it searches merger parties
alongside pages and mergers. Party results appear in their own group,
load from the shared parties-list cache when available, and lazily
fetch parties.json on a cold cache (mirroring the merger loading path).
Selecting a party navigates to its detail page.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A8LD3regVo9pZJDeTMWCu8