### PR TITLE
Deduplicate chart colours into constants/chartColors.js

### DIFF
--- a/merger-tracker/frontend/src/constants/chartColors.js
+++ b/merger-tracker/frontend/src/constants/chartColors.js
@@ -1,0 +1,46 @@
+/**
+ * Chart colour palette shared by Analysis, Dashboard, and Extensions.
+ *
+ * CHART_PALETTE holds the named brand colours (plus rgba "Light" variants)
+ * used to build chart.js datasets on Analysis/Dashboard. THEME_HEXES holds
+ * the hex values that mirror tailwind.config.js theme colors, for contexts
+ * (inline styles) that can't reference Tailwind classes directly.
+ */
+import { MERGER_STATUS } from './mergerStatus';
+
+export const CHART_PALETTE = {
+  primary: '#335145',
+  primaryLight: 'rgba(51, 81, 69, 0.15)',
+  accent: '#e07a5f',
+  accentLight: 'rgba(224, 122, 95, 0.15)',
+  teal: '#6b8f7f',
+  tealLight: 'rgba(107, 143, 127, 0.15)',
+  sage: '#8cafa0',
+};
+
+// Fallback order for chart segments whose label has no explicit colour
+// mapping below (e.g. an unrecognised determination).
+export const CHART_PALETTE_ORDER = [
+  CHART_PALETTE.primary,
+  CHART_PALETTE.accent,
+  CHART_PALETTE.teal,
+  CHART_PALETTE.sage,
+];
+
+// merger.accc_determination -> chart colour, so "Approved" is always the
+// primary green regardless of key order in the underlying stats object.
+export const DETERMINATION_COLORS = {
+  [MERGER_STATUS.APPROVED]: CHART_PALETTE.primary,
+  [MERGER_STATUS.NOT_APPROVED]: CHART_PALETTE.accent,
+  [MERGER_STATUS.DECLINED]: CHART_PALETTE.accent,
+  [MERGER_STATUS.NOT_OPPOSED]: CHART_PALETTE.teal,
+  [MERGER_STATUS.REFERRED_TO_PHASE_2]: CHART_PALETTE.sage,
+};
+
+// Hex values mirroring tailwind.config.js theme colors (primary, phase-2,
+// phase-2-referral), for use where a Tailwind class isn't applicable.
+export const THEME_HEXES = {
+  primary: '#335145',
+  phase2: '#52489c',
+  phase2Referral: '#d97706',
+};

--- a/merger-tracker/frontend/src/pages/Analysis.jsx
+++ b/merger-tracker/frontend/src/pages/Analysis.jsx
@@ -17,6 +17,7 @@ import SEO from '../components/SEO';
 import { API_ENDPOINTS } from '../config';
 import { useFetchData } from '../hooks/useFetchData';
 import { industryPath } from '../utils/slug';
+import { CHART_PALETTE as COLORS } from '../constants/chartColors';
 
 ChartJS.register(
   CategoryScale,
@@ -28,16 +29,6 @@ ChartJS.register(
   Tooltip,
   Legend
 );
-
-const COLORS = {
-  primary: '#335145',
-  primaryLight: 'rgba(51, 81, 69, 0.15)',
-  accent: '#e07a5f',
-  accentLight: 'rgba(224, 122, 95, 0.15)',
-  teal: '#6b8f7f',
-  tealLight: 'rgba(107, 143, 127, 0.15)',
-  sage: '#8cafa0',
-};
 
 function formatMonthLabel(yyyymm) {
   const [year, month] = yyyymm.split('-');

--- a/merger-tracker/frontend/src/pages/Dashboard.jsx
+++ b/merger-tracker/frontend/src/pages/Dashboard.jsx
@@ -19,6 +19,7 @@ import { getDaysRemaining, isDatePast } from '../utils/dates';
 import { useFetchData } from '../hooks/useFetchData';
 import { markItemsAsSeen } from '../utils/lastVisit';
 import { formatMedian } from '../utils/formatMedian';
+import { CHART_PALETTE, CHART_PALETTE_ORDER, DETERMINATION_COLORS } from '../constants/chartColors';
 
 ChartJS.register(
   Title,
@@ -61,12 +62,15 @@ function Dashboard() {
   if (error) return <div role="alert" className="text-red-600 p-8 text-center">Error: {error}</div>;
   if (!stats) return null;
 
+  const determinationLabels = Object.keys(stats.by_determination);
   const determinationData = {
-    labels: Object.keys(stats.by_determination),
+    labels: determinationLabels,
     datasets: [
       {
         data: Object.values(stats.by_determination),
-        backgroundColor: ['#335145', '#e07a5f', '#6b8f7f', '#8cafa0'],
+        backgroundColor: determinationLabels.map((label, i) =>
+          DETERMINATION_COLORS[label] || CHART_PALETTE_ORDER[i % CHART_PALETTE_ORDER.length]
+        ),
         borderWidth: 0,
         borderRadius: 4,
       },
@@ -82,7 +86,7 @@ function Dashboard() {
       {
         data: waiverLabels.map((label) => stats.by_waiver_determination[label]),
         backgroundColor: waiverLabels.map((label) =>
-          label === 'Approved' ? '#335145' : '#e07a5f'
+          DETERMINATION_COLORS[label] || CHART_PALETTE.accent
         ),
         borderWidth: 0,
         borderRadius: 4,

--- a/merger-tracker/frontend/src/pages/Extensions.jsx
+++ b/merger-tracker/frontend/src/pages/Extensions.jsx
@@ -13,13 +13,14 @@ import { API_ENDPOINTS } from '../config';
 import { useFetchData } from '../hooks/useFetchData';
 import { mergerPath } from '../utils/slug';
 import { formatDateMedium } from '../utils/dates';
+import { THEME_HEXES } from '../constants/chartColors';
 
 // Reason categories map to a fixed colour so the clock bars, the legend and the
 // "why the clock was extended" breakdown all read as one palette.
 const REASON_STYLE = {
-  'Requested by the merger parties': { color: '#335145', label: 'Requested by the merger parties' },
-  'ACCC information request': { color: '#52489c', label: 'ACCC information request' },
-  'Remedy under consideration': { color: '#d97706', label: 'Remedy under consideration' },
+  'Requested by the merger parties': { color: THEME_HEXES.primary, label: 'Requested by the merger parties' },
+  'ACCC information request': { color: THEME_HEXES.phase2, label: 'ACCC information request' },
+  'Remedy under consideration': { color: THEME_HEXES.phase2Referral, label: 'Remedy under consideration' },
   Other: { color: '#94a3b8', label: 'Other' },
 };
 


### PR DESCRIPTION
## Summary

- Adds `src/constants/chartColors.js`, exporting `CHART_PALETTE` (the primary/accent/teal/sage brand chart palette + `...Light` rgba variants used by Analysis/Dashboard) and `THEME_HEXES` (the `primary`/`phase2`/`phase2Referral` hexes mirroring `tailwind.config.js`, for `Extensions.jsx`).
- `Analysis.jsx` now imports `CHART_PALETTE` instead of defining its own local `COLORS` object.
- `Dashboard.jsx` imports the shared palette and builds the Phase 1 determinations doughnut's `backgroundColor` array by mapping each label through a new `DETERMINATION_COLORS` lookup (falling back to `CHART_PALETTE_ORDER` for any unrecognised label), so "Approved" is always the primary green regardless of key order in `stats.by_determination`. The waiver doughnut uses the same lookup.
- `Extensions.jsx`'s `REASON_STYLE` now references `THEME_HEXES.primary` / `.phase2` / `.phase2Referral` instead of retyped hex literals.

Fixes #666.

## Test plan

- [x] `npm run lint` — no new errors (pre-existing unrelated warning in `Mergers.jsx`)
- [x] `npm run build` — succeeds
- [x] `npm run test` — 161 tests pass across 17 files


---
_Generated by [Claude Code](https://claude.ai/code/session_01GYRWSKhy4jXEJyqb6Ygqoq)_