### PR TITLE
Extract shared TrackButton component from IndustryDetail and MergerDetail

### DIFF
--- a/merger-tracker/frontend/src/components/TrackButton.jsx
+++ b/merger-tracker/frontend/src/components/TrackButton.jsx
@@ -1,0 +1,30 @@
+import BellIcon from './BellIcon';
+
+function TrackButton({
+  active,
+  onClick,
+  activeLabel,
+  inactiveLabel,
+  activeAriaLabel,
+  inactiveAriaLabel,
+  title,
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`inline-flex items-center justify-center gap-1.5 px-2.5 py-1 text-xs font-semibold rounded-lg border transition-all duration-200 flex-shrink-0 ${
+        active
+          ? 'bg-primary text-white border-primary hover:bg-primary-dark shadow-sm'
+          : 'bg-gray-100 text-gray-600 border-gray-200/60 hover:bg-gray-200'
+      }`}
+      aria-pressed={active}
+      aria-label={active ? activeAriaLabel : inactiveAriaLabel}
+      title={title}
+    >
+      <BellIcon filled={active} className="w-3.5 h-3.5" />
+      {active ? activeLabel : inactiveLabel}
+    </button>
+  );
+}
+
+export default TrackButton;

--- a/merger-tracker/frontend/src/pages/IndustryDetail.jsx
+++ b/merger-tracker/frontend/src/pages/IndustryDetail.jsx
@@ -7,7 +7,7 @@ import IndustryMergerGroups from '../components/IndustryMergerGroups';
 import PhaseDurationComparison from '../components/PhaseDurationComparison';
 import SearchInput from '../components/SearchInput';
 import SEO from '../components/SEO';
-import BellIcon from '../components/BellIcon';
+import TrackButton from '../components/TrackButton';
 import Breadcrumb from '../components/Breadcrumb';
 import DetailStatGrid from '../components/DetailStatGrid';
 import { API_ENDPOINTS } from '../config';
@@ -184,22 +184,15 @@ function IndustryDetail() {
                 ANZSIC {levelLabel ? `${levelLabel.toLowerCase()} ` : 'code: '}{decodedCode} · {mergers.length} merger{mergers.length !== 1 ? 's' : ''}
               </p>
             </div>
-            <button
+            <TrackButton
+              active={following}
               onClick={() => toggleIndustryTracking(decodedCode, industryName)}
-              className={`inline-flex items-center justify-center gap-1.5 px-2.5 py-1 text-xs font-semibold rounded-lg border transition-all duration-200 flex-shrink-0 ${
-                following
-                  ? 'bg-primary text-white border-primary hover:bg-primary-dark shadow-sm'
-                  : 'bg-gray-100 text-gray-600 border-gray-200/60 hover:bg-gray-200'
-              }`}
-              aria-pressed={following}
-              aria-label={following
-                ? 'Stop following this industry'
-                : 'Follow this industry for new filings and determinations'}
+              activeLabel="Following"
+              inactiveLabel="Follow"
+              activeAriaLabel="Stop following this industry"
+              inactiveAriaLabel="Follow this industry for new filings and determinations"
               title="Get notified when a new merger is filed or a determination is published in this industry"
-            >
-              <BellIcon filled={following} className="w-3.5 h-3.5" />
-              {following ? 'Following' : 'Follow'}
-            </button>
+            />
           </div>
         </div>
 

--- a/merger-tracker/frontend/src/pages/MergerDetail.jsx
+++ b/merger-tracker/frontend/src/pages/MergerDetail.jsx
@@ -5,7 +5,7 @@ import ReactMarkdown from 'react-markdown';
 import LoadingSpinner from '../components/LoadingSpinner';
 import ErrorCard from '../components/ErrorCard';
 import StatusBadge from '../components/StatusBadge';
-import BellIcon from '../components/BellIcon';
+import TrackButton from '../components/TrackButton';
 import WaiverBadge from '../components/WaiverBadge';
 import BusinessDayProgress from '../components/BusinessDayProgress';
 import { getBusinessDayProgress } from '../utils/businessDayProgress';
@@ -290,19 +290,14 @@ function MergerDetail() {
                 determination={merger.accc_determination}
                 hasConditions={merger.has_conditions}
               />
-              <button
+              <TrackButton
+                active={tracked}
                 onClick={() => toggleTracking(id)}
-                className={`inline-flex items-center justify-center gap-1.5 px-2.5 py-1 text-xs font-semibold rounded-lg border transition-all duration-200 ${
-                  tracked
-                    ? 'bg-primary text-white border-primary hover:bg-primary-dark shadow-sm'
-                    : 'bg-gray-100 text-gray-600 border-gray-200/60 hover:bg-gray-200'
-                }`}
-                aria-pressed={tracked}
-                aria-label={tracked ? 'Stop tracking this merger' : 'Track this merger for updates'}
-              >
-                <BellIcon filled={tracked} className="w-3.5 h-3.5" />
-                {tracked ? 'Tracking' : 'Track'}
-              </button>
+                activeLabel="Tracking"
+                inactiveLabel="Track"
+                activeAriaLabel="Stop tracking this merger"
+                inactiveAriaLabel="Track this merger for updates"
+              />
             </div>
           </div>
 


### PR DESCRIPTION
## Summary

- Extracts `components/TrackButton.jsx` from the duplicated follow/track toggle button in `pages/IndustryDetail.jsx` (Follow/Following) and `pages/MergerDetail.jsx` (Track/Tracking).
- The new component takes `active`, `onClick`, active/inactive labels, active/inactive aria-labels, and an optional `title` tooltip (used by `IndustryDetail`).
- Both pages now render `<TrackButton />` instead of duplicating the button markup, class strings, and `BellIcon` usage.

Closes #674

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test` (161 tests passed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BTbTHEk7S2WtcnJ8dpSPbD)_