### PR TITLE
Add setting to auto-track mergers that reach Phase 2

### DIFF
--- a/merger-tracker/frontend/src/context/TrackingContext.jsx
+++ b/merger-tracker/frontend/src/context/TrackingContext.jsx
@@ -11,6 +11,12 @@ const STORAGE_KEYS = {
   // so each is acted on exactly once. See the auto-track logic in the fetch
   // effect for why this is persisted.
   AUTO_TRACK_LINKS: 'merger_tracker_auto_track_links',
+  // User setting: automatically track any merger that reaches Phase 2.
+  AUTO_TRACK_PHASE2: 'merger_tracker_auto_track_phase2',
+  // Phase 2 merger IDs we've already auto-tracked, so each is acted on exactly
+  // once (a matter the user later untracks is not silently re-added). Mirrors
+  // AUTO_TRACK_LINKS. See the Phase 2 auto-track effect.
+  AUTO_TRACK_PHASE2_IDS: 'merger_tracker_auto_tracked_phase2_ids',
 };
 
 // Relationship values (from the data pipeline, see scripts/static_data/loaders.py)
@@ -135,6 +141,44 @@ export function TrackingProvider({ children }) {
   useEffect(() => {
     autoTrackLinksRef.current = autoTrackLinks;
   }, [autoTrackLinks]);
+
+  // User setting: when enabled, every matter that reaches Phase 2 is added to
+  // tracked mergers.
+  const [autoTrackPhase2, setAutoTrackPhase2] = useState(() => {
+    try {
+      return localStorage.getItem(STORAGE_KEYS.AUTO_TRACK_PHASE2) === 'true';
+    } catch (err) {
+      console.error('Failed to read auto-track Phase 2 setting from localStorage:', err);
+      return false;
+    }
+  });
+
+  // Phase 2 merger IDs already acted on by the auto-track effect. Persisted so a
+  // matter is auto-tracked exactly once: a matter the user later untracks is not
+  // re-added, while a matter that reaches Phase 2 after the setting was enabled
+  // is still picked up on the next load. Mirrored in a ref so the effect can read
+  // the latest set without listing it as a dependency (which would re-run it).
+  const [autoTrackedPhase2Ids, setAutoTrackedPhase2Ids] = useState(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEYS.AUTO_TRACK_PHASE2_IDS);
+      return stored ? new Set(JSON.parse(stored)) : new Set();
+    } catch (err) {
+      console.error('Failed to read auto-tracked Phase 2 IDs from localStorage:', err);
+      return new Set();
+    }
+  });
+  const autoTrackedPhase2IdsRef = useRef(autoTrackedPhase2Ids);
+  useEffect(() => {
+    autoTrackedPhase2IdsRef.current = autoTrackedPhase2Ids;
+  }, [autoTrackedPhase2Ids]);
+
+  // Latest tracked IDs mirrored in a ref so the Phase 2 auto-track effect can
+  // tell which matters are already tracked without depending on trackedMergerIds
+  // (which would make it re-fetch phase2.json on every track/untrack).
+  const trackedMergerIdsRef = useRef(trackedMergerIds);
+  useEffect(() => {
+    trackedMergerIdsRef.current = trackedMergerIds;
+  }, [trackedMergerIds]);
 
   // Fetch events on mount and when tracked mergers change
   useEffect(() => {
@@ -431,6 +475,83 @@ export function TrackingProvider({ children }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [trackedIndustryCodesKey, newlyTrackedIndustryCodes, newlyTrackedIndustryCodesSet]);
 
+  // Auto-track matters that reach Phase 2 when the user has opted in. Fetches the
+  // Phase 2 feed and tracks every current matter not yet acted on. Mirrors the
+  // forward re-file auto-tracking: each matter is recorded in autoTrackedPhase2Ids
+  // so it is added exactly once — a matter the user later untracks stays untracked,
+  // while a matter that reaches Phase 2 after the setting was enabled is picked up
+  // on the next load. Their existing events are marked seen (like a manual track)
+  // so enabling the setting doesn't flood the notification panel with historical
+  // milestones; future milestones (NOCC, determination) still surface.
+  useEffect(() => {
+    if (!autoTrackPhase2) return;
+    let cancelled = false;
+
+    const run = async () => {
+      try {
+        const res = await fetch(API_ENDPOINTS.phase2);
+        if (!res.ok || cancelled) return;
+        const data = await res.json();
+        if (cancelled) return;
+
+        const current = (data && data.current) || [];
+        const currentlyTracked = new Set(trackedMergerIdsRef.current);
+        const idsToRecord = [];
+        const idsToTrack = [];
+        current.forEach((matter) => {
+          const id = matter && matter.merger_id;
+          if (!id || autoTrackedPhase2IdsRef.current.has(id)) return;
+          idsToRecord.push(id);
+          if (!currentlyTracked.has(id)) idsToTrack.push(id);
+        });
+
+        if (idsToRecord.length > 0) {
+          setAutoTrackedPhase2Ids((prev) => {
+            const next = new Set(prev);
+            idsToRecord.forEach((id) => next.add(id));
+            return next;
+          });
+        }
+        if (idsToTrack.length > 0) {
+          setNewlyTrackedIds((ids) => [...ids, ...idsToTrack]);
+          setTrackedMergerIds((prev) => {
+            const prevSet = new Set(prev);
+            const fresh = idsToTrack.filter((id) => !prevSet.has(id));
+            return fresh.length ? [...prev, ...fresh] : prev;
+          });
+        }
+      } catch (err) {
+        console.error('Failed to auto-track Phase 2 matters:', err);
+      }
+    };
+
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [autoTrackPhase2]);
+
+  // Persist the Phase 2 auto-track setting to localStorage.
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEYS.AUTO_TRACK_PHASE2, autoTrackPhase2 ? 'true' : 'false');
+    } catch (e) {
+      console.error('Failed to save auto-track Phase 2 setting:', e);
+    }
+  }, [autoTrackPhase2]);
+
+  // Persist the set of auto-tracked Phase 2 IDs to localStorage.
+  useEffect(() => {
+    try {
+      localStorage.setItem(
+        STORAGE_KEYS.AUTO_TRACK_PHASE2_IDS,
+        JSON.stringify(Array.from(autoTrackedPhase2Ids))
+      );
+    } catch (e) {
+      console.error('Failed to save auto-tracked Phase 2 IDs:', e);
+    }
+  }, [autoTrackedPhase2Ids]);
+
   // Persist tracked mergers to localStorage
   useEffect(() => {
     try {
@@ -527,6 +648,10 @@ export function TrackingProvider({ children }) {
     });
   }, []);
 
+  const toggleAutoTrackPhase2 = useCallback(() => {
+    setAutoTrackPhase2((prev) => !prev);
+  }, []);
+
   const markEventAsSeen = useCallback((event) => {
     const key = getEventKey(event);
     setSeenEventKeys((prev) => {
@@ -596,6 +721,8 @@ export function TrackingProvider({ children }) {
     toggleIndustryTracking,
     trackedIndustryEvents,
     unseenIndustryEvents,
+    autoTrackPhase2,
+    toggleAutoTrackPhase2,
     markEventAsSeen,
     markEventsAsSeen,
     isEventSeen,
@@ -618,6 +745,8 @@ export function TrackingProvider({ children }) {
     toggleIndustryTracking,
     trackedIndustryEvents,
     unseenIndustryEvents,
+    autoTrackPhase2,
+    toggleAutoTrackPhase2,
     markEventAsSeen,
     markEventsAsSeen,
     isEventSeen,

--- a/merger-tracker/frontend/src/context/__tests__/TrackingContext.test.jsx
+++ b/merger-tracker/frontend/src/context/__tests__/TrackingContext.test.jsx
@@ -280,3 +280,112 @@ describe('TrackingContext auto-tracking of related mergers', () => {
     expect(second.result.current.trackedMergerIds).toContain('WA-1');
   });
 });
+
+// Stub globalThis.fetch to serve a phase2.json payload (current + completed) and
+// treat any per-merger detail URL as an empty, event-less matter so the main
+// event-fetch effect resolves cleanly.
+function mockFetchFromPhase2(phase2) {
+  globalThis.fetch = vi.fn((url) => {
+    if (/\/data\/phase2\.json$/.test(url)) {
+      return Promise.resolve(okResponse(phase2));
+    }
+    const match = /\/data\/mergers\/([^/]+)\.json$/.exec(url);
+    if (match) {
+      return Promise.resolve(okResponse({ merger_id: match[1], merger_name: match[1], events: [] }));
+    }
+    return Promise.resolve(notFoundResponse());
+  });
+}
+
+describe('TrackingContext auto-tracking of Phase 2 matters', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('does nothing while the setting is off', async () => {
+    mockFetchFromPhase2({ current: [{ merger_id: 'MN-1' }], completed: [] });
+
+    const { result } = renderHook(() => useTracking(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.autoTrackPhase2).toBe(false);
+    expect(result.current.trackedMergerIds).not.toContain('MN-1');
+  });
+
+  it('tracks all current Phase 2 matters when the setting is enabled', async () => {
+    mockFetchFromPhase2({
+      current: [{ merger_id: 'MN-1' }, { merger_id: 'MN-2' }],
+      completed: [{ merger_id: 'MN-OLD' }],
+    });
+
+    const { result } = renderHook(() => useTracking(), { wrapper });
+
+    act(() => {
+      result.current.toggleAutoTrackPhase2();
+    });
+
+    await waitFor(() => {
+      expect(result.current.trackedMergerIds).toEqual(expect.arrayContaining(['MN-1', 'MN-2']));
+    });
+    // Completed matters are not retroactively tracked.
+    expect(result.current.trackedMergerIds).not.toContain('MN-OLD');
+  });
+
+  it('does not re-add a Phase 2 matter the user untracked while the setting stays on', async () => {
+    mockFetchFromPhase2({ current: [{ merger_id: 'MN-1' }], completed: [] });
+
+    const { result, unmount } = renderHook(() => useTracking(), { wrapper });
+
+    act(() => {
+      result.current.toggleAutoTrackPhase2();
+    });
+    await waitFor(() => {
+      expect(result.current.trackedMergerIds).toContain('MN-1');
+    });
+
+    act(() => {
+      result.current.untrackMerger('MN-1');
+    });
+    await waitFor(() => {
+      expect(result.current.trackedMergerIds).not.toContain('MN-1');
+    });
+
+    // Re-mounting (a later visit) with the same feed must not silently re-add it.
+    unmount();
+    const second = renderHook(() => useTracking(), { wrapper });
+    await waitFor(() => {
+      expect(second.result.current.loading).toBe(false);
+    });
+    expect(second.result.current.trackedMergerIds).not.toContain('MN-1');
+  });
+
+  it('picks up a matter that reaches Phase 2 after the setting was enabled', async () => {
+    mockFetchFromPhase2({ current: [{ merger_id: 'MN-1' }], completed: [] });
+
+    const first = renderHook(() => useTracking(), { wrapper });
+    act(() => {
+      first.result.current.toggleAutoTrackPhase2();
+    });
+    await waitFor(() => {
+      expect(first.result.current.trackedMergerIds).toContain('MN-1');
+    });
+    first.unmount();
+
+    // Later visit: a new matter has entered Phase 2. The setting persists via
+    // localStorage, so the new matter is auto-tracked too.
+    mockFetchFromPhase2({ current: [{ merger_id: 'MN-1' }, { merger_id: 'MN-3' }], completed: [] });
+    const second = renderHook(() => useTracking(), { wrapper });
+    await waitFor(() => {
+      expect(second.result.current.trackedMergerIds).toContain('MN-3');
+    });
+    expect(second.result.current.trackedMergerIds).toContain('MN-1');
+  });
+});

--- a/merger-tracker/frontend/src/pages/Phase2.jsx
+++ b/merger-tracker/frontend/src/pages/Phase2.jsx
@@ -4,9 +4,11 @@ import Phase2CompletedCards from '../components/Phase2CompletedCards';
 import SEO from '../components/SEO';
 import { API_ENDPOINTS } from '../config';
 import { useFetchData } from '../hooks/useFetchData';
+import { useTracking } from '../context/TrackingContext';
 
 function Phase2() {
   const { data, loading, error } = useFetchData(API_ENDPOINTS.phase2, { cacheKey: 'phase2' });
+  const { autoTrackPhase2, toggleAutoTrackPhase2 } = useTracking();
 
   if (loading) return <LoadingSpinner />;
   if (error) return <div role="alert" className="text-red-600 p-8 text-center">Error: {error}</div>;
@@ -27,6 +29,37 @@ function Phase2() {
             Phase 2 tracker
           </h1>
         </header>
+
+        <div className="mb-6 bg-white rounded-2xl border border-gray-100 shadow-card p-4 sm:p-5">
+          <button
+            type="button"
+            role="switch"
+            aria-checked={autoTrackPhase2}
+            onClick={toggleAutoTrackPhase2}
+            className="flex items-start gap-3 w-full text-left"
+          >
+            <span
+              className={`relative mt-0.5 inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full transition-colors ${
+                autoTrackPhase2 ? 'bg-primary' : 'bg-gray-300'
+              }`}
+            >
+              <span
+                className={`inline-block h-3.5 w-3.5 rounded-full bg-white shadow-sm transform transition-transform ${
+                  autoTrackPhase2 ? 'translate-x-4' : 'translate-x-0.5'
+                }`}
+              />
+            </span>
+            <span>
+              <span className="block text-sm font-medium text-gray-900">
+                Automatically track Phase 2 matters
+              </span>
+              <span className="block text-xs text-gray-500 mt-0.5">
+                When on, every merger that proceeds to Phase 2 is added to your tracked mergers, so
+                its milestones show up in your notifications.
+              </span>
+            </span>
+          </button>
+        </div>
 
         <section aria-labelledby="phase2-current-heading" className="mb-8">
           <h2 id="phase2-current-heading" className="text-lg font-semibold text-gray-900 mb-4">

--- a/merger-tracker/frontend/src/pages/Phase2.jsx
+++ b/merger-tracker/frontend/src/pages/Phase2.jsx
@@ -24,22 +24,23 @@ function Phase2() {
         url="/phase-2"
       />
       <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8 animate-fade-in">
-        <header className="mb-6">
+        <header className="mb-6 flex items-center justify-between gap-4">
           <h1 className="text-2xl sm:text-3xl font-bold tracking-tight text-gray-900">
             Phase 2 tracker
           </h1>
-        </header>
-
-        <div className="mb-6 bg-white rounded-2xl border border-gray-100 shadow-card p-4 sm:p-5">
           <button
             type="button"
             role="switch"
             aria-checked={autoTrackPhase2}
             onClick={toggleAutoTrackPhase2}
-            className="flex items-start gap-3 w-full text-left"
+            title="When on, every merger that proceeds to Phase 2 is added to your tracked mergers, so its milestones show up in your notifications."
+            className="flex items-center gap-2 flex-shrink-0"
           >
+            <span className="text-sm font-medium text-gray-600 whitespace-nowrap">
+              Auto track
+            </span>
             <span
-              className={`relative mt-0.5 inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full transition-colors ${
+              className={`relative inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full transition-colors ${
                 autoTrackPhase2 ? 'bg-primary' : 'bg-gray-300'
               }`}
             >
@@ -49,17 +50,8 @@ function Phase2() {
                 }`}
               />
             </span>
-            <span>
-              <span className="block text-sm font-medium text-gray-900">
-                Automatically track Phase 2 matters
-              </span>
-              <span className="block text-xs text-gray-500 mt-0.5">
-                When on, every merger that proceeds to Phase 2 is added to your tracked mergers, so
-                its milestones show up in your notifications.
-              </span>
-            </span>
           </button>
-        </div>
+        </header>
 
         <section aria-labelledby="phase2-current-heading" className="mb-8">
           <h2 id="phase2-current-heading" className="text-lg font-semibold text-gray-900 mb-4">


### PR DESCRIPTION
Add an opt-in setting on the Phase 2 page that, when enabled,
automatically adds every merger that proceeds to Phase 2 to the user's
tracked mergers so its milestones surface in notifications.

The setting and the set of already-acted-on Phase 2 matter IDs are
persisted in localStorage, mirroring the existing forward re-file
auto-tracking: each matter is added exactly once, so a matter the user
later untracks is not silently re-added, while a matter that reaches
Phase 2 after the setting was enabled is picked up on the next load.
Existing events are marked seen on add to avoid flooding the
notification panel; future milestones still surface.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VVeohMnUYAkX7Q8bNAaK6C