### PR TITLE
Fix related-parties checkbox selection silently failing

### DIFF
--- a/data/processed/related_parties.json
+++ b/data/processed/related_parties.json
@@ -220,6 +220,26 @@
         {
           "name": "Henkel AG & Co. KGaA",
           "identifier": "Germany registration number (HRB): 4724"
+        },
+        {
+          "name": "Henkel Australia Pty Ltd",
+          "identifier": "82 001 302 996"
+        },
+        {
+          "name": "Henkel Finance Australia L.P.",
+          "identifier": "15 740 196 765"
+        },
+        {
+          "name": "Henkel Ireland Distribution Limited",
+          "identifier": "Ireland registration number: 430837"
+        },
+        {
+          "name": "Henkel Singapore Pte Ltd",
+          "identifier": "Singapore registration number (UEN): 198304615H"
+        },
+        {
+          "name": "Henkel US Operations Corporation",
+          "identifier": "Delaware registration number: 740913"
         }
       ]
     },
@@ -1446,6 +1466,88 @@
         {
           "name": "Whalar Inc",
           "identifier": "Delaware company number  6534128"
+        }
+      ]
+    },
+    {
+      "id": "national-dental-care",
+      "canonical_name": "National Dental Care",
+      "members": [
+        {
+          "name": "NATIONAL DENTAL CARE LIMITED",
+          "identifier": "89 160 442 071"
+        },
+        {
+          "name": "NDC AUSTRALIA PTY LIMITED",
+          "identifier": "49 162 955 866"
+        },
+        {
+          "name": "NDC FINCO PTY LTD",
+          "identifier": "14 654 149 818"
+        },
+        {
+          "name": "NDC HOLDCO PTY LTD",
+          "identifier": "13 654 148 188"
+        },
+        {
+          "name": "NDC PROPERTY CO PTY LIMITED",
+          "identifier": "68 163 264 097"
+        },
+        {
+          "name": "NDC SERVICE CO PTY LIMITED",
+          "identifier": "11 162 958 072"
+        }
+      ]
+    },
+    {
+      "id": "australian-venue-co",
+      "canonical_name": "Australian Venue Co",
+      "members": [
+        {
+          "name": "AVC Operations Pty Limited",
+          "identifier": "81 607 832 299"
+        },
+        {
+          "name": "Australian Venue Co. Holdings Limited",
+          "identifier": ""
+        }
+      ]
+    },
+    {
+      "id": "fulton-hogan",
+      "canonical_name": "Fulton Hogan",
+      "members": [
+        {
+          "name": "FULTON HOGAN CONSTRUCTION PTY LTD",
+          "identifier": "46 010 240 758"
+        },
+        {
+          "name": "FULTON HOGAN INDUSTRIES PTY LTD",
+          "identifier": "54 000 538 689"
+        },
+        {
+          "name": "FULTON HOGAN AUSTRALIA (MANAGEMENT) PTY LTD",
+          "identifier": "66 637 368 088"
+        },
+        {
+          "name": "Fulton Hogan Australia Pty Ltd",
+          "identifier": "42 135 849 115"
+        },
+        {
+          "name": "FULTON HOGAN EGIS O&M PTY LTD",
+          "identifier": "37 609 764 730"
+        },
+        {
+          "name": "Fulton Hogan Ltd (NZ)",
+          "identifier": "New Zealand ID  144659"
+        },
+        {
+          "name": "FULTON HOGAN QUARRIES PTY LTD",
+          "identifier": "16 004 475 076"
+        },
+        {
+          "name": "FULTON HOGAN UTILITIES PTY LTD",
+          "identifier": "83 632 499 686"
         }
       ]
     }

--- a/scripts/tools/related_parties.py
+++ b/scripts/tools/related_parties.py
@@ -337,6 +337,10 @@ const selected = new Map();   // key -> { name, identifier }
 
 function partyKey(p) { return p.name + '\\u0000' + (p.identifier || ''); }
 function esc(s) { return (s == null ? '' : String(s)).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); }
+// Keys contain a NUL separator, which the browser's HTML parser mangles when it
+// round-trips through an inline event-handler attribute (innerHTML -> onchange="..."),
+// silently breaking the lookup. Percent-encode so only safe ASCII ever hits the attribute.
+function attrKey(key) { return encodeURIComponent(key).replace(/'/g, '%27'); }
 
 async function load() {
     document.getElementById('ungrouped').innerHTML = '<div class="text-gray-400">Loading...</div>';
@@ -380,8 +384,8 @@ function renderUngrouped() {
         const key = partyKey(p);
         const isSel = selected.has(key);
         return `<label class="flex items-start gap-3 bg-white p-3 rounded border ${isSel ? 'border-accent ring-1 ring-accent' : 'border-gray-200'} hover:shadow-sm cursor-pointer transition-all">
-            <input type="checkbox" ${isSel ? 'checked' : ''} onchange="toggleSelect(this, '${esc(key).replace(/'/g, "\\\\'")}')"
-                class="mt-1 h-4 w-4 accent-brand" data-key="${esc(key)}" />
+            <input type="checkbox" ${isSel ? 'checked' : ''} onchange="toggleSelect(this, '${attrKey(key)}')"
+                class="mt-1 h-4 w-4 accent-brand" data-key="${attrKey(key)}" />
             <div class="min-w-0 flex-1">
                 <div class="text-sm font-medium text-gray-900 break-words">${esc(p.name)}</div>
                 <div class="text-xs text-gray-500 mt-0.5">
@@ -397,6 +401,7 @@ function renderUngrouped() {
 function findUngrouped(key) { return STATE.ungrouped.find(p => partyKey(p) === key); }
 
 function toggleSelect(cb, key) {
+    key = decodeURIComponent(key);
     const p = findUngrouped(key);
     if (!p) return;
     if (cb.checked) selected.set(key, { name: p.name, identifier: p.identifier });


### PR DESCRIPTION
The party key used a NUL separator, embedded directly into the
checkbox's onchange attribute. Browsers replace raw NUL bytes during
HTML parsing, so the key read back on click never matched the
original, making toggleSelect() silently no-op — checkboxes appeared
to check but selection never registered and the "New group" bar never
showed. Percent-encode the key before embedding it in the attribute
and decode it back in toggleSelect.