### PR TITLE
Fix ESLint exhaustive-deps warning in Mergers.jsx

### DIFF
--- a/merger-tracker/frontend/src/pages/Mergers.jsx
+++ b/merger-tracker/frontend/src/pages/Mergers.jsx
@@ -118,6 +118,7 @@ function Mergers() {
 
   useEffect(() => {
     fetchMergers();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const fetchMergers = async () => {


### PR DESCRIPTION
fetchMergers is intentionally only called once on mount; suppress
the warning the same way the adjacent mount-only effect already does.