### PR TITLE
Extract shared SearchInput component (issue #672)

### DIFF
--- a/merger-tracker/frontend/src/components/SearchInput.jsx
+++ b/merger-tracker/frontend/src/components/SearchInput.jsx
@@ -1,0 +1,28 @@
+function SearchInput({ id, value, onChange, placeholder, ariaLabel, autoComplete, className = '' }) {
+  return (
+    <div className={`relative ${className}`.trim()}>
+      <svg
+        className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth="2"
+        stroke="currentColor"
+        aria-hidden="true"
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
+      </svg>
+      <input
+        type="text"
+        id={id}
+        className="w-full pl-10 pr-3 py-2.5 bg-gray-50 border border-gray-200 rounded-xl text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary focus:bg-white transition-all"
+        placeholder={placeholder}
+        aria-label={ariaLabel}
+        value={value}
+        onChange={onChange}
+        autoComplete={autoComplete}
+      />
+    </div>
+  );
+}
+
+export default SearchInput;

--- a/merger-tracker/frontend/src/pages/Industries.jsx
+++ b/merger-tracker/frontend/src/pages/Industries.jsx
@@ -3,6 +3,7 @@ import LoadingSpinner from '../components/LoadingSpinner';
 import ErrorMessage from '../components/ErrorMessage';
 import IndustryMergerGroups from '../components/IndustryMergerGroups';
 import Treemap from '../components/Treemap';
+import SearchInput from '../components/SearchInput';
 import SEO from '../components/SEO';
 import { API_ENDPOINTS } from '../config';
 import { dataCache } from '../utils/dataCache';
@@ -162,19 +163,12 @@ function Industries() {
             Showing {filteredIndustries.length} of {industries.length}
           </p>
         </div>
-        <div className="relative">
-          <svg className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" fill="none" viewBox="0 0 24 24" strokeWidth="2" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
-          </svg>
-          <input
-            type="text"
-            id="search"
-            className="w-full pl-10 pr-3 py-2.5 bg-gray-50 border border-gray-200 rounded-xl text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary focus:bg-white transition-all"
-            placeholder="Search by industry name or code..."
-            value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
-          />
-        </div>
+        <SearchInput
+          id="search"
+          placeholder="Search by industry name or code..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+        />
       </div>
 
       {/* Industries Table */}

--- a/merger-tracker/frontend/src/pages/IndustryDetail.jsx
+++ b/merger-tracker/frontend/src/pages/IndustryDetail.jsx
@@ -5,6 +5,7 @@ import LoadingSpinner from '../components/LoadingSpinner';
 import ErrorCard from '../components/ErrorCard';
 import IndustryMergerGroups from '../components/IndustryMergerGroups';
 import PhaseDurationComparison from '../components/PhaseDurationComparison';
+import SearchInput from '../components/SearchInput';
 import SEO from '../components/SEO';
 import BellIcon from '../components/BellIcon';
 import Breadcrumb from '../components/Breadcrumb';
@@ -271,19 +272,13 @@ function IndustryDetail() {
         {/* Free-text filter for the merger list, worth showing only once the
             list is long enough to be awkward to scan by eye. */}
         {mergers.length > 5 && (
-          <div className="relative mb-4">
-            <svg className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" fill="none" viewBox="0 0 24 24" strokeWidth="2" stroke="currentColor" aria-hidden="true">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
-            </svg>
-            <input
-              type="text"
-              aria-label="Search mergers in this industry"
-              className="w-full pl-10 pr-3 py-2.5 bg-gray-50 border border-gray-200 rounded-xl text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary focus:bg-white transition-all"
-              placeholder="Search mergers in this industry..."
-              value={mergerSearch}
-              onChange={(e) => setMergerSearch(e.target.value)}
-            />
-          </div>
+          <SearchInput
+            ariaLabel="Search mergers in this industry"
+            placeholder="Search mergers in this industry..."
+            value={mergerSearch}
+            onChange={(e) => setMergerSearch(e.target.value)}
+            className="mb-4"
+          />
         )}
 
         <IndustryMergerGroups mergers={filteredMergers} variant="full" />

--- a/merger-tracker/frontend/src/pages/Parties.jsx
+++ b/merger-tracker/frontend/src/pages/Parties.jsx
@@ -4,6 +4,7 @@ import { FaArrowRightLong } from 'react-icons/fa6';
 import LoadingSpinner from '../components/LoadingSpinner';
 import ErrorMessage from '../components/ErrorMessage';
 import Treemap from '../components/Treemap';
+import SearchInput from '../components/SearchInput';
 import SEO from '../components/SEO';
 import { API_ENDPOINTS } from '../config';
 import { useFetchData } from '../hooks/useFetchData';
@@ -102,20 +103,13 @@ function Parties() {
               </p>
             )}
           </div>
-          <div className="relative">
-            <svg className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" fill="none" viewBox="0 0 24 24" strokeWidth="2" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
-            </svg>
-            <input
-              type="text"
-              id="search"
-              className="w-full pl-10 pr-3 py-2.5 bg-gray-50 border border-gray-200 rounded-xl text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary focus:bg-white transition-all"
-              placeholder="Search by party name..."
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              autoComplete="off"
-            />
-          </div>
+          <SearchInput
+            id="search"
+            placeholder="Search by party name..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            autoComplete="off"
+          />
 
           {/* Results appear only while searching — the full list is never shown */}
           {isSearching && (


### PR DESCRIPTION
## Summary
- Adds `components/SearchInput.jsx` wrapping the relative div, magnifying-glass SVG, and input previously copy-pasted across pages
- Replaces the identical search input markup in `pages/Industries.jsx`, `pages/Parties.jsx`, and `pages/IndustryDetail.jsx` with the new component
- Leaves `pages/Mergers.jsx` untouched — its search input has extra behavior (a clear button, conditional right padding) that doesn't fit the shared component's simple pass-through API without changing its appearance, per the issue's guidance to leave it for a follow-up

Closes #672

## Test plan
- [x] `npm run lint` passes
- [x] `npm run build` succeeds
- [x] `npm run test` — all 161 tests pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01TpXDgnntEdSAN3Pi4n2bsm)_