### PR TITLE
Extract shared ErrorMessage component for page-level error states

### DIFF
--- a/merger-tracker/frontend/src/components/ErrorMessage.jsx
+++ b/merger-tracker/frontend/src/components/ErrorMessage.jsx
@@ -1,0 +1,9 @@
+function ErrorMessage({ error }) {
+  return (
+    <div role="alert" className="text-red-600 p-8 text-center">
+      Error: {error}
+    </div>
+  );
+}
+
+export default ErrorMessage;

--- a/merger-tracker/frontend/src/pages/Analysis.jsx
+++ b/merger-tracker/frontend/src/pages/Analysis.jsx
@@ -13,6 +13,7 @@ import {
   Legend,
 } from 'chart.js';
 import LoadingSpinner from '../components/LoadingSpinner';
+import ErrorMessage from '../components/ErrorMessage';
 import SEO from '../components/SEO';
 import { API_ENDPOINTS } from '../config';
 import { useFetchData } from '../hooks/useFetchData';
@@ -81,7 +82,7 @@ function Analysis() {
   const [calendarDays, setCalendarDays] = useState(false);
 
   if (loading) return <LoadingSpinner />;
-  if (error) return <div className="text-red-600 p-8 text-center">Error: {error}</div>;
+  if (error) return <ErrorMessage error={error} />;
   if (!data) return null;
 
   const { phase1_duration, waiver_duration, monthly_volume, industry_phase1_duration } = data;

--- a/merger-tracker/frontend/src/pages/Commentary.jsx
+++ b/merger-tracker/frontend/src/pages/Commentary.jsx
@@ -3,6 +3,7 @@ import { mergerPath } from '../utils/slug';
 import { FaComment } from 'react-icons/fa';
 import ReactMarkdown from 'react-markdown';
 import LoadingSpinner from '../components/LoadingSpinner';
+import ErrorMessage from '../components/ErrorMessage';
 import StatusBadge from '../components/StatusBadge';
 import WaiverBadge from '../components/WaiverBadge';
 import ExternalLinkIcon from '../components/ExternalLinkIcon';
@@ -19,7 +20,7 @@ function Commentary() {
   const items = data?.items || [];
 
   if (loading) return <LoadingSpinner />;
-  if (error) return <div className="text-red-600 p-8 text-center">Error: {error}</div>;
+  if (error) return <ErrorMessage error={error} />;
 
   return (
     <>

--- a/merger-tracker/frontend/src/pages/Dashboard.jsx
+++ b/merger-tracker/frontend/src/pages/Dashboard.jsx
@@ -10,6 +10,7 @@ import {
 } from 'chart.js';
 import StatCard from '../components/StatCard';
 import LoadingSpinner from '../components/LoadingSpinner';
+import ErrorMessage from '../components/ErrorMessage';
 import UpcomingEventsTimeline from '../components/UpcomingEventsTimeline';
 import RecentDeterminationsCards from '../components/RecentDeterminationsCards';
 import RecentMergersCards from '../components/RecentMergersCards';
@@ -58,7 +59,7 @@ function Dashboard() {
   }, [stats]);
 
   if (loading) return <LoadingSpinner />;
-  if (error) return <div role="alert" className="text-red-600 p-8 text-center">Error: {error}</div>;
+  if (error) return <ErrorMessage error={error} />;
   if (!stats) return null;
 
   const determinationData = {

--- a/merger-tracker/frontend/src/pages/Digest.jsx
+++ b/merger-tracker/frontend/src/pages/Digest.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { mergerPath } from '../utils/slug';
 import ReactMarkdown from 'react-markdown';
 import LoadingSpinner from '../components/LoadingSpinner';
+import ErrorMessage from '../components/ErrorMessage';
 import ExternalLinkIcon from '../components/ExternalLinkIcon';
 import WaiverBadge from '../components/WaiverBadge';
 import SEO from '../components/SEO';
@@ -384,7 +385,7 @@ function Digest() {
   };
 
   if (loading) return <LoadingSpinner />;
-  if (error) return <div className="text-red-600 p-8 text-center">Error: {error}</div>;
+  if (error) return <ErrorMessage error={error} />;
   if (!digest) return null;
 
   const dateRange = formatDateRange(digest.period_start, digest.period_end);

--- a/merger-tracker/frontend/src/pages/Extensions.jsx
+++ b/merger-tracker/frontend/src/pages/Extensions.jsx
@@ -6,6 +6,7 @@ import {
   FaArrowTrendUp,
 } from 'react-icons/fa6';
 import LoadingSpinner from '../components/LoadingSpinner';
+import ErrorMessage from '../components/ErrorMessage';
 import StatusBadge from '../components/StatusBadge';
 import StatCard from '../components/StatCard';
 import SEO from '../components/SEO';
@@ -164,7 +165,7 @@ function Extensions() {
   const { data, loading, error } = useFetchData(API_ENDPOINTS.extensions, { cacheKey: 'extensions' });
 
   if (loading) return <LoadingSpinner />;
-  if (error) return <div role="alert" className="text-red-600 p-8 text-center">Error: {error}</div>;
+  if (error) return <ErrorMessage error={error} />;
 
   const summary = data?.summary || {};
   const reasons = data?.reasons || [];

--- a/merger-tracker/frontend/src/pages/Industries.jsx
+++ b/merger-tracker/frontend/src/pages/Industries.jsx
@@ -1,5 +1,6 @@
 import { useState, Fragment } from 'react';
 import LoadingSpinner from '../components/LoadingSpinner';
+import ErrorMessage from '../components/ErrorMessage';
 import IndustryMergerGroups from '../components/IndustryMergerGroups';
 import IndustryTreemap from '../components/IndustryTreemap';
 import SEO from '../components/SEO';
@@ -104,7 +105,7 @@ function Industries() {
   };
 
   if (loading) return <LoadingSpinner />;
-  if (error) return <div role="alert" className="text-red-600 p-8 text-center">Error: {error}</div>;
+  if (error) return <ErrorMessage error={error} />;
 
   return (
     <>

--- a/merger-tracker/frontend/src/pages/Mergers.jsx
+++ b/merger-tracker/frontend/src/pages/Mergers.jsx
@@ -3,6 +3,7 @@ import { FaSearch, FaTimes, FaSlidersH, FaArrowDown, FaStar } from 'react-icons/
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { mergerPath } from '../utils/slug';
 import LoadingSpinner from '../components/LoadingSpinner';
+import ErrorMessage from '../components/ErrorMessage';
 import StatusBadge from '../components/StatusBadge';
 import BellIcon from '../components/BellIcon';
 import WaiverBadge from '../components/WaiverBadge';
@@ -348,7 +349,7 @@ function Mergers() {
   }, [handleListKeyDown]);
 
   if (loading) return <LoadingSpinner />;
-  if (error) return <div className="text-red-600 p-8 text-center">Error: {error}</div>;
+  if (error) return <ErrorMessage error={error} />;
 
   return (
     <>

--- a/merger-tracker/frontend/src/pages/Parties.jsx
+++ b/merger-tracker/frontend/src/pages/Parties.jsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { FaArrowRightLong } from 'react-icons/fa6';
 import LoadingSpinner from '../components/LoadingSpinner';
+import ErrorMessage from '../components/ErrorMessage';
 import PartyTreemap from '../components/PartyTreemap';
 import SEO from '../components/SEO';
 import { API_ENDPOINTS } from '../config';
@@ -47,7 +48,7 @@ function Parties() {
   const isSearching = debouncedSearch.trim().length > 0;
 
   if (loading) return <LoadingSpinner />;
-  if (error) return <div role="alert" className="text-red-600 p-8 text-center">Error: {error}</div>;
+  if (error) return <ErrorMessage error={error} />;
 
   return (
     <>

--- a/merger-tracker/frontend/src/pages/Phase2.jsx
+++ b/merger-tracker/frontend/src/pages/Phase2.jsx
@@ -1,4 +1,5 @@
 import LoadingSpinner from '../components/LoadingSpinner';
+import ErrorMessage from '../components/ErrorMessage';
 import Phase2Timeline from '../components/Phase2Timeline';
 import Phase2CompletedCards from '../components/Phase2CompletedCards';
 import SEO from '../components/SEO';
@@ -11,7 +12,7 @@ function Phase2() {
   const { autoTrackPhase2, toggleAutoTrackPhase2 } = useTracking();
 
   if (loading) return <LoadingSpinner />;
-  if (error) return <div role="alert" className="text-red-600 p-8 text-center">Error: {error}</div>;
+  if (error) return <ErrorMessage error={error} />;
 
   const current = data?.current || [];
   const completed = data?.completed || [];

--- a/merger-tracker/frontend/src/pages/RefiledNotifications.jsx
+++ b/merger-tracker/frontend/src/pages/RefiledNotifications.jsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import { differenceInCalendarDays, parseISO, isValid } from 'date-fns';
 import { FaArrowRightArrowLeft, FaHourglassHalf, FaCalendarDays } from 'react-icons/fa6';
 import LoadingSpinner from '../components/LoadingSpinner';
+import ErrorMessage from '../components/ErrorMessage';
 import StatusBadge from '../components/StatusBadge';
 import StatCard from '../components/StatCard';
 import SEO from '../components/SEO';
@@ -162,7 +163,7 @@ function RefiledNotifications() {
   const { data, loading, error } = useFetchData(API_ENDPOINTS.refiledNotifications, { cacheKey: 'refiled-notifications' });
 
   if (loading) return <LoadingSpinner />;
-  if (error) return <div role="alert" className="text-red-600 p-8 text-center">Error: {error}</div>;
+  if (error) return <ErrorMessage error={error} />;
 
   const current = data?.current || [];
   const completed = data?.completed || [];

--- a/merger-tracker/frontend/src/pages/Timeline.jsx
+++ b/merger-tracker/frontend/src/pages/Timeline.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { mergerPath } from '../utils/slug';
 import LoadingSpinner from '../components/LoadingSpinner';
+import ErrorMessage from '../components/ErrorMessage';
 import SEO from '../components/SEO';
 import ExternalLinkIcon from '../components/ExternalLinkIcon';
 import { formatDate } from '../utils/dates';
@@ -258,7 +259,7 @@ function Timeline() {
   };
 
   if (loading) return <LoadingSpinner />;
-  if (error) return <div className="text-red-600 p-8 text-center">Error: {error}</div>;
+  if (error) return <ErrorMessage error={error} />;
 
   return (
     <>


### PR DESCRIPTION
## Summary

- Adds `components/ErrorMessage.jsx`, rendering the `Error: {error}` div with `role="alert"` always included.
- Replaces the 11 inline occurrences of `<div ... >Error: {error}</div>` across `pages/Extensions.jsx`, `pages/Industries.jsx`, `pages/Dashboard.jsx`, `pages/RefiledNotifications.jsx`, `pages/Parties.jsx`, `pages/Phase2.jsx` (already had `role="alert"`) and `pages/Digest.jsx`, `pages/Timeline.jsx`, `pages/Commentary.jsx`, `pages/Analysis.jsx`, `pages/Mergers.jsx` (were missing it) with `<ErrorMessage error={error} />`.
- `components/ErrorCard.jsx` (the richer detail-page error) is untouched, per the issue.

Closes #664

## Test plan

- [x] `npm run lint`
- [x] `npm test` (161 tests passing)
- [x] `npm run build`


---
_Generated by [Claude Code](https://claude.ai/code/session_013kpYSX8AUUzYGcRhtRqccc)_