### PR TITLE
Extract shared breadcrumb, stat grid, and param-decode helpers

### DIFF
--- a/merger-tracker/frontend/src/components/Breadcrumb.jsx
+++ b/merger-tracker/frontend/src/components/Breadcrumb.jsx
@@ -1,0 +1,41 @@
+import { Link } from 'react-router-dom';
+import { FaChevronRight } from 'react-icons/fa';
+
+/**
+ * Breadcrumb trail with FaChevronRight separators. `items` is a flat list of
+ * `{ label, to }`; every item links to `to` except the last, which renders as
+ * the current page (plain text, `aria-current="page"`).
+ */
+function Breadcrumb({ ariaLabel, items }) {
+  const lastIndex = items.length - 1;
+
+  return (
+    <nav aria-label={ariaLabel} className="mb-5">
+      <ol className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-sm text-gray-500">
+        {items.map((item, index) => {
+          const isCurrent = index === lastIndex;
+          return (
+            <li
+              key={item.to || item.label}
+              className={index === 0 ? undefined : 'flex items-center gap-x-1.5'}
+              aria-current={isCurrent ? 'page' : undefined}
+            >
+              {index > 0 && (
+                <FaChevronRight className="w-3 h-3 text-gray-300" aria-hidden="true" />
+              )}
+              {isCurrent ? (
+                <span className="font-medium text-gray-700">{item.label}</span>
+              ) : (
+                <Link to={item.to} className="hover:text-primary transition-colors">
+                  {item.label}
+                </Link>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}
+
+export default Breadcrumb;

--- a/merger-tracker/frontend/src/components/DetailStatGrid.jsx
+++ b/merger-tracker/frontend/src/components/DetailStatGrid.jsx
@@ -1,0 +1,24 @@
+/**
+ * 2x4 stat-card grid used on industry/party detail pages. Distinct from
+ * `StatCard` (the Dashboard's visually different treatment) — don't merge
+ * the two.
+ */
+function DetailStatGrid({ statCards }) {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6">
+      {statCards.map(({ label, value, subtitle }) => (
+        <div key={label} className="bg-white p-5 rounded-2xl border border-gray-100 shadow-card">
+          <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">{label}</p>
+          <p className="text-2xl font-bold text-gray-900 mt-1.5 tracking-tight tabular-nums">
+            {value}
+          </p>
+          {subtitle && (
+            <p className="text-xs text-gray-500 mt-1">{subtitle}</p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default DetailStatGrid;

--- a/merger-tracker/frontend/src/hooks/useDecodedParam.js
+++ b/merger-tracker/frontend/src/hooks/useDecodedParam.js
@@ -1,0 +1,18 @@
+import { useParams } from 'react-router-dom';
+
+/**
+ * Reads a route param and URI-decodes it, falling back to the raw value if
+ * decoding fails (e.g. a malformed `%` sequence) rather than throwing.
+ *
+ * @param {string} name - param name, as passed to react-router's useParams
+ * @returns {string} the decoded param value
+ */
+export function useDecodedParam(name) {
+  const params = useParams();
+  const raw = params[name];
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}

--- a/merger-tracker/frontend/src/pages/IndustryDetail.jsx
+++ b/merger-tracker/frontend/src/pages/IndustryDetail.jsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { FaChevronRight } from 'react-icons/fa';
 import LoadingSpinner from '../components/LoadingSpinner';
 import ErrorCard from '../components/ErrorCard';
@@ -7,8 +7,11 @@ import IndustryMergerGroups from '../components/IndustryMergerGroups';
 import PhaseDurationComparison from '../components/PhaseDurationComparison';
 import SEO from '../components/SEO';
 import BellIcon from '../components/BellIcon';
+import Breadcrumb from '../components/Breadcrumb';
+import DetailStatGrid from '../components/DetailStatGrid';
 import { API_ENDPOINTS } from '../config';
 import { useFetchData } from '../hooks/useFetchData';
+import { useDecodedParam } from '../hooks/useDecodedParam';
 import { useTracking } from '../context/TrackingContext';
 import { industryPath } from '../utils/slug';
 
@@ -21,13 +24,7 @@ const LEVEL_LABELS = {
 };
 
 function IndustryDetail() {
-  const { code } = useParams();
-  let decodedCode;
-  try {
-    decodedCode = decodeURIComponent(code);
-  } catch {
-    decodedCode = code;
-  }
+  const decodedCode = useDecodedParam('code');
 
   const { data, loading, error } = useFetchData(
     API_ENDPOINTS.industryDetail(decodedCode),
@@ -166,30 +163,14 @@ function IndustryDetail() {
       />
       <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8 animate-fade-in">
         {/* Breadcrumb: Industries → division → … → current node */}
-        <nav aria-label="Industry hierarchy" className="mb-5">
-          <ol className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-sm text-gray-500">
-            <li>
-              <Link to="/industries" className="hover:text-primary transition-colors">
-                Industries
-              </Link>
-            </li>
-            {ancestors.map((a) => (
-              <li key={a.code} className="flex items-center gap-x-1.5">
-                <FaChevronRight className="w-3 h-3 text-gray-300" aria-hidden="true" />
-                <Link
-                  to={industryPath(a.code, a.name)}
-                  className="hover:text-primary transition-colors"
-                >
-                  {a.name}
-                </Link>
-              </li>
-            ))}
-            <li className="flex items-center gap-x-1.5" aria-current="page">
-              <FaChevronRight className="w-3 h-3 text-gray-300" aria-hidden="true" />
-              <span className="font-medium text-gray-700">{industryName}</span>
-            </li>
-          </ol>
-        </nav>
+        <Breadcrumb
+          ariaLabel="Industry hierarchy"
+          items={[
+            { label: 'Industries', to: '/industries' },
+            ...ancestors.map((a) => ({ label: a.name, to: industryPath(a.code, a.name) })),
+            { label: industryName },
+          ]}
+        />
 
         <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6 mb-6 card-accent">
           <div className="pt-1 flex items-start justify-between gap-4">
@@ -220,21 +201,7 @@ function IndustryDetail() {
           </div>
         </div>
 
-        {mergers.length > 0 && (
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6">
-            {statCards.map(({ label, value, subtitle }) => (
-              <div key={label} className="bg-white p-5 rounded-2xl border border-gray-100 shadow-card">
-                <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">{label}</p>
-                <p className="text-2xl font-bold text-gray-900 mt-1.5 tracking-tight tabular-nums">
-                  {value}
-                </p>
-                {subtitle && (
-                  <p className="text-xs text-gray-500 mt-1">{subtitle}</p>
-                )}
-              </div>
-            ))}
-          </div>
-        )}
+        {mergers.length > 0 && <DetailStatGrid statCards={statCards} />}
 
         {/* Phase 1 duration, shown visually against the parent industry. */}
         {mergers.length > 0 && duration?.average_business_days != null && (

--- a/merger-tracker/frontend/src/pages/PartyDetail.jsx
+++ b/merger-tracker/frontend/src/pages/PartyDetail.jsx
@@ -1,12 +1,13 @@
-import { useParams, Link } from 'react-router-dom';
-import { FaChevronRight } from 'react-icons/fa';
 import LoadingSpinner from '../components/LoadingSpinner';
 import ErrorCard from '../components/ErrorCard';
 import IndustryMergerGroups from '../components/IndustryMergerGroups';
 import PhaseDurationComparison from '../components/PhaseDurationComparison';
 import SEO from '../components/SEO';
+import Breadcrumb from '../components/Breadcrumb';
+import DetailStatGrid from '../components/DetailStatGrid';
 import { API_ENDPOINTS } from '../config';
 import { useFetchData } from '../hooks/useFetchData';
+import { useDecodedParam } from '../hooks/useDecodedParam';
 import { partyPath } from '../utils/slug';
 
 const ROLE_LABELS = {
@@ -16,13 +17,7 @@ const ROLE_LABELS = {
 };
 
 function PartyDetail() {
-  const { id } = useParams();
-  let decodedId;
-  try {
-    decodedId = decodeURIComponent(id);
-  } catch {
-    decodedId = id;
-  }
+  const decodedId = useDecodedParam('id');
 
   const { data, loading, error } = useFetchData(
     API_ENDPOINTS.partyDetail(decodedId),
@@ -90,19 +85,13 @@ function PartyDetail() {
         url={partyPath(decodedId, partyName)}
       />
       <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8 animate-fade-in">
-        <nav aria-label="Party breadcrumb" className="mb-5">
-          <ol className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-sm text-gray-500">
-            <li>
-              <Link to="/parties" className="hover:text-primary transition-colors">
-                Parties
-              </Link>
-            </li>
-            <li className="flex items-center gap-x-1.5" aria-current="page">
-              <FaChevronRight className="w-3 h-3 text-gray-300" aria-hidden="true" />
-              <span className="font-medium text-gray-700">{partyName}</span>
-            </li>
-          </ol>
-        </nav>
+        <Breadcrumb
+          ariaLabel="Party breadcrumb"
+          items={[
+            { label: 'Parties', to: '/parties' },
+            { label: partyName },
+          ]}
+        />
 
         <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6 mb-6 card-accent">
           <h1 className="text-2xl font-bold text-gray-900 tracking-tight">{partyName}</h1>
@@ -136,18 +125,7 @@ function PartyDetail() {
           )}
         </div>
 
-        {mergerCount > 0 && (
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6">
-            {statCards.map(({ label, value }) => (
-              <div key={label} className="bg-white p-5 rounded-2xl border border-gray-100 shadow-card">
-                <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">{label}</p>
-                <p className="text-2xl font-bold text-gray-900 mt-1.5 tracking-tight tabular-nums">
-                  {value}
-                </p>
-              </div>
-            ))}
-          </div>
-        )}
+        {mergerCount > 0 && <DetailStatGrid statCards={statCards} />}
 
         {mergerCount > 0 && duration?.average_business_days != null && (
           <div className="mb-6">


### PR DESCRIPTION
## Summary
- `IndustryDetail.jsx` and `PartyDetail.jsx` hand-rolled the same 2×4 stat-card grid, breadcrumb nav (`FaChevronRight` separators), and `decodeURIComponent` try/catch.
- Extracted `components/DetailStatGrid.jsx` (takes the `statCards` array), `components/Breadcrumb.jsx` (takes a list of `{label, to}` items, last one rendered as the current page), and `hooks/useDecodedParam.js` (wraps `useParams` + decode try/catch).
- Both pages now use these shared pieces; the `ErrorCard` not-found/generic-error branching was left inline per the issue, since it's short and the messages differ per page.
- `DetailStatGrid` is intentionally kept separate from the existing `StatCard` component (a different, Dashboard-only visual treatment).

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` (161 tests passing)
- [x] Manually rendered `/industries/0142` (multi-level ancestor breadcrumb) and `/parties/3m-company` in a headless browser — layout matches the pre-refactor pages, no console errors

Fixes #673

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRwYRfqxJRmjpWvhyDrwcT)_