### PR TITLE
Show completed Phase 2 matters as coloured cards

### DIFF
--- a/merger-tracker/frontend/src/components/Phase2CompletedCards.jsx
+++ b/merger-tracker/frontend/src/components/Phase2CompletedCards.jsx
@@ -1,0 +1,53 @@
+import { Link } from 'react-router-dom';
+import { mergerPath } from '../utils/slug';
+import { calculateDuration } from '../utils/dates';
+import { MERGER_STATUS } from '../constants/mergerStatus';
+import { getCardStyle } from '../constants/cardStyles';
+import CardCollapseGrid from './CardCollapseGrid';
+
+// "Assessment ceased" is a mouthful for the compact card header; abbreviate it
+// the same way the dashboard's recent-determination cards do.
+const DETERMINATION_LABELS = {
+  [MERGER_STATUS.ASSESSMENT_CEASED]: 'Ceased',
+};
+
+// Solid, determination-coloured cards for completed Phase 2 matters — echoing
+// the dashboard card grids. Each card surfaces just the outcome and the time
+// the review took, laid over a colour that reflects the determination.
+function Phase2CompletedCards({ matters }) {
+  return (
+    <CardCollapseGrid
+      items={matters}
+      getKey={(item) => item.merger_id}
+      getStyle={(item) => getCardStyle({ determination: item.determination })}
+      renderBody={(item, style) => {
+        const duration = calculateDuration(item.referral_date, item.determination_date);
+        return (
+          <>
+            <span className="text-xs font-semibold uppercase tracking-wide">
+              {DETERMINATION_LABELS[item.determination] || item.determination}
+            </span>
+            <Link
+              to={mergerPath(item.merger_id, item.merger_name)}
+              className={`mt-2 text-sm font-semibold leading-snug hover:underline after:absolute after:inset-0 ${style.text}`}
+              aria-label={`View merger details for ${item.merger_name}`}
+            >
+              {item.merger_name}
+            </Link>
+            <div className={`mt-2 flex flex-wrap items-center gap-2 text-xs ${style.sub}`}>
+              <span>{item.merger_id}</span>
+              {duration !== null && (
+                <>
+                  <span aria-hidden="true">·</span>
+                  <span className="tabular-nums">{duration} days in Phase 2</span>
+                </>
+              )}
+            </div>
+          </>
+        );
+      }}
+    />
+  );
+}
+
+export default Phase2CompletedCards;

--- a/merger-tracker/frontend/src/components/Phase2Timeline.jsx
+++ b/merger-tracker/frontend/src/components/Phase2Timeline.jsx
@@ -50,10 +50,10 @@ function MatterBar({ matter }) {
   };
 
   return (
-    <li className="py-4 first:pt-0 last:pb-0">
+    <li className="group relative -mx-3 rounded-xl px-3 py-4 transition-colors hover:bg-gray-50/70 first:pt-0 last:pb-0">
       <Link
         to={mergerPath(merger_id, merger_name)}
-        className="block text-sm font-semibold text-gray-900 hover:text-primary transition-colors truncate mb-3"
+        className="block text-sm font-semibold text-gray-900 transition-colors truncate mb-3 group-hover:text-primary after:absolute after:inset-0"
       >
         {merger_name}
       </Link>

--- a/merger-tracker/frontend/src/pages/Phase2.jsx
+++ b/merger-tracker/frontend/src/pages/Phase2.jsx
@@ -1,12 +1,9 @@
-import { Link } from 'react-router-dom';
 import LoadingSpinner from '../components/LoadingSpinner';
 import Phase2Timeline from '../components/Phase2Timeline';
-import StatusBadge from '../components/StatusBadge';
+import Phase2CompletedCards from '../components/Phase2CompletedCards';
 import SEO from '../components/SEO';
 import { API_ENDPOINTS } from '../config';
 import { useFetchData } from '../hooks/useFetchData';
-import { mergerPath } from '../utils/slug';
-import { formatDateMedium, calculateDuration } from '../utils/dates';
 
 function Phase2() {
   const { data, loading, error } = useFetchData(API_ENDPOINTS.phase2, { cacheKey: 'phase2' });
@@ -47,52 +44,7 @@ function Phase2() {
               <p className="text-gray-500 text-sm">No Phase 2 matters have been completed yet.</p>
             </div>
           ) : (
-            <div className="bg-white border border-gray-100 shadow-card rounded-2xl overflow-hidden overflow-x-auto">
-              <table className="min-w-full divide-y divide-gray-100">
-                <caption className="sr-only">
-                  Completed Phase 2 mergers with referral date, determination and duration
-                </caption>
-                <thead>
-                  <tr className="bg-gray-50/80">
-                    <th className="px-6 py-3.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Merger</th>
-                    <th className="px-6 py-3.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Referred</th>
-                    <th className="px-6 py-3.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Determined</th>
-                    <th className="px-6 py-3.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Duration</th>
-                    <th className="px-6 py-3.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Outcome</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-50">
-                  {completed.map((matter) => {
-                    const duration = calculateDuration(matter.referral_date, matter.determination_date);
-                    return (
-                      <tr key={matter.merger_id} className="hover:bg-gray-50/50 transition-colors">
-                        <td className="px-6 py-4 text-sm text-gray-900">
-                          <Link
-                            to={mergerPath(matter.merger_id, matter.merger_name)}
-                            className="font-medium hover:text-primary transition-colors"
-                          >
-                            {matter.merger_name}
-                          </Link>
-                          <div className="text-xs text-gray-500 mt-0.5">{matter.merger_id}</div>
-                        </td>
-                        <td className="px-6 py-4 text-sm text-gray-500 whitespace-nowrap">
-                          {formatDateMedium(matter.referral_date)}
-                        </td>
-                        <td className="px-6 py-4 text-sm text-gray-500 whitespace-nowrap">
-                          {formatDateMedium(matter.determination_date)}
-                        </td>
-                        <td className="px-6 py-4 text-sm text-gray-500 whitespace-nowrap tabular-nums">
-                          {duration !== null ? `${duration} days` : 'N/A'}
-                        </td>
-                        <td className="px-6 py-4 text-sm">
-                          <StatusBadge determination={matter.determination} />
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
+            <Phase2CompletedCards matters={completed} />
           )}
         </section>
       </div>


### PR DESCRIPTION
Replace the completed Phase 2 table with a determination-coloured card
grid, mirroring the dashboard's card layout. Each card surfaces just the
outcome and the days spent in Phase 2, laid over a colour that reflects
the determination.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012R5snQnAxXeeU51XxHHgzf