### PR TITLE
Extract CARD and SECTION_HEADING shared class constants

### DIFF
--- a/merger-tracker/frontend/src/components/CollapsibleCard.jsx
+++ b/merger-tracker/frontend/src/components/CollapsibleCard.jsx
@@ -1,5 +1,6 @@
 import { useId, useState } from 'react';
 import { FaChevronDown } from 'react-icons/fa';
+import { CARD } from '../utils/classNames';
 
 function CollapsibleCard({ icon, iconBgClass = 'bg-gray-100', title, subtitle, onExpand, children }) {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -12,7 +13,7 @@ function CollapsibleCard({ icon, iconBgClass = 'bg-gray-100', title, subtitle, o
   };
 
   return (
-    <div className="bg-white rounded-2xl border border-gray-100 shadow-card mb-6 overflow-hidden">
+    <div className={`${CARD} mb-6 overflow-hidden`}>
       <button
         type="button"
         onClick={handleToggle}

--- a/merger-tracker/frontend/src/components/DetailStatGrid.jsx
+++ b/merger-tracker/frontend/src/components/DetailStatGrid.jsx
@@ -1,3 +1,5 @@
+import { SECTION_HEADING } from '../utils/classNames';
+
 /**
  * 2x4 stat-card grid used on industry/party detail pages. Distinct from
  * `StatCard` (the Dashboard's visually different treatment) — don't merge
@@ -8,7 +10,7 @@ function DetailStatGrid({ statCards }) {
     <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6">
       {statCards.map(({ label, value, subtitle }) => (
         <div key={label} className="bg-white p-5 rounded-2xl border border-gray-100 shadow-card">
-          <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">{label}</p>
+          <p className={SECTION_HEADING}>{label}</p>
           <p className="text-2xl font-bold text-gray-900 mt-1.5 tracking-tight tabular-nums">
             {value}
           </p>

--- a/merger-tracker/frontend/src/components/EmptyStateCard.jsx
+++ b/merger-tracker/frontend/src/components/EmptyStateCard.jsx
@@ -1,6 +1,8 @@
+import { CARD } from '../utils/classNames';
+
 function EmptyStateCard({ heading, message }) {
   return (
-    <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6">
+    <div className={`${CARD} p-6`}>
       <h2 className="text-lg font-semibold text-gray-900 mb-4">{heading}</h2>
       <p className="text-gray-500 text-sm">{message}</p>
     </div>

--- a/merger-tracker/frontend/src/components/ErrorCard.jsx
+++ b/merger-tracker/frontend/src/components/ErrorCard.jsx
@@ -1,10 +1,11 @@
 import { Link } from 'react-router-dom';
 import { FaExclamationCircle } from 'react-icons/fa';
+import { CARD } from '../utils/classNames';
 
 function ErrorCard({ title, message, backTo, backLabel, secondaryAction }) {
   return (
     <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-      <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-10 text-center">
+      <div className={`${CARD} p-10 text-center`}>
         <div className="w-16 h-16 mx-auto mb-5 rounded-2xl bg-gray-100 flex items-center justify-center">
           <FaExclamationCircle className="w-8 h-8 text-gray-500" aria-hidden="true" />
         </div>

--- a/merger-tracker/frontend/src/components/IndustryMergerGroups.jsx
+++ b/merger-tracker/frontend/src/components/IndustryMergerGroups.jsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import StatusBadge from './StatusBadge';
 import { mergerPath } from '../utils/slug';
 import { groupMergersByPhase } from '../utils/industryGroups';
+import { CARD } from '../utils/classNames';
 
 // Per-phase accent styling. Literal class strings so Tailwind picks them up.
 const GROUP_STYLES = {
@@ -44,7 +45,7 @@ function IndustryMergerGroups({ mergers, variant = 'full' }) {
                   className={
                     compact
                       ? 'block p-3 bg-white rounded-xl border border-gray-100 hover:border-primary/30 hover:shadow-sm transition-all'
-                      : 'block bg-white rounded-2xl border border-gray-100 shadow-card hover:shadow-card-hover hover:border-gray-200 transition-all duration-200 p-5'
+                      : `block ${CARD} hover:shadow-card-hover hover:border-gray-200 transition-all duration-200 p-5`
                   }
                   aria-label={`View merger details for ${merger.merger_name}`}
                 >

--- a/merger-tracker/frontend/src/components/MergerTimeline.jsx
+++ b/merger-tracker/frontend/src/components/MergerTimeline.jsx
@@ -9,6 +9,7 @@ import {
 } from '../utils/dates';
 import { MERGER_STATUS } from '../constants/mergerStatus';
 import { getOutcomeDot } from '../constants/outcomeDotColors';
+import { SECTION_HEADING } from '../utils/classNames';
 
 // Statutory window the ACCC works to for merger waiver applications. Waivers
 // aren't published with an explicit end-of-determination date, so we derive the
@@ -40,7 +41,7 @@ function MergerTimelineFallback({ merger, startStr }) {
   return (
     <dl className="flex flex-wrap gap-x-12 gap-y-4">
       <div>
-        <dt className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1.5">
+        <dt className={`${SECTION_HEADING} mb-1.5`}>
           {startLabel}
         </dt>
         <dd className="text-sm font-medium text-gray-900">
@@ -59,7 +60,7 @@ function MergerTimelineFallback({ merger, startStr }) {
         </dd>
       </div>
       <div>
-        <dt className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1.5">
+        <dt className={`${SECTION_HEADING} mb-1.5`}>
           Status
         </dt>
         <dd className="text-sm font-medium text-gray-900">{merger.status || 'N/A'}</dd>
@@ -196,7 +197,7 @@ function MergerTimeline({ merger }) {
 
   // No nowrap on labels so multi-word endpoint labels wrap within the fixed
   // column width on small screens instead of squeezing the track.
-  const labelClass = 'text-xs font-medium text-gray-500 uppercase tracking-wider';
+  const labelClass = SECTION_HEADING;
   const dateClass = 'text-xs sm:text-sm font-medium text-gray-900 whitespace-nowrap';
   // Every label sits its bottom this far above the line; every value sits its
   // top this far below it. Shared across endpoints and mid markers so the three

--- a/merger-tracker/frontend/src/components/Phase2Timeline.jsx
+++ b/merger-tracker/frontend/src/components/Phase2Timeline.jsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import { differenceInCalendarDays, parseISO, isValid } from 'date-fns';
 import { mergerPath } from '../utils/slug';
 import { formatDateMedium } from '../utils/dates';
+import { CARD } from '../utils/classNames';
 
 // Position of `date` along the referral -> deadline axis, clamped to [0, 100]
 // so a milestone that lands before/after the span (bad data, clock restarts)
@@ -114,14 +115,14 @@ function MatterBar({ matter }) {
 function Phase2Timeline({ matters }) {
   if (!matters || matters.length === 0) {
     return (
-      <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6">
+      <div className={`${CARD} p-6`}>
         <p className="text-gray-500 text-sm">No matters are currently in Phase 2.</p>
       </div>
     );
   }
 
   return (
-    <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-5 sm:p-6">
+    <div className={`${CARD} p-5 sm:p-6`}>
       <ul className="divide-y divide-gray-100">
         {matters.map((matter) => (
           <MatterBar key={matter.merger_id} matter={matter} />

--- a/merger-tracker/frontend/src/components/PhaseDurationComparison.jsx
+++ b/merger-tracker/frontend/src/components/PhaseDurationComparison.jsx
@@ -1,4 +1,5 @@
 import { FaArrowUp, FaArrowDown } from 'react-icons/fa';
+import { CARD, SECTION_HEADING } from '../utils/classNames';
 
 // A single horizontal bar with its value to the right and a caption (plus an
 // optional delta chip) underneath.
@@ -61,7 +62,7 @@ function MetricComparison({ label, current, comparisons, subjectLabel }) {
   if (current == null) {
     return (
       <div>
-        <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">{label}</p>
+        <p className={SECTION_HEADING}>{label}</p>
         <p className="text-sm text-gray-500 mt-2">No completed reviews</p>
       </div>
     );
@@ -75,7 +76,7 @@ function MetricComparison({ label, current, comparisons, subjectLabel }) {
 
   return (
     <div>
-      <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2.5">
+      <p className={`${SECTION_HEADING} mb-2.5`}>
         {label}
       </p>
 
@@ -140,9 +141,9 @@ function PhaseDurationComparison({
   const medianComparisons = toMetric('median_business_days');
 
   return (
-    <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6">
+    <div className={`${CARD} p-6`}>
       <div className="flex items-baseline justify-between gap-3 mb-5">
-        <h2 className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <h2 className={SECTION_HEADING}>
           {title}
         </h2>
         <span className="text-[11px] text-gray-500">business days</span>

--- a/merger-tracker/frontend/src/components/StatCard.jsx
+++ b/merger-tracker/frontend/src/components/StatCard.jsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import { CARD } from '../utils/classNames';
 
 function StatCard({ title, value, subtitle, icon, href }) {
   const Wrapper = href ? Link : 'div';
@@ -7,7 +8,7 @@ function StatCard({ title, value, subtitle, icon, href }) {
   return (
     <Wrapper
       {...wrapperProps}
-      className="block bg-white rounded-2xl border border-gray-100 shadow-card hover:shadow-card-hover transition-all duration-200 overflow-hidden group"
+      className={`block ${CARD} hover:shadow-card-hover transition-all duration-200 overflow-hidden group`}
     >
       <div className="p-6">
         <div className="flex items-start gap-4">

--- a/merger-tracker/frontend/src/components/UpcomingEventsTimeline.jsx
+++ b/merger-tracker/frontend/src/components/UpcomingEventsTimeline.jsx
@@ -4,6 +4,7 @@ import { FaRegComments, FaGavel, FaTriangleExclamation } from 'react-icons/fa6';
 import { mergerPath } from '../utils/slug';
 import { formatWeekday, getCalendarDaysUntil } from '../utils/dates';
 import { PHASES } from '../constants/mergerStatus';
+import { CARD } from '../utils/classNames';
 import EmptyStateCard from './EmptyStateCard';
 
 // Each event type carries its own accent (icon tile + chip) so the kind of
@@ -112,7 +113,7 @@ function UpcomingEventsTimeline({ events }) {
       >
         Upcoming events
       </h2>
-      <div className="bg-white rounded-2xl border border-gray-100 shadow-card overflow-hidden">
+      <div className={`${CARD} overflow-hidden`}>
       <ol className="px-5 sm:px-6 py-5">
         {days.map((day, dayIndex) => {
           const daysRemaining = getCalendarDaysUntil(day.date);

--- a/merger-tracker/frontend/src/pages/Analysis.jsx
+++ b/merger-tracker/frontend/src/pages/Analysis.jsx
@@ -19,6 +19,7 @@ import { API_ENDPOINTS } from '../config';
 import { useFetchData } from '../hooks/useFetchData';
 import { industryPath } from '../utils/slug';
 import { CHART_PALETTE as COLORS } from '../constants/chartColors';
+import { CARD, SECTION_HEADING } from '../utils/classNames';
 
 ChartJS.register(
   CategoryScale,
@@ -443,13 +444,13 @@ function Analysis() {
           </div>
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             {/* Notifications phase 1 */}
-            <div className="bg-white rounded-2xl border border-gray-100 shadow-card overflow-hidden">
+            <div className={`${CARD} overflow-hidden`}>
               <div className="px-5 py-3 bg-primary">
                 <p className="text-sm font-semibold text-white">Notifications phase 1</p>
               </div>
               <div className="grid grid-cols-2 divide-x divide-gray-100">
                 <div className="p-5">
-                  <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">Avg duration</p>
+                  <p className={SECTION_HEADING}>Avg duration</p>
                   <p className="text-2xl font-bold text-gray-900 mt-1.5 tracking-tight">
                     {phase1Stats.average ? `${phase1Stats.average} days` : 'N/A'}
                   </p>
@@ -458,7 +459,7 @@ function Analysis() {
                   )}
                 </div>
                 <div className="p-5">
-                  <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">Median duration</p>
+                  <p className={SECTION_HEADING}>Median duration</p>
                   <p className="text-2xl font-bold text-gray-900 mt-1.5 tracking-tight">
                     {phase1Stats.median ? `${phase1Stats.median} days` : 'N/A'}
                   </p>
@@ -470,13 +471,13 @@ function Analysis() {
             </div>
 
             {/* Waivers */}
-            <div className="bg-white rounded-2xl border border-gray-100 shadow-card overflow-hidden">
+            <div className={`${CARD} overflow-hidden`}>
               <div className="px-5 py-3 bg-primary">
                 <p className="text-sm font-semibold text-white">Waivers</p>
               </div>
               <div className="grid grid-cols-2 divide-x divide-gray-100">
                 <div className="p-5">
-                  <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">Avg duration</p>
+                  <p className={SECTION_HEADING}>Avg duration</p>
                   <p className="text-2xl font-bold text-gray-900 mt-1.5 tracking-tight">
                     {waiverStats.average ? `${waiverStats.average} days` : 'N/A'}
                   </p>
@@ -485,7 +486,7 @@ function Analysis() {
                   )}
                 </div>
                 <div className="p-5">
-                  <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">Median duration</p>
+                  <p className={SECTION_HEADING}>Median duration</p>
                   <p className="text-2xl font-bold text-gray-900 mt-1.5 tracking-tight">
                     {waiverStats.median ? `${waiverStats.median} days` : 'N/A'}
                   </p>
@@ -500,7 +501,7 @@ function Analysis() {
 
         {/* Monthly Volume */}
         <div className="grid grid-cols-1 gap-6 mb-8">
-          <div className="bg-white rounded-2xl border border-gray-100 shadow-card overflow-hidden">
+          <div className={`${CARD} overflow-hidden`}>
             <div className="px-6 py-5 border-b border-gray-100">
               <h2 className="text-base font-semibold text-gray-900">Monthly notification volume</h2>
               <p className="text-sm text-gray-500 mt-0.5">
@@ -521,7 +522,7 @@ function Analysis() {
         {/* Industry Phase 1 Duration Comparison */}
         {industryDurations.length > 0 && (
           <section className="mb-8">
-            <div className="bg-white rounded-2xl border border-gray-100 shadow-card overflow-hidden">
+            <div className={`${CARD} overflow-hidden`}>
               <div className="px-6 py-5 border-b border-gray-100">
                 <h2 className="text-lg font-semibold text-gray-900">Phase 1 duration by industry</h2>
                 <p className="text-sm text-gray-500 mt-0.5">
@@ -540,7 +541,7 @@ function Analysis() {
         {/* Phase 1 Duration ECDF */}
         {ecdfPoints.length > 0 && (
           <section className="mb-8">
-            <div className="bg-white rounded-2xl border border-gray-100 shadow-card overflow-hidden">
+            <div className={`${CARD} overflow-hidden`}>
               <div className="px-6 py-5 border-b border-gray-100">
                 <h2 id="chart-phase1-ecdf-title" className="text-lg font-semibold text-gray-900">
                   Phase 1 duration: share of reviews concluded
@@ -581,7 +582,7 @@ function Analysis() {
         {/* Waiver Duration ECDF */}
         {waiverEcdfPoints.length > 0 && (
           <section className="mb-8">
-            <div className="bg-white rounded-2xl border border-gray-100 shadow-card overflow-hidden">
+            <div className={`${CARD} overflow-hidden`}>
               <div className="px-6 py-5 border-b border-gray-100">
                 <h2 id="chart-waiver-ecdf-title" className="text-lg font-semibold text-gray-900">
                   Waiver duration: share of applications concluded

--- a/merger-tracker/frontend/src/pages/Commentary.jsx
+++ b/merger-tracker/frontend/src/pages/Commentary.jsx
@@ -11,7 +11,7 @@ import SEO from '../components/SEO';
 import { formatDate } from '../utils/dates';
 import { API_ENDPOINTS } from '../config';
 import { useFetchData } from '../hooks/useFetchData';
-import { PROSE_MARKDOWN } from '../utils/classNames';
+import { PROSE_MARKDOWN, CARD } from '../utils/classNames';
 
 function Commentary() {
   const { data, loading, error } = useFetchData(API_ENDPOINTS.commentary, {
@@ -42,7 +42,7 @@ function Commentary() {
           {items.map((item) => (
             <div
               key={item.merger_id}
-              className="bg-white rounded-2xl border border-gray-100 shadow-card overflow-hidden"
+              className={`${CARD} overflow-hidden`}
             >
               {/* Header */}
               <div className="p-5 border-b border-gray-50">

--- a/merger-tracker/frontend/src/pages/Digest.jsx
+++ b/merger-tracker/frontend/src/pages/Digest.jsx
@@ -15,6 +15,7 @@ import {
   DIGEST_COLOR_CLASSES as COLOR_CLASSES,
   MERGER_STATUS,
 } from '../constants/mergerStatus';
+import { SECTION_HEADING } from '../utils/classNames';
 
 const scrollToTop = () => {
   window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -55,7 +56,7 @@ function DigestSection({ id, title, emptyMessage, colorKey, mergers, columns, re
             <thead>
               <tr className="bg-gray-50/80">
                 {columns.map((col) => (
-                  <th key={col} scope="col" className="px-5 sm:px-6 py-3.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th key={col} scope="col" className={`px-5 sm:px-6 py-3.5 text-left ${SECTION_HEADING}`}>
                     {col}
                   </th>
                 ))}
@@ -170,7 +171,7 @@ function ClearedSection({ mergers, getDeterminationPdf }) {
             <thead>
               <tr className="bg-gray-50/80">
                 {columns.map((col) => (
-                  <th key={col} scope="col" className="px-5 sm:px-6 py-3.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th key={col} scope="col" className={`px-5 sm:px-6 py-3.5 text-left ${SECTION_HEADING}`}>
                     {col}
                   </th>
                 ))}

--- a/merger-tracker/frontend/src/pages/Extensions.jsx
+++ b/merger-tracker/frontend/src/pages/Extensions.jsx
@@ -15,6 +15,7 @@ import { useFetchData } from '../hooks/useFetchData';
 import { mergerPath } from '../utils/slug';
 import { formatDateMedium } from '../utils/dates';
 import { THEME_HEXES } from '../constants/chartColors';
+import { CARD } from '../utils/classNames';
 
 // Reason categories map to a fixed colour so the clock bars, the legend and the
 // "why the clock was extended" breakdown all read as one palette.
@@ -30,7 +31,7 @@ const BASE_CLOCK_COLOR = '#E5E7EB'; // gray-200 — the statutory 30-BD window
 function ReasonBreakdown({ reasons }) {
   const maxEvents = Math.max(...reasons.map((r) => r.events), 1);
   return (
-    <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-5 sm:p-6">
+    <div className={`${CARD} p-5 sm:p-6`}>
       <ul className="space-y-4">
         {reasons.map((r) => {
           const style = REASON_STYLE[r.category] || REASON_STYLE.Other;
@@ -259,11 +260,11 @@ function Extensions() {
             coloured by reason. Longest clock first.
           </p>
           {matters.length === 0 ? (
-            <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6">
+            <div className={`${CARD} p-6`}>
               <p className="text-gray-500 text-sm">No Phase 1 extensions have been published yet.</p>
             </div>
           ) : (
-            <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-5 sm:p-6">
+            <div className={`${CARD} p-5 sm:p-6`}>
               <ul className="divide-y divide-gray-100">
                 {matters.map((matter) => (
                   <MatterCard

--- a/merger-tracker/frontend/src/pages/Feedback.jsx
+++ b/merger-tracker/frontend/src/pages/Feedback.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { FaCheckCircle } from 'react-icons/fa';
 import { FEEDBACK_ENDPOINT, TURNSTILE_SITE_KEY } from '../config';
 import SEO from '../components/SEO';
+import { CARD } from '../utils/classNames';
 
 export default function Feedback() {
   const [message, setMessage] = useState('');
@@ -95,7 +96,7 @@ export default function Feedback() {
           <p className="text-gray-500">Got a suggestion or spotted an issue? Let me know.</p>
         </div>
 
-        <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-8">
+        <div className={`${CARD} p-8`}>
           {status === 'success' ? (
             <div className="flex items-center gap-3 py-2">
               <FaCheckCircle className="h-6 w-6 text-primary shrink-0" aria-hidden="true" />

--- a/merger-tracker/frontend/src/pages/Industries.jsx
+++ b/merger-tracker/frontend/src/pages/Industries.jsx
@@ -8,6 +8,7 @@ import { API_ENDPOINTS } from '../config';
 import { dataCache } from '../utils/dataCache';
 import { useFetchData } from '../hooks/useFetchData';
 import { industryPath } from '../utils/slug';
+import { CARD, SECTION_HEADING } from '../utils/classNames';
 
 const SCROLL_THRESHOLD = 6; // Show scrollable container when industry has more than this many mergers
 
@@ -141,7 +142,7 @@ function Industries() {
       </header>
 
       {/* Industry heatmap */}
-      <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-5 mb-6">
+      <div className={`${CARD} p-5 mb-6`}>
         <Treemap
           items={industries}
           getKey={(ind) => ind.code}
@@ -150,15 +151,15 @@ function Industries() {
       </div>
 
       {/* Search */}
-      <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-5 mb-6">
+      <div className={`${CARD} p-5 mb-6`}>
         <div className="flex items-baseline justify-between gap-3 mb-2">
           <label
             htmlFor="search"
-            className="text-xs font-medium text-gray-500 uppercase tracking-wider"
+            className={SECTION_HEADING}
           >
             Search industries
           </label>
-          <p className="text-xs font-medium text-gray-500 uppercase tracking-wider shrink-0">
+          <p className={`${SECTION_HEADING} shrink-0`}>
             Showing {filteredIndustries.length} of {industries.length}
           </p>
         </div>
@@ -185,10 +186,10 @@ function Industries() {
           </caption>
           <thead>
             <tr className="bg-gray-50/80">
-              <th className="px-6 py-3.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th className={`px-6 py-3.5 text-left ${SECTION_HEADING}`}>
                 Industry name
               </th>
-              <th className="px-6 py-3.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th className={`px-6 py-3.5 text-left ${SECTION_HEADING}`}>
                 Mergers &amp; share of all reviews
               </th>
             </tr>
@@ -269,7 +270,7 @@ function Industries() {
                           instead of stretching the table past the viewport on mobile. */}
                       <td colSpan="2" className="px-6 py-5 bg-gray-100 border-t border-gray-200 shadow-inner max-w-0">
                         <div className="space-y-2">
-                          <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-3">
+                          <p className={`${SECTION_HEADING} mb-3`}>
                             Mergers in this industry
                           </p>
                           {isLoadingThisIndustry ? (

--- a/merger-tracker/frontend/src/pages/IndustryDetail.jsx
+++ b/merger-tracker/frontend/src/pages/IndustryDetail.jsx
@@ -15,6 +15,7 @@ import { useDecodedParam } from '../hooks/useDecodedParam';
 import { useTracking } from '../context/TrackingContext';
 import { industryPath } from '../utils/slug';
 import { MERGER_STATUS, PHASES } from '../constants/mergerStatus';
+import { CARD, SECTION_HEADING } from '../utils/classNames';
 
 // ANZSIC level → human label for the page subtitle and breadcrumb.
 const LEVEL_LABELS = {
@@ -173,7 +174,7 @@ function IndustryDetail() {
           ]}
         />
 
-        <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6 mb-6 card-accent">
+        <div className={`${CARD} p-6 mb-6 card-accent`}>
           <div className="pt-1 flex items-start justify-between gap-4">
             <div>
               <h1 className="text-2xl font-bold text-gray-900 tracking-tight">
@@ -227,8 +228,8 @@ function IndustryDetail() {
 
         {/* Sub-industries: children one level down, for drilling into the tree. */}
         {children.length > 0 && (
-          <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6 mb-6">
-            <h2 className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-3">
+          <div className={`${CARD} p-6 mb-6`}>
+            <h2 className={`${SECTION_HEADING} mb-3`}>
               Sub-industries
             </h2>
             <ul className="divide-y divide-gray-50">
@@ -257,11 +258,11 @@ function IndustryDetail() {
 
         {mergers.length > 0 && (
           <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 mb-3">
-            <h2 className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+            <h2 className={SECTION_HEADING}>
               Mergers in this industry
             </h2>
             {mergers.length > 5 && (
-              <p className="text-xs font-medium text-gray-500 uppercase tracking-wider shrink-0">
+              <p className={`${SECTION_HEADING} shrink-0`}>
                 Showing {filteredMergers.length} of {mergers.length}
               </p>
             )}

--- a/merger-tracker/frontend/src/pages/MergerDetail.jsx
+++ b/merger-tracker/frontend/src/pages/MergerDetail.jsx
@@ -19,7 +19,7 @@ import { useTracking } from '../context/TrackingContext';
 import { useFetchData } from '../hooks/useFetchData';
 import { formatDate } from '../utils/dates';
 import { API_ENDPOINTS } from '../config';
-import { PROSE_MARKDOWN } from '../utils/classNames';
+import { PROSE_MARKDOWN, CARD, SECTION_HEADING } from '../utils/classNames';
 import { slugify, mergerPath, industryPath, partyPath } from '../utils/slug';
 import { MERGER_STATUS } from '../constants/mergerStatus';
 import { OUTCOME_DOT_COLORS, DEFAULT_OUTCOME_DOT, getOutcomeDot } from '../constants/outcomeDotColors';
@@ -75,7 +75,7 @@ function MergerDetail() {
     const hiddenCount = parties.length - VISIBLE_COUNT;
 
     return (
-      <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6">
+      <div className={`${CARD} p-6`}>
         <h2 className="text-sm font-semibold text-gray-900 uppercase tracking-wider mb-4">{title}</h2>
         {visibleParties.map((party, idx) => (
           <div key={`${partyType}-${party.name}-${party.identifier || idx}`} className="mb-3 last:mb-0">
@@ -259,7 +259,7 @@ function MergerDetail() {
         </Link>
 
         {/* Header */}
-        <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6 mb-6 card-accent">
+        <div className={`${CARD} p-6 mb-6 card-accent`}>
           <div className="flex items-start justify-between gap-4 pt-1">
             <div className="min-w-0">
               <div className="flex items-center gap-3 mb-2 flex-wrap">
@@ -321,12 +321,12 @@ function MergerDetail() {
           {/* Stage & determination */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6 pt-6 border-t border-gray-100">
             <div>
-              <h3 className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1.5">Stage</h3>
+              <h3 className={`${SECTION_HEADING} mb-1.5`}>Stage</h3>
               <p className="text-sm font-medium text-gray-900">{merger.stage || 'N/A'}</p>
             </div>
             {merger.accc_determination && (
               <div>
-                <h3 className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1.5">
+                <h3 className={`${SECTION_HEADING} mb-1.5`}>
                   Determination
                 </h3>
                 <p className="text-sm font-medium text-gray-900">
@@ -436,7 +436,7 @@ function MergerDetail() {
 
         {/* Description */}
         {merger.merger_description && (
-          <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6 mb-6">
+          <div className={`${CARD} p-6 mb-6`}>
             <h2 className="text-sm font-semibold text-gray-900 uppercase tracking-wider mb-4">
               Description
             </h2>
@@ -453,7 +453,7 @@ function MergerDetail() {
 
         {/* Industries */}
         {merger.anzsic_codes && merger.anzsic_codes.length > 0 && (
-          <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6 mb-6">
+          <div className={`${CARD} p-6 mb-6`}>
             <h2 className="text-sm font-semibold text-gray-900 uppercase tracking-wider mb-4">
               Industries
             </h2>
@@ -473,7 +473,7 @@ function MergerDetail() {
 
         {/* Timeline */}
         {sortedEvents.length > 0 && (
-          <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6">
+          <div className={`${CARD} p-6`}>
             <h2 className="text-sm font-semibold text-gray-900 uppercase tracking-wider mb-6">
               Timeline & Events
             </h2>
@@ -530,7 +530,7 @@ function MergerDetail() {
 
         {/* Similar Mergers */}
         {merger.similar_mergers && merger.similar_mergers.length > 0 && (
-          <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6 mt-6">
+          <div className={`${CARD} p-6 mt-6`}>
             <h2 className="text-sm font-semibold text-gray-900 uppercase tracking-wider mb-4">
               You might be interested in
             </h2>

--- a/merger-tracker/frontend/src/pages/Mergers.jsx
+++ b/merger-tracker/frontend/src/pages/Mergers.jsx
@@ -16,6 +16,7 @@ import { useTracking } from '../context/TrackingContext';
 import { useDebounce } from '../hooks/useDebounce';
 import { buildSearchIndex, searchMergers, clearSearchIndex } from '../utils/searchIndex';
 import { PHASES } from '../constants/mergerStatus';
+import { CARD, SECTION_HEADING } from '../utils/classNames';
 
 const SORT_FIELDS = [
   { value: 'notification', label: 'Notification date' },
@@ -361,7 +362,7 @@ function Mergers() {
       />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 animate-fade-in">
         {/* Search & Filters */}
-        <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-5 mb-6">
+        <div className={`${CARD} p-5 mb-6`}>
           {/* Search row with filter toggle */}
           <div className="flex gap-3">
             <div className="flex-1 relative">
@@ -423,7 +424,7 @@ function Mergers() {
                 <div>
                   <label
                     htmlFor="phase"
-                    className="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-2"
+                    className={`block ${SECTION_HEADING} mb-2`}
                   >
                     Phase
                   </label>
@@ -445,7 +446,7 @@ function Mergers() {
                 <div>
                   <label
                     htmlFor="status"
-                    className="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-2"
+                    className={`block ${SECTION_HEADING} mb-2`}
                   >
                     Status
                   </label>
@@ -469,7 +470,7 @@ function Mergers() {
                 </div>
                 <div>
                   <label
-                    className="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-2"
+                    className={`block ${SECTION_HEADING} mb-2`}
                   >
                     Tracked
                   </label>

--- a/merger-tracker/frontend/src/pages/NickTwort.jsx
+++ b/merger-tracker/frontend/src/pages/NickTwort.jsx
@@ -1,5 +1,6 @@
 import { FaLinkedin, FaGithub, FaEnvelope } from 'react-icons/fa';
 import SEO from '../components/SEO';
+import { CARD } from '../utils/classNames';
 
 const structuredData = {
   "@context": "https://schema.org",
@@ -86,7 +87,7 @@ export default function NickTwort() {
         </div>
 
         {/* Overview */}
-        <section className="bg-white rounded-2xl border border-gray-100 shadow-card p-8 mb-8">
+        <section className={`${CARD} p-8 mb-8`}>
           <h2 className="text-xl font-semibold text-gray-900 mb-4">Overview</h2>
           <p className="text-gray-700 leading-relaxed mb-4">
             Nick Twort is a competition economist with eight years of experience applying microeconomic principles to
@@ -108,7 +109,7 @@ export default function NickTwort() {
         </section>
 
         {/* Merger Clearance Expertise */}
-        <section className="bg-white rounded-2xl border border-gray-100 shadow-card p-8 mb-8">
+        <section className={`${CARD} p-8 mb-8`}>
           <h2 className="text-xl font-semibold text-gray-900 mb-4">Merger Clearance &amp; the Australian Merger Regime</h2>
           <p className="text-gray-700 leading-relaxed mb-4">
             Merger clearance is a central pillar of Nick's practice and he has been a vocal commentator on the transition
@@ -134,7 +135,7 @@ export default function NickTwort() {
         </section>
 
         {/* Antitrust Practice Areas */}
-        <section className="bg-white rounded-2xl border border-gray-100 shadow-card p-8 mb-8">
+        <section className={`${CARD} p-8 mb-8`}>
           <h2 className="text-xl font-semibold text-gray-900 mb-4">Antitrust Practice Areas</h2>
           <p className="text-gray-700 leading-relaxed mb-4">
             Beyond mergers, Nick advises across the full range of competition law matters:
@@ -167,7 +168,7 @@ export default function NickTwort() {
         </section>
 
         {/* Industry Experience */}
-        <section className="bg-white rounded-2xl border border-gray-100 shadow-card p-8 mb-8">
+        <section className={`${CARD} p-8 mb-8`}>
           <h2 className="text-xl font-semibold text-gray-900 mb-4">Industry Experience</h2>
           <p className="text-gray-700 leading-relaxed mb-4">
             Nick has worked across a broad range of Australian industries and markets, bringing sector-specific
@@ -224,7 +225,7 @@ export default function NickTwort() {
         </section>
 
         {/* Analytical Approach */}
-        <section className="bg-white rounded-2xl border border-gray-100 shadow-card p-8 mb-8">
+        <section className={`${CARD} p-8 mb-8`}>
           <h2 className="text-xl font-semibold text-gray-900 mb-4">Empirical &amp; Analytical Methods</h2>
           <p className="text-gray-700 leading-relaxed mb-4">
             A distinguishing feature of Nick's practice is his use of data and advanced quantitative methods to

--- a/merger-tracker/frontend/src/pages/NotFound.jsx
+++ b/merger-tracker/frontend/src/pages/NotFound.jsx
@@ -1,6 +1,7 @@
 import { Link, useLocation } from 'react-router-dom';
 import { FaFile, FaExclamationCircle } from 'react-icons/fa';
 import SEO from '../components/SEO';
+import { CARD } from '../utils/classNames';
 
 function NotFound() {
   const location = useLocation();
@@ -20,7 +21,7 @@ function NotFound() {
           description="This ACCC document is not currently available."
         />
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 animate-fade-in">
-          <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-10 text-center max-w-lg mx-auto">
+          <div className={`${CARD} p-10 text-center max-w-lg mx-auto`}>
             <div className="w-16 h-16 mx-auto mb-5 rounded-2xl bg-gray-100 flex items-center justify-center">
               <FaFile className="w-8 h-8 text-gray-500" aria-hidden="true" />
             </div>
@@ -59,7 +60,7 @@ function NotFound() {
         description="The page you're looking for doesn't exist on the Australian Merger Tracker."
       />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 animate-fade-in">
-        <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-10 text-center max-w-lg mx-auto">
+        <div className={`${CARD} p-10 text-center max-w-lg mx-auto`}>
           <div className="w-16 h-16 mx-auto mb-5 rounded-2xl bg-gray-100 flex items-center justify-center">
             <FaExclamationCircle className="w-8 h-8 text-gray-500" aria-hidden="true" />
           </div>

--- a/merger-tracker/frontend/src/pages/Parties.jsx
+++ b/merger-tracker/frontend/src/pages/Parties.jsx
@@ -9,6 +9,7 @@ import { API_ENDPOINTS } from '../config';
 import { useFetchData } from '../hooks/useFetchData';
 import { useDebounce } from '../hooks/useDebounce';
 import { partyPath } from '../utils/slug';
+import { CARD, SECTION_HEADING } from '../utils/classNames';
 
 // How many search results to render at once. The full index runs to well over a
 // thousand parties (mostly one-deal entities), so we never render the whole
@@ -77,7 +78,7 @@ function Parties() {
         </header>
 
         {/* Party heatmap */}
-        <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-5 mb-6">
+        <div className={`${CARD} p-5 mb-6`}>
           <Treemap
             items={parties}
             getKey={(party) => party.id}
@@ -86,16 +87,16 @@ function Parties() {
         </div>
 
         {/* Search */}
-        <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-5">
+        <div className={`${CARD} p-5`}>
           <div className="flex items-baseline justify-between gap-3 mb-2">
             <label
               htmlFor="search"
-              className="text-xs font-medium text-gray-500 uppercase tracking-wider"
+              className={SECTION_HEADING}
             >
               Search parties
             </label>
             {isSearching && (
-              <p className="text-xs font-medium text-gray-500 uppercase tracking-wider shrink-0">
+              <p className={`${SECTION_HEADING} shrink-0`}>
                 {totalMatches > MAX_RESULTS
                   ? `Showing ${MAX_RESULTS} of ${totalMatches}`
                   : `${totalMatches} match${totalMatches === 1 ? '' : 'es'}`}

--- a/merger-tracker/frontend/src/pages/PartyDetail.jsx
+++ b/merger-tracker/frontend/src/pages/PartyDetail.jsx
@@ -9,6 +9,7 @@ import { API_ENDPOINTS } from '../config';
 import { useFetchData } from '../hooks/useFetchData';
 import { useDecodedParam } from '../hooks/useDecodedParam';
 import { partyPath } from '../utils/slug';
+import { CARD, SECTION_HEADING } from '../utils/classNames';
 
 const ROLE_LABELS = {
   acquirer: 'As acquirer',
@@ -93,7 +94,7 @@ function PartyDetail() {
           ]}
         />
 
-        <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6 mb-6 card-accent">
+        <div className={`${CARD} p-6 mb-6 card-accent`}>
           <h1 className="text-2xl font-bold text-gray-900 tracking-tight">{partyName}</h1>
           <p className="text-sm text-gray-500 mt-1">
             {mergerCount} merger{mergerCount !== 1 ? 's' : ''}
@@ -101,7 +102,7 @@ function PartyDetail() {
 
           {members.length > 1 && (
             <div className="mt-4 pt-4 border-t border-gray-100">
-              <h2 className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">
+              <h2 className={`${SECTION_HEADING} mb-2`}>
                 Also registered as
               </h2>
               <ul className="space-y-1">
@@ -150,7 +151,7 @@ function PartyDetail() {
 
         {roles.map((role) => (
           <div key={role} className="mb-8">
-            <h2 className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-3">
+            <h2 className={`${SECTION_HEADING} mb-3`}>
               {ROLE_LABELS[role]}
             </h2>
             <IndustryMergerGroups mergers={mergersByRole[role]} variant="full" />

--- a/merger-tracker/frontend/src/pages/Phase2.jsx
+++ b/merger-tracker/frontend/src/pages/Phase2.jsx
@@ -6,6 +6,7 @@ import SEO from '../components/SEO';
 import { API_ENDPOINTS } from '../config';
 import { useFetchData } from '../hooks/useFetchData';
 import { useTracking } from '../context/TrackingContext';
+import { CARD } from '../utils/classNames';
 
 function Phase2() {
   const { data, loading, error } = useFetchData(API_ENDPOINTS.phase2, { cacheKey: 'phase2' });
@@ -66,7 +67,7 @@ function Phase2() {
             Completed Phase 2 matters
           </h2>
           {completed.length === 0 ? (
-            <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6">
+            <div className={`${CARD} p-6`}>
               <p className="text-gray-500 text-sm">No Phase 2 matters have been completed yet.</p>
             </div>
           ) : (

--- a/merger-tracker/frontend/src/pages/PrivacyPolicy.jsx
+++ b/merger-tracker/frontend/src/pages/PrivacyPolicy.jsx
@@ -1,4 +1,5 @@
 import SEO from '../components/SEO';
+import { CARD } from '../utils/classNames';
 
 export default function PrivacyPolicy() {
   return (
@@ -18,7 +19,7 @@ export default function PrivacyPolicy() {
         </div>
 
         {/* 1. Introduction */}
-        <section className="bg-white rounded-2xl border border-gray-100 shadow-card p-8 mb-6">
+        <section className={`${CARD} p-8 mb-6`}>
           <h2 className="text-xl font-semibold text-gray-900 mb-4">1. Introduction</h2>
           <p className="text-gray-700 leading-relaxed mb-4">
             Welcome to mergers.fyi (&#34;we&#34;, &#34;us&#34;, &#34;our&#34;). We are committed to protecting your privacy and
@@ -30,7 +31,7 @@ export default function PrivacyPolicy() {
         </section>
 
         {/* 2. Information We Collect */}
-        <section className="bg-white rounded-2xl border border-gray-100 shadow-card p-8 mb-6">
+        <section className={`${CARD} p-8 mb-6`}>
           <h2 className="text-xl font-semibold text-gray-900 mb-4">2. Information We Collect</h2>
           <p className="text-gray-700 leading-relaxed mb-4">
             We collect only the minimum personal information necessary to provide our services.
@@ -45,7 +46,7 @@ export default function PrivacyPolicy() {
         </section>
 
         {/* 3. How We Use Your Information */}
-        <section className="bg-white rounded-2xl border border-gray-100 shadow-card p-8 mb-6">
+        <section className={`${CARD} p-8 mb-6`}>
           <h2 className="text-xl font-semibold text-gray-900 mb-4">3. How We Use Your Information</h2>
           <p className="text-gray-700 leading-relaxed mb-3">We use your email address solely to:</p>
           <ul className="list-disc list-inside text-gray-700 space-y-1 mb-4">
@@ -60,7 +61,7 @@ export default function PrivacyPolicy() {
         </section>
 
         {/* 4. Email Delivery and Third-Party Services */}
-        <section className="bg-white rounded-2xl border border-gray-100 shadow-card p-8 mb-6">
+        <section className={`${CARD} p-8 mb-6`}>
           <h2 className="text-xl font-semibold text-gray-900 mb-4">4. Email Delivery and Third-Party Services</h2>
           <p className="text-gray-700 leading-relaxed mb-4">
             We use Resend to store email addresses and deliver our email digest.
@@ -73,7 +74,7 @@ export default function PrivacyPolicy() {
         </section>
 
         {/* 5. Data Storage and Security */}
-        <section className="bg-white rounded-2xl border border-gray-100 shadow-card p-8 mb-6">
+        <section className={`${CARD} p-8 mb-6`}>
           <h2 className="text-xl font-semibold text-gray-900 mb-4">5. Data Storage and Security</h2>
           <p className="text-gray-700 leading-relaxed mb-4">
             We take reasonable steps to protect your information from misuse, loss, or unauthorised access.
@@ -85,7 +86,7 @@ export default function PrivacyPolicy() {
         </section>
 
         {/* 6. Unsubscribing */}
-        <section className="bg-white rounded-2xl border border-gray-100 shadow-card p-8 mb-6">
+        <section className={`${CARD} p-8 mb-6`}>
           <h2 className="text-xl font-semibold text-gray-900 mb-4">6. Unsubscribing</h2>
           <p className="text-gray-700 leading-relaxed mb-3">You can unsubscribe at any time by:</p>
           <ul className="list-disc list-inside text-gray-700 space-y-1 mb-4">
@@ -97,7 +98,7 @@ export default function PrivacyPolicy() {
         </section>
 
         {/* 7. Cookies and Analytics */}
-        <section className="bg-white rounded-2xl border border-gray-100 shadow-card p-8 mb-6">
+        <section className={`${CARD} p-8 mb-6`}>
           <h2 className="text-xl font-semibold text-gray-900 mb-4">7. Cookies and Analytics</h2>
           <p className="text-gray-700 leading-relaxed mb-3">We do not use cookies to track individual users. You browser
             stores some limited information locally, ie:</p>
@@ -113,7 +114,7 @@ export default function PrivacyPolicy() {
         </section>
 
         {/* 8. Access and Correction */}
-        <section className="bg-white rounded-2xl border border-gray-100 shadow-card p-8 mb-6">
+        <section className={`${CARD} p-8 mb-6`}>
           <h2 className="text-xl font-semibold text-gray-900 mb-4">8. Access and Correction</h2>
           <p className="text-gray-700 leading-relaxed">
             If you would like to access, update, or delete your email address, you can contact us at{' '}
@@ -128,7 +129,7 @@ export default function PrivacyPolicy() {
         </section>
 
         {/* 9. Changes to This Policy */}
-        <section className="bg-white rounded-2xl border border-gray-100 shadow-card p-8 mb-6">
+        <section className={`${CARD} p-8 mb-6`}>
           <h2 className="text-xl font-semibold text-gray-900 mb-4">9. Changes to This Policy</h2>
           <p className="text-gray-700 leading-relaxed">
             We may update this Privacy Policy from time to time. Any changes will be posted on this page
@@ -137,7 +138,7 @@ export default function PrivacyPolicy() {
         </section>
 
         {/* 10. Contact */}
-        <section className="bg-white rounded-2xl border border-gray-100 shadow-card p-8">
+        <section className={`${CARD} p-8`}>
           <h2 className="text-xl font-semibold text-gray-900 mb-4">10. Contact</h2>
           <p className="text-gray-700 leading-relaxed">
             If you have any questions about this Privacy Policy, you can contact us at{' '}

--- a/merger-tracker/frontend/src/pages/RefiledNotifications.jsx
+++ b/merger-tracker/frontend/src/pages/RefiledNotifications.jsx
@@ -10,6 +10,7 @@ import { API_ENDPOINTS } from '../config';
 import { useFetchData } from '../hooks/useFetchData';
 import { mergerPath } from '../utils/slug';
 import { formatDateMedium, calculateDuration } from '../utils/dates';
+import { CARD } from '../utils/classNames';
 
 // Position of `date` along the waiver-filed -> track-end axis, clamped to
 // [0, 100] so a milestone landing outside the span (bad data) still renders
@@ -142,14 +143,14 @@ function RefiledCard({ pair, showOutcome }) {
 function RefiledList({ pairs, showOutcome, emptyMessage }) {
   if (pairs.length === 0) {
     return (
-      <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6">
+      <div className={`${CARD} p-6`}>
         <p className="text-gray-500 text-sm">{emptyMessage}</p>
       </div>
     );
   }
 
   return (
-    <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-5 sm:p-6">
+    <div className={`${CARD} p-5 sm:p-6`}>
       <ul className="divide-y divide-gray-100">
         {pairs.map((pair) => (
           <RefiledCard key={pair.notification_id} pair={pair} showOutcome={showOutcome} />

--- a/merger-tracker/frontend/src/pages/Timeline.jsx
+++ b/merger-tracker/frontend/src/pages/Timeline.jsx
@@ -11,6 +11,7 @@ import { dataCache } from '../utils/dataCache';
 import { useFetchData } from '../hooks/useFetchData';
 import { MERGER_STATUS } from '../constants/mergerStatus';
 import { OUTCOME_DOT_COLORS, DEFAULT_OUTCOME_DOT } from '../constants/outcomeDotColors';
+import { CARD } from '../utils/classNames';
 
 const ITEMS_PER_PAGE = 15;
 const LOAD_MORE_COUNT = 10;
@@ -326,7 +327,7 @@ function Timeline() {
                       </div>
                       <Link
                         to={mergerPath(event.merger_id, event.merger_name)}
-                        className="min-w-0 flex-1 bg-white rounded-2xl border border-gray-100 shadow-card p-4 hover:shadow-card-hover hover:border-gray-200 transition-all duration-200 block"
+                        className={`min-w-0 flex-1 ${CARD} p-4 hover:shadow-card-hover hover:border-gray-200 transition-all duration-200 block`}
                         aria-label={`View merger details for ${event.merger_name}`}
                       >
                         <span className="text-sm font-semibold text-gray-900">

--- a/merger-tracker/frontend/src/utils/classNames.js
+++ b/merger-tracker/frontend/src/utils/classNames.js
@@ -4,3 +4,9 @@
 
 /** Prose styles for rendered markdown content (ReactMarkdown wrappers). */
 export const PROSE_MARKDOWN = "text-gray-600 prose prose-sm max-w-none leading-relaxed [&>p]:mb-4 [&>ul]:mb-4 [&>ul]:list-disc [&>ul]:pl-5 [&>ul>li]:mb-2 [&>ol]:mb-4 [&>ol]:list-decimal [&>ol]:pl-5 [&>ol>li]:mb-2 [&_a]:underline";
+
+/** Base card container: white background, rounded corners, subtle border and shadow. */
+export const CARD = "bg-white rounded-2xl border border-gray-100 shadow-card";
+
+/** Uppercase, muted section heading label. */
+export const SECTION_HEADING = "text-xs font-medium text-gray-500 uppercase tracking-wider";


### PR DESCRIPTION
## Summary

Closes #675.

Two Tailwind utility-class strings had drifted into ~85 hand-typed copies across the frontend:

- `bg-white rounded-2xl border border-gray-100 shadow-card` (card container)
- `text-xs font-medium text-gray-500 uppercase tracking-wider` (uppercase section heading label)

- Added `CARD` and `SECTION_HEADING` exports to `utils/classNames.js`, alongside the existing `PROSE_MARKDOWN` constant.
- Migrated every **exact-match** occurrence (28 files) to reference the constants via template literals, appending each site's extra classes after the constant. Full literal strings are still preserved in `classNames.js` per the Tailwind scanner rule.
- Left variants alone, as the issue calls for: e.g. `DetailStatGrid.jsx` (`bg-white p-5 rounded-2xl ...`, different class order), `Mergers.jsx`'s conditionally-selected card border, `MergerDetail.jsx`'s amber notice / blue gradient panels, and `Industries.jsx`'s table wrapper (`shadow-card` before `rounded-2xl`).
- No behavioural or visual changes — same classes render in the same combinations, just deduplicated.

Migrated file-by-file across 10 commits (plus the constants commit) rather than one mega-commit, per the issue's guidance.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 161 tests passing across 17 files (same as baseline before the change)
- [x] `npm run build` — production build succeeds
- [x] Verified no exact-match occurrences of either class string remain outside `classNames.js`


---
_Generated by [Claude Code](https://claude.ai/code/session_01UBy87eeA28cMQDRr9okox7)_