### PR TITLE
Unify Navbar and CommandPalette page lists

### DIFF
--- a/merger-tracker/frontend/src/components/CommandPalette.jsx
+++ b/merger-tracker/frontend/src/components/CommandPalette.jsx
@@ -6,17 +6,11 @@ import { dataCache } from '../utils/dataCache';
 import { buildSearchIndex, searchMergers } from '../utils/searchIndex';
 import { fetchAllMergers } from '../utils/fetchAllMergers';
 import { mergerPath, partyPath } from '../utils/slug';
+import { NAV_PAGES } from '../constants/navPages';
 
-const PAGES = [
-  { label: 'Dashboard', path: '/' },
-  { label: 'Mergers', path: '/mergers' },
-  { label: 'Industries', path: '/industries' },
-  { label: 'Parties', path: '/parties' },
-  { label: 'Analysis', path: '/analysis' },
-  { label: 'Commentary', path: '/commentary' },
-  { label: 'Digest', path: '/digest' },
-  { label: 'Refiled waivers', path: '/refiled-notifications' },
-];
+const PAGES = NAV_PAGES.filter((p) => p.inPalette)
+  .sort((a, b) => a.paletteOrder - b.paletteOrder)
+  .map(({ path, label }) => ({ path, label }));
 
 // Mergers and parties share one combined budget of rows. By default it's
 // split evenly, but each group can borrow the other's unused capacity — so

--- a/merger-tracker/frontend/src/components/Navbar.jsx
+++ b/merger-tracker/frontend/src/components/Navbar.jsx
@@ -4,18 +4,13 @@ import { FaSearch, FaBars, FaTimes, FaChevronDown } from 'react-icons/fa';
 import { useTracking } from '../context/TrackingContext';
 import NotificationPanel from './NotificationPanel';
 import BellIcon from './BellIcon';
+import { NAV_PAGES } from '../constants/navPages';
 
 const SCROLL_HIDE_THRESHOLD_PX = 50;
 
-const navLinks = [
-  { path: '/', label: 'Dashboard', shortcut: 'd' },
-  { path: '/mergers', label: 'Mergers', shortcut: 'm' },
-  { path: '/phase-2', label: 'Phase 2' },
-  { path: '/industries', label: 'Industries', shortcut: 'i' },
-  { path: '/commentary', label: 'Commentary', shortcut: 'c' },
-  { path: '/analysis', label: 'Analysis', shortcut: 'a' },
-  { path: '/digest', label: 'Catch me up' },
-];
+const navLinks = NAV_PAGES.filter((p) => p.inNavbar)
+  .sort((a, b) => a.navOrder - b.navOrder)
+  .map(({ path, label, navbarLabel, shortcut }) => ({ path, label: navbarLabel || label, shortcut }));
 
 const mainNavLinks = navLinks.slice(0, 2);
 const moreNavLinks = navLinks.slice(2);

--- a/merger-tracker/frontend/src/constants/navPages.js
+++ b/merger-tracker/frontend/src/constants/navPages.js
@@ -1,0 +1,23 @@
+// Single source of truth for pages surfaced in the Navbar and the
+// CommandPalette. Each entry carries both `navOrder` and `paletteOrder` so
+// each surface can render its own filtered, ordered list from one place
+// instead of hardcoding a diverging copy.
+export const NAV_PAGES = [
+  { label: 'Dashboard', path: '/', shortcut: 'd', inNavbar: true, navOrder: 1, inPalette: true, paletteOrder: 1 },
+  { label: 'Mergers', path: '/mergers', shortcut: 'm', inNavbar: true, navOrder: 2, inPalette: true, paletteOrder: 2 },
+  { label: 'Phase 2', path: '/phase-2', inNavbar: true, navOrder: 3, inPalette: true, paletteOrder: 3 },
+  { label: 'Industries', path: '/industries', shortcut: 'i', inNavbar: true, navOrder: 4, inPalette: true, paletteOrder: 4 },
+  { label: 'Parties', path: '/parties', inNavbar: false, inPalette: true, paletteOrder: 5 },
+  { label: 'Analysis', path: '/analysis', shortcut: 'a', inNavbar: true, navOrder: 6, inPalette: true, paletteOrder: 6 },
+  { label: 'Commentary', path: '/commentary', shortcut: 'c', inNavbar: true, navOrder: 5, inPalette: true, paletteOrder: 7 },
+  {
+    label: 'Digest',
+    navbarLabel: 'Catch me up',
+    path: '/digest',
+    inNavbar: true,
+    navOrder: 7,
+    inPalette: true,
+    paletteOrder: 8,
+  },
+  { label: 'Refiled waivers', path: '/refiled-notifications', inNavbar: false, inPalette: true, paletteOrder: 9 },
+];


### PR DESCRIPTION
## Summary

`components/Navbar.jsx` and `components/CommandPalette.jsx` each hardcoded their own list of pages, and the two lists had drifted apart (the palette was missing Phase 2; the navbar was missing Parties and Refiled waivers).

- Added `constants/navPages.js` exporting a single `NAV_PAGES` list. Each entry has `label`, `path`, optional `shortcut`, an optional per-surface label override (`navbarLabel`, used for Digest → "Catch me up"), and `inNavbar`/`inPalette` booleans plus `navOrder`/`paletteOrder` to preserve each surface's existing ordering.
- `Navbar.jsx` and `CommandPalette.jsx` now derive their local lists by filtering/sorting `NAV_PAGES` instead of defining their own arrays.
- Added Phase 2 to the palette list (`inPalette: true`) since its absence was the clear drift bug called out in the issue.
- Left which pages appear on which surface otherwise unchanged (no changes to Timeline/Extensions visibility, per the issue's instruction not to alter that without maintainer input).

Closes #665

## Test plan
- [x] `npx vitest run` — all 161 tests pass (17 files)
- [x] `npx eslint src/constants/navPages.js src/components/Navbar.jsx src/components/CommandPalette.jsx` — clean
- [x] `npm run build` — succeeds


---
_Generated by [Claude Code](https://claude.ai/code/session_01QMUy2FPF18KHvyCawfRgjC)_