### PR TITLE
Add search and merge for canonical related-party groups

### DIFF
--- a/data/processed/related_parties.json
+++ b/data/processed/related_parties.json
@@ -1564,6 +1564,38 @@
           "identifier": "U.S. EIN: 943320693"
         }
       ]
+    },
+    {
+      "id": "imagine-education-investments",
+      "canonical_name": "Imagine Education Investments",
+      "members": [
+        {
+          "name": "Imagine Education Investments Pty Ltd",
+          "identifier": ""
+        },
+        {
+          "name": "Imagine Education Investments Trust",
+          "identifier": "54 637 909 142"
+        },
+        {
+          "name": "POLAR 993 PTY LTD as trustee of Imagine Education Investments Trust",
+          "identifier": "77 642 129 226"
+        }
+      ]
+    },
+    {
+      "id": "north-queensland-regional-energy",
+      "canonical_name": "North Queensland Regional Energy",
+      "members": [
+        {
+          "name": "NORTH QUEENSLAND REGIONAL ENERGY CO PTY LTD",
+          "identifier": "99 695 814 101"
+        },
+        {
+          "name": "North Queensland Regional Energy Trust",
+          "identifier": ""
+        }
+      ]
     }
   ]
 }

--- a/data/processed/related_parties.json
+++ b/data/processed/related_parties.json
@@ -211,7 +211,7 @@
     },
     {
       "id": "henkel-ag-co-kgaa",
-      "canonical_name": "Henkel AG & Co. KGaA",
+      "canonical_name": "Henkel",
       "members": [
         {
           "name": "Henkel AG & Co. KGaA",
@@ -240,13 +240,7 @@
         {
           "name": "Henkel US Operations Corporation",
           "identifier": "Delaware registration number: 740913"
-        }
-      ]
-    },
-    {
-      "id": "henkel-global-supply-chain-b-v",
-      "canonical_name": "Henkel Global Supply Chain B.V.",
-      "members": [
+        },
         {
           "name": "Henkel Global Supply Chain B.V.",
           "identifier": "Netherlands registration number: 854017447, CCI 60683945"
@@ -329,7 +323,7 @@
     },
     {
       "id": "ampol-petroleum-pty-ltd",
-      "canonical_name": "Ampol Petroleum Pty Ltd",
+      "canonical_name": "Ampol",
       "members": [
         {
           "name": "AMPOL AUSTRALIA PETROLEUM PTY LTD",
@@ -338,13 +332,7 @@
         {
           "name": "AMPOL PETROLEUM PTY LTD",
           "identifier": "11 000 007 876"
-        }
-      ]
-    },
-    {
-      "id": "ampol-retail-holding-pty-ltd",
-      "canonical_name": "Ampol Retail Holding Pty Ltd",
-      "members": [
+        },
         {
           "name": "AMPOL RETAIL HOLDING PTY LTD",
           "identifier": "689 777 704"
@@ -571,7 +559,7 @@
     },
     {
       "id": "colliers-international-engineering-design-pty-limited",
-      "canonical_name": "Colliers International Engineering & Design Pty Limited",
+      "canonical_name": "Colliers International",
       "members": [
         {
           "name": "COLLIERS INTERNATIONAL ENGINEERING & DESIGN PTY LIMITED",
@@ -580,13 +568,7 @@
         {
           "name": "Colliers International Engineering & Design (Holdings) Pty Limited",
           "identifier": "670 625 617"
-        }
-      ]
-    },
-    {
-      "id": "colliers-international-group-inc",
-      "canonical_name": "Colliers International Group Inc.",
-      "members": [
+        },
         {
           "name": "COLLIERS INTERNATIONAL HOLDINGS (AUSTRALIA) LIMITED",
           "identifier": "65 008 178 238"
@@ -1401,7 +1383,7 @@
     },
     {
       "id": "telstra-limited",
-      "canonical_name": "Telstra Limited",
+      "canonical_name": "Telstra",
       "members": [
         {
           "name": "TELSTRA CORPORATION LIMITED",
@@ -1410,6 +1392,14 @@
         {
           "name": "TELSTRA LIMITED",
           "identifier": "64 086 174 781"
+        },
+        {
+          "name": "TELSTRA AUSTRALIA NETWORKS PTY LIMITED",
+          "identifier": "58 100 816 206"
+        },
+        {
+          "name": "TELSTRA INTERNATIONAL NETWORKS PTY LIMITED",
+          "identifier": "56 142 220 157"
         }
       ]
     },
@@ -1438,20 +1428,6 @@
         {
           "name": "Marc Jacobs International, LLC",
           "identifier": "2684319"
-        }
-      ]
-    },
-    {
-      "id": "telstra-australia-networks-pty-limited",
-      "canonical_name": "Telstra Australia Networks Pty Limited",
-      "members": [
-        {
-          "name": "TELSTRA AUSTRALIA NETWORKS PTY LIMITED",
-          "identifier": "58 100 816 206"
-        },
-        {
-          "name": "TELSTRA INTERNATIONAL NETWORKS PTY LIMITED",
-          "identifier": "56 142 220 157"
         }
       ]
     },

--- a/data/processed/related_parties.json
+++ b/data/processed/related_parties.json
@@ -401,7 +401,7 @@
     },
     {
       "id": "zurich-assure-australia-pty-ltd",
-      "canonical_name": "Zurich Assure Australia Pty Ltd",
+      "canonical_name": "Zurich",
       "members": [
         {
           "name": "ZURICH ASSURE AUSTRALIA PTY LIMITED",
@@ -410,13 +410,55 @@
         {
           "name": "Zurich Assure Australia Pty Ltd",
           "identifier": ""
-        }
-      ]
-    },
-    {
-      "id": "zurich-australian-property-holdings-pty-ltd",
-      "canonical_name": "Zurich Australian Property Holdings Pty Ltd",
-      "members": [
+        },
+        {
+          "name": "Zurich Insurance Company Ltd",
+          "identifier": ""
+        },
+        {
+          "name": "Zurich Australia Insurance Limited",
+          "identifier": ""
+        },
+        {
+          "name": "Zurich Finance (Australia) Limited",
+          "identifier": ""
+        },
+        {
+          "name": "Zurich Australia Limited",
+          "identifier": ""
+        },
+        {
+          "name": "Zurich Australia Insurance Properties Pty Ltd",
+          "identifier": ""
+        },
+        {
+          "name": "Zurich Financial Services Australia Limited",
+          "identifier": ""
+        },
+        {
+          "name": "ZURICH FINANCIAL SERVICES AUSTRALIA LIMITED",
+          "identifier": "11 008 423 372"
+        },
+        {
+          "name": "ZURICH AUSTRALIAN INSURANCE PROPERTIES PTY LTD",
+          "identifier": "79 002 463 292"
+        },
+        {
+          "name": "ZURICH FINANCE (AUSTRALIA) LIMITED",
+          "identifier": "48 618 177 423"
+        },
+        {
+          "name": "ZURICH AUSTRALIA LIMITED",
+          "identifier": "92 000 010 195"
+        },
+        {
+          "name": "ZURICH AUSTRALIAN INSURANCE LIMITED",
+          "identifier": "13 000 296 640"
+        },
+        {
+          "name": "ZURICH INVESTMENT MANAGEMENT LIMITED",
+          "identifier": "56 063 278 400"
+        },
         {
           "name": "ZURICH AUSTRALIAN PROPERTY HOLDINGS PTY LTD",
           "identifier": "91 620 869 230"
@@ -424,13 +466,7 @@
         {
           "name": "Zurich Australian Property Holdings Pty Limited",
           "identifier": ""
-        }
-      ]
-    },
-    {
-      "id": "zurich-services-australia-pty-ltd",
-      "canonical_name": "Zurich Services (Australia) Pty Ltd",
-      "members": [
+        },
         {
           "name": "ZURICH SERVICES (AUSTRALIA) PTY LIMITED",
           "identifier": "17 627 298 337"
@@ -576,6 +612,10 @@
         {
           "name": "Colliers International Group Inc.",
           "identifier": "Ontario Registry  1936883"
+        },
+        {
+          "name": "COLLIERS INTERNATIONAL URBAN PLANNING PTY LIMITED",
+          "identifier": "13 615 087 931"
         }
       ]
     },
@@ -1400,6 +1440,10 @@
         {
           "name": "TELSTRA INTERNATIONAL NETWORKS PTY LIMITED",
           "identifier": "56 142 220 157"
+        },
+        {
+          "name": "Telstra Singapore Pte. Ltd.",
+          "identifier": "Singapore registration No. 200209830G"
         }
       ]
     },

--- a/scripts/detect_related_parties.py
+++ b/scripts/detect_related_parties.py
@@ -393,6 +393,56 @@ def build_candidate(
     }
 
 
+def find_group_merge_candidates(
+    groups: list[dict],
+    fuzzy_threshold: float = DEFAULT_FUZZY_THRESHOLD,
+    enable_fuzzy: bool = True,
+) -> list[dict]:
+    """Find existing canonical groups that look like the same real-world
+    entity and should be merged into one.
+
+    Where ``find_candidates`` clusters *ungrouped* parties, this clusters
+    every member across *all* recorded groups using the same matching rules
+    and reports clusters that span more than one group id — i.e. the same
+    identifier/name/fuzzy match shows up under two different canonical
+    groups, most often because they were recorded separately before either
+    was noticed to be the same entity.
+    """
+    records: list[PartyRecord] = []
+    owners: list[str] = []
+    for g in groups:
+        gid = g.get("id", "")
+        for m in g.get("members", []):
+            name = (m.get("name") or "").strip()
+            identifier = (m.get("identifier") or "").strip()
+            if not normalise_name(name) and not normalise_identifier(identifier):
+                continue
+            records.append(PartyRecord(name, identifier))
+            owners.append(gid)
+
+    components, link_signals = _cluster(records, fuzzy_threshold, enable_fuzzy)
+    by_id = {g.get("id"): g for g in groups}
+
+    candidates: list[dict] = []
+    for members in components:
+        group_ids = sorted({owners[i] for i in members})
+        if len(group_ids) < 2:
+            continue  # cluster is entirely within one group already
+        signal = _component_signal(members, link_signals)
+        candidates.append({
+            "group_ids": group_ids,
+            "groups": [
+                {"id": gid, "canonical_name": by_id[gid].get("canonical_name", "")}
+                for gid in group_ids
+            ],
+            "signal": signal,
+            "score": _SIGNAL_SCORES[signal],
+        })
+
+    candidates.sort(key=lambda c: (-c["score"], c["group_ids"]))
+    return candidates
+
+
 def find_candidates(
     mergers: list[dict],
     groups: list[dict],
@@ -490,6 +540,18 @@ def print_summary(candidates: list[dict]) -> None:
         print()
 
 
+def print_group_merge_summary(candidates: list[dict]) -> None:
+    if not candidates:
+        print("No candidate group merges found.")
+        return
+    print(f"Found {len(candidates)} group(s) that look like the same entity:")
+    print()
+    for c in candidates:
+        names = " / ".join(f"{g['canonical_name']} ({g['id']})" for g in c["groups"])
+        print(f"  {names}  (score {c['score']:.2f}, {c['signal']})")
+    print()
+
+
 def build_pr_body(candidates: list[dict], date: str) -> str:
     """Build a markdown PR body recommending the candidate groups."""
     lines = [
@@ -568,6 +630,11 @@ def main() -> int:
         "--pr-markdown", type=Path, default=None, dest="pr_markdown",
         help="Write a PR body (markdown) recommending the candidates to this path",
     )
+    parser.add_argument(
+        "--group-merge-candidates", action="store_true", dest="group_merge_candidates",
+        help="Instead of detecting new groups, find existing groups in --parties "
+        "that look like the same entity and should be merged (see related_parties.py)",
+    )
     args = parser.parse_args()
 
     if not args.mergers.exists():
@@ -582,6 +649,18 @@ def main() -> int:
     if args.parties.exists():
         with args.parties.open() as fh:
             groups = json.load(fh).get("groups", [])
+
+    if args.group_merge_candidates:
+        merge_candidates = find_group_merge_candidates(groups, args.fuzzy_threshold)
+        print_group_merge_summary(merge_candidates)
+        if args.json:
+            args.json.parent.mkdir(parents=True, exist_ok=True)
+            with args.json.open("w") as fh:
+                json.dump(
+                    {"count": len(merge_candidates), "candidates": merge_candidates},
+                    fh, indent=2,
+                )
+        return 1 if merge_candidates else 0
 
     candidates = find_candidates(mergers, groups, args.fuzzy_threshold, args.fuzzy)
 

--- a/scripts/party_matching.py
+++ b/scripts/party_matching.py
@@ -97,3 +97,68 @@ def match_party(party: dict, by_identifier: dict, by_name: dict) -> dict | None:
     if name and name in by_name:
         return by_name[name]
     return None
+
+
+def dedupe_members(members: list[dict]) -> list[dict]:
+    """Drop exact duplicate (normalised name, normalised identifier) members,
+    keeping the first display form seen."""
+    seen: set[tuple[str, str]] = set()
+    out: list[dict] = []
+    for m in members:
+        name = (m.get("name") or "").strip()
+        identifier = (m.get("identifier") or "").strip()
+        if not name and not identifier:
+            continue
+        key = (normalise_name(name), normalise_identifier(identifier))
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append({"name": name, "identifier": identifier})
+    return out
+
+
+def merge_groups(groups: list[dict], group_ids: list[str], canonical_name: str = "") -> list[dict]:
+    """Merge the groups identified by ``group_ids`` into a single group.
+
+    The merged group keeps the id of whichever of ``group_ids`` appears first
+    in ``groups``; the rest are folded into it (members combined and
+    de-duplicated) and dropped. ``canonical_name``, if given, becomes the
+    merged group's display name; otherwise the kept group's own name is used.
+
+    Returns a new list — ``groups`` is not mutated. Raises ``ValueError`` if
+    fewer than two distinct ids are given, or ``KeyError`` if any id is not
+    found in ``groups``.
+    """
+    ids = list(dict.fromkeys(group_ids))
+    if len(ids) < 2:
+        raise ValueError("merge_groups needs at least two distinct group ids")
+
+    by_id = {g.get("id"): g for g in groups}
+    missing = [gid for gid in ids if gid not in by_id]
+    if missing:
+        raise KeyError(f"Group(s) not found: {', '.join(missing)}")
+
+    # Keep whichever of the merged groups appears first in the input order.
+    keep = next(g for g in groups if g.get("id") in ids)
+    merging = [g for g in groups if g.get("id") in ids]
+
+    combined_members: list[dict] = []
+    for g in merging:
+        combined_members.extend(g.get("members", []))
+    merged_members = dedupe_members(combined_members)
+    merged_name = (canonical_name or "").strip() or keep.get("canonical_name", "")
+
+    merge_set = set(ids)
+    result = []
+    for g in groups:
+        gid = g.get("id")
+        if gid == keep.get("id"):
+            new_g = dict(g)
+            new_g["members"] = merged_members
+            new_g["canonical_name"] = merged_name
+            result.append(new_g)
+        elif gid in merge_set:
+            continue
+        else:
+            result.append(g)
+    return result

--- a/scripts/party_matching.py
+++ b/scripts/party_matching.py
@@ -120,10 +120,11 @@ def dedupe_members(members: list[dict]) -> list[dict]:
 def merge_groups(groups: list[dict], group_ids: list[str], canonical_name: str = "") -> list[dict]:
     """Merge the groups identified by ``group_ids`` into a single group.
 
-    The merged group keeps the id of whichever of ``group_ids`` appears first
-    in ``groups``; the rest are folded into it (members combined and
-    de-duplicated) and dropped. ``canonical_name``, if given, becomes the
-    merged group's display name; otherwise the kept group's own name is used.
+    The merged group keeps the id of ``group_ids[0]`` (the caller's own
+    ordering, not whatever order the groups happen to be stored in); the rest
+    are folded into it (members combined and de-duplicated) and dropped.
+    ``canonical_name``, if given, becomes the merged group's display name;
+    otherwise the kept group's own name is used.
 
     Returns a new list — ``groups`` is not mutated. Raises ``ValueError`` if
     fewer than two distinct ids are given, or ``KeyError`` if any id is not
@@ -138,9 +139,10 @@ def merge_groups(groups: list[dict], group_ids: list[str], canonical_name: str =
     if missing:
         raise KeyError(f"Group(s) not found: {', '.join(missing)}")
 
-    # Keep whichever of the merged groups appears first in the input order.
-    keep = next(g for g in groups if g.get("id") in ids)
-    merging = [g for g in groups if g.get("id") in ids]
+    keep_id = ids[0]
+    keep = by_id[keep_id]
+    merge_set = set(ids)
+    merging = [g for g in groups if g.get("id") in merge_set]
 
     combined_members: list[dict] = []
     for g in merging:
@@ -148,11 +150,10 @@ def merge_groups(groups: list[dict], group_ids: list[str], canonical_name: str =
     merged_members = dedupe_members(combined_members)
     merged_name = (canonical_name or "").strip() or keep.get("canonical_name", "")
 
-    merge_set = set(ids)
     result = []
     for g in groups:
         gid = g.get("id")
-        if gid == keep.get("id"):
+        if gid == keep_id:
             new_g = dict(g)
             new_g["members"] = merged_members
             new_g["canonical_name"] = merged_name

--- a/scripts/tests/test_related_parties.py
+++ b/scripts/tests/test_related_parties.py
@@ -139,6 +139,19 @@ def test_merge_groups_combines_members_and_dedupes():
     assert len(groups) == 3
 
 
+def test_merge_groups_keeps_first_requested_id_regardless_of_storage_order():
+    # "coles-2" is stored *before* "coles", but the caller asked to merge
+    # ["coles", "coles-2"] - the kept id must follow the caller's order, not
+    # whatever order the groups happen to be stored in.
+    groups = [
+        {"id": "coles-2", "canonical_name": "Coles Supermarkets", "members": [{"name": "B", "identifier": ""}]},
+        {"id": "coles", "canonical_name": "Coles Group", "members": [{"name": "A", "identifier": ""}]},
+    ]
+    merged = pm.merge_groups(groups, ["coles", "coles-2"])
+    assert [g["id"] for g in merged] == ["coles"]
+    assert merged[0]["canonical_name"] == "Coles Group"
+
+
 def test_merge_groups_accepts_custom_canonical_name():
     groups = [
         {"id": "a", "canonical_name": "A", "members": [{"name": "A Pty Ltd", "identifier": "1"}]},

--- a/scripts/tests/test_related_parties.py
+++ b/scripts/tests/test_related_parties.py
@@ -13,6 +13,8 @@ import os
 import sys
 import unittest.mock
 
+import pytest
+
 # Add scripts directory to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
@@ -88,6 +90,75 @@ def test_match_party_prefers_identifier_then_name():
     )["id"] == "coles"
     # No match
     assert pm.match_party({"name": "Woolworths", "identifier": ""}, by_id, by_name) is None
+
+
+def test_dedupe_members_drops_normalised_duplicates_keeping_first_display_form():
+    members = [
+        {"name": "COLES GROUP LIMITED", "identifier": "11 004 089 936"},
+        {"name": "Coles Group Limited", "identifier": "11004089936"},  # same, different casing/spacing
+        {"name": "COLES SUPERMARKETS AUSTRALIA PTY LTD", "identifier": ""},
+    ]
+    out = pm.dedupe_members(members)
+    assert out == [
+        {"name": "COLES GROUP LIMITED", "identifier": "11 004 089 936"},
+        {"name": "COLES SUPERMARKETS AUSTRALIA PTY LTD", "identifier": ""},
+    ]
+
+
+def test_merge_groups_combines_members_and_dedupes():
+    groups = [
+        {
+            "id": "coles",
+            "canonical_name": "Coles Group",
+            "members": [{"name": "COLES GROUP LIMITED", "identifier": "11 004 089 936"}],
+        },
+        {
+            "id": "coles-2",
+            "canonical_name": "Coles Supermarkets",
+            "members": [
+                {"name": "COLES SUPERMARKETS AUSTRALIA PTY LTD", "identifier": "45 004 189 708"},
+                {"name": "COLES GROUP LIMITED", "identifier": "11 004 089 936"},  # duplicate
+            ],
+        },
+        {
+            "id": "woolworths",
+            "canonical_name": "Woolworths Group",
+            "members": [{"name": "WOOLWORTHS GROUP LIMITED", "identifier": "88 000 014 675"}],
+        },
+    ]
+    merged = pm.merge_groups(groups, ["coles", "coles-2"])
+    ids = [g["id"] for g in merged]
+    assert ids == ["coles", "woolworths"]  # first-listed id kept, other dropped, rest untouched
+    kept = next(g for g in merged if g["id"] == "coles")
+    assert kept["canonical_name"] == "Coles Group"  # default: kept group's own name
+    assert kept["members"] == [
+        {"name": "COLES GROUP LIMITED", "identifier": "11 004 089 936"},
+        {"name": "COLES SUPERMARKETS AUSTRALIA PTY LTD", "identifier": "45 004 189 708"},
+    ]
+    # Original list is untouched.
+    assert len(groups) == 3
+
+
+def test_merge_groups_accepts_custom_canonical_name():
+    groups = [
+        {"id": "a", "canonical_name": "A", "members": [{"name": "A Pty Ltd", "identifier": "1"}]},
+        {"id": "b", "canonical_name": "B", "members": [{"name": "B Pty Ltd", "identifier": "2"}]},
+    ]
+    merged = pm.merge_groups(groups, ["a", "b"], canonical_name="A and B Combined")
+    assert len(merged) == 1
+    assert merged[0]["canonical_name"] == "A and B Combined"
+
+
+def test_merge_groups_requires_two_distinct_ids():
+    groups = [{"id": "a", "canonical_name": "A", "members": []}]
+    with pytest.raises(ValueError):
+        pm.merge_groups(groups, ["a"])
+
+
+def test_merge_groups_raises_on_unknown_id():
+    groups = [{"id": "a", "canonical_name": "A", "members": []}]
+    with pytest.raises(KeyError):
+        pm.merge_groups(groups, ["a", "missing"])
 
 
 # ---------------------------------------------------------------------------
@@ -294,6 +365,43 @@ def test_apply_suggestions_appends_groups(tmp_path):
     assert data["groups"][0]["id"] == "old-name-pty-ltd"
     # merger_count / merger_ids are stripped from the stored members
     assert data["groups"][0]["members"][0] == {"name": "Old Name Pty Ltd", "identifier": "12 345 678 901"}
+
+
+def test_find_group_merge_candidates_flags_groups_sharing_an_identifier():
+    groups = [
+        {
+            "id": "old-name",
+            "canonical_name": "Old Name",
+            "members": [{"name": "Old Name Pty Ltd", "identifier": "12 345 678 901"}],
+        },
+        {
+            "id": "new-name",
+            "canonical_name": "New Name",
+            "members": [{"name": "New Name Pty Ltd", "identifier": "12 345 678 901"}],
+        },
+    ]
+    candidates = drp.find_group_merge_candidates(groups, enable_fuzzy=False)
+    assert len(candidates) == 1
+    c = candidates[0]
+    assert c["group_ids"] == ["new-name", "old-name"]
+    assert c["signal"] == "identifier"
+    assert {g["canonical_name"] for g in c["groups"]} == {"Old Name", "New Name"}
+
+
+def test_find_group_merge_candidates_ignores_clusters_within_one_group():
+    groups = [{
+        "id": "coles",
+        "canonical_name": "Coles Group",
+        "members": [
+            {"name": "COLES GROUP LIMITED", "identifier": "11 004 089 936"},
+            {"name": "Coles Group Limited", "identifier": "11 004 089 936"},
+        ],
+    }]
+    assert drp.find_group_merge_candidates(groups, enable_fuzzy=False) == []
+
+
+def test_find_group_merge_candidates_no_groups_is_noop():
+    assert drp.find_group_merge_candidates([], enable_fuzzy=False) == []
 
 
 def test_generated_ids_are_unique():

--- a/scripts/tools/README.md
+++ b/scripts/tools/README.md
@@ -36,7 +36,11 @@ canonical *groups*. Reads every acquirer/target/other party across
 `data/processed/mergers.json`, shows which are already grouped and which are
 still ungrouped, and lets you select ungrouped parties to form a new group or
 fold into an existing one (plus rename/delete groups and remove members).
-Writes back to `data/processed/related_parties.json`.
+Both the ungrouped-party list and the canonical-groups list have their own
+search box (name, ABN, or group id). You can also select two or more
+canonical groups (checkbox on each card) and **merge** them into one — members
+are combined and de-duplicated, and you're prompted for the merged canonical
+name. Writes back to `data/processed/related_parties.json`.
 
 This is the hand-editing counterpart to `scripts/detect_related_parties.py`,
 which suggests new groups daily via a pull request. The grouping rules — how a
@@ -48,6 +52,23 @@ merger detail page links to the register filtered by the group's canonical name.
 python scripts/tools/related_parties.py
 # open http://127.0.0.1:8003
 ```
+
+To find *existing* canonical groups that look like the same entity and are
+candidates to merge (e.g. two groups recorded separately before anyone
+noticed they were the same company), run the detector in group-merge mode:
+
+```bash
+python scripts/detect_related_parties.py --group-merge-candidates
+```
+
+This clusters every member across all recorded groups using the same
+identifier/name/name-variant/fuzzy signals as the normal detector, and reports
+clusters that span more than one group id. As with the normal detector, the
+`fuzzy` signal is the weakest — it clusters merely similar names sharing a
+distinctive token, which can produce false positives (e.g. two unrelated
+companies that each have a subsidiary named "... Operations Pty Ltd"), so
+treat fuzzy hits as leads to check by hand in the tool, not groups to merge
+automatically.
 
 ## `advisors.py`
 

--- a/scripts/tools/related_parties.py
+++ b/scripts/tools/related_parties.py
@@ -38,7 +38,14 @@ from detect_related_parties import (
     _title_case_name,
     collect_party_records,
 )
-from party_matching import build_group_lookups, match_party, normalise_identifier, normalise_name
+from party_matching import (
+    build_group_lookups,
+    dedupe_members,
+    match_party,
+    merge_groups,
+    normalise_identifier,
+    normalise_name,
+)
 from slug import slugify
 
 app = FastAPI()
@@ -87,24 +94,6 @@ def _new_group_id(canonical_name: str, existing_ids: set[str]) -> str:
         slug = f"{base}-{n}"
         n += 1
     return slug
-
-
-def _dedupe_members(members: list[dict]) -> list[dict]:
-    """Drop exact duplicate (normalised name, normalised identifier) members,
-    keeping the first display form seen."""
-    seen: set[tuple[str, str]] = set()
-    out: list[dict] = []
-    for m in members:
-        name = (m.get("name") or "").strip()
-        identifier = (m.get("identifier") or "").strip()
-        if not name and not identifier:
-            continue
-        key = (normalise_name(name), normalise_identifier(identifier))
-        if key in seen:
-            continue
-        seen.add(key)
-        out.append({"name": name, "identifier": identifier})
-    return out
 
 
 # ---------------------------------------------------------------------------
@@ -194,6 +183,11 @@ class RemoveMember(BaseModel):
     index: int
 
 
+class MergeGroups(BaseModel):
+    group_ids: list[str]
+    canonical_name: str = ""
+
+
 # ---------------------------------------------------------------------------
 # API endpoints
 # ---------------------------------------------------------------------------
@@ -210,7 +204,7 @@ def get_state() -> dict:
 
 @app.post("/api/groups")
 def create_group(req: CreateGroup) -> dict:
-    members = _dedupe_members([m.model_dump() for m in req.members])
+    members = dedupe_members([m.model_dump() for m in req.members])
     if not members:
         raise HTTPException(status_code=400, detail="A group needs at least one member.")
 
@@ -237,7 +231,7 @@ def add_members(group_id: str, req: AddMembers) -> dict:
     doc = load_parties_doc()
     group = _find_group(doc, group_id)
     combined = list(group.get("members", [])) + [m.model_dump() for m in req.members]
-    group["members"] = _dedupe_members(combined)
+    group["members"] = dedupe_members(combined)
     save_parties_doc(doc)
     return {"status": "success", "group": group}
 
@@ -267,6 +261,20 @@ def remove_member(group_id: str, req: RemoveMember) -> dict:
         doc["groups"] = [g for g in doc["groups"] if g.get("id") != group_id]
     save_parties_doc(doc)
     return {"status": "success"}
+
+
+@app.post("/api/groups/merge")
+def merge_groups_endpoint(req: MergeGroups) -> dict:
+    if len(set(req.group_ids)) < 2:
+        raise HTTPException(status_code=400, detail="Select at least two different groups to merge.")
+    doc = load_parties_doc()
+    try:
+        doc["groups"] = merge_groups(doc["groups"], req.group_ids, req.canonical_name)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=exc.args[0])
+    save_parties_doc(doc)
+    kept_id = req.group_ids[0]
+    return {"status": "success", "group": _find_group(doc, kept_id)}
 
 
 @app.delete("/api/groups/{group_id}")
@@ -325,7 +333,16 @@ HTML_CONTENT = """
 
         <!-- Existing groups -->
         <div>
-            <h2 class="text-xl font-bold text-gray-900 mb-2 sticky top-0 bg-gray-50 pt-1 pb-3 z-10">Canonical groups</h2>
+            <div class="sticky top-0 bg-gray-50 pt-1 pb-3 z-10">
+                <h2 class="text-xl font-bold text-gray-900 mb-2">Canonical groups</h2>
+                <input id="group-search" oninput="renderGroups()" placeholder="Search canonical name, member or ABN..."
+                    class="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-accent" />
+                <div id="group-selection-bar" class="hidden mt-3 flex items-center gap-3 bg-brand text-white px-4 py-2 rounded">
+                    <span id="group-selection-count" class="text-sm font-medium"></span>
+                    <button onclick="mergeSelectedGroups()" class="text-sm bg-accent hover:bg-emerald-600 px-3 py-1.5 rounded font-medium transition-colors">Merge</button>
+                    <button onclick="clearGroupSelection()" class="text-sm bg-white/20 hover:bg-white/30 px-3 py-1.5 rounded transition-colors">Clear</button>
+                </div>
+            </div>
             <div id="groups" class="space-y-4"></div>
         </div>
     </div>
@@ -333,7 +350,8 @@ HTML_CONTENT = """
 
 <script>
 let STATE = { groups: [], ungrouped: [], merger_names: {}, counts: {} };
-const selected = new Map();   // key -> { name, identifier }
+const selected = new Map();       // key -> { name, identifier }
+const selectedGroups = new Map(); // group id -> canonical_name
 
 function partyKey(p) { return p.name + '\\u0000' + (p.identifier || ''); }
 function esc(s) { return (s == null ? '' : String(s)).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); }
@@ -349,10 +367,14 @@ async function load() {
     // Drop any selections that are no longer ungrouped (e.g. just got grouped).
     const valid = new Set(STATE.ungrouped.map(partyKey));
     for (const k of [...selected.keys()]) if (!valid.has(k)) selected.delete(k);
+    // Drop any group selections that no longer exist (e.g. just got merged).
+    const validGroups = new Set(STATE.groups.map(g => g.id));
+    for (const k of [...selectedGroups.keys()]) if (!validGroups.has(k)) selectedGroups.delete(k);
     renderStats();
     renderUngrouped();
     renderGroups();
     renderSelectionBar();
+    renderGroupSelectionBar();
 }
 
 function renderStats() {
@@ -455,19 +477,39 @@ function titleCase(s) {
     return s;
 }
 
+function groupMatches(g, q) {
+    if (!q) return true;
+    if (g.canonical_name.toLowerCase().includes(q)) return true;
+    if (g.id.toLowerCase().includes(q)) return true;
+    return g.members.some(m =>
+        m.name.toLowerCase().includes(q) || (m.identifier || '').toLowerCase().includes(q));
+}
+
 function renderGroups() {
     const container = document.getElementById('groups');
     if (STATE.groups.length === 0) {
         container.innerHTML = '<div class="p-4 bg-white rounded border border-gray-200 text-gray-400 text-sm">No groups yet. Select parties on the left to create one.</div>';
         return;
     }
-    container.innerHTML = STATE.groups.map(g => `
-        <div class="bg-white rounded-lg shadow-sm border-t-4 border-brand p-4">
+    const q = document.getElementById('group-search').value.trim().toLowerCase();
+    const list = STATE.groups.filter(g => groupMatches(g, q));
+    if (list.length === 0) {
+        container.innerHTML = '<div class="p-4 bg-white rounded border border-gray-200 text-gray-400 text-sm">No matching groups.</div>';
+        return;
+    }
+    container.innerHTML = list.map(g => {
+        const isSel = selectedGroups.has(g.id);
+        return `
+        <div class="bg-white rounded-lg shadow-sm border-t-4 ${isSel ? 'border-accent ring-1 ring-accent' : 'border-brand'} p-4">
             <div class="flex items-start justify-between gap-3 mb-3">
-                <div class="min-w-0">
-                    <div class="text-lg font-bold text-gray-900 break-words">${esc(g.canonical_name)}</div>
-                    <div class="text-xs text-gray-400 font-mono">${esc(g.id)} &middot; ${g.merger_count} merger${g.merger_count === 1 ? '' : 's'}</div>
-                </div>
+                <label class="flex items-start gap-2 min-w-0 cursor-pointer">
+                    <input type="checkbox" ${isSel ? 'checked' : ''} onchange="toggleGroupSelect(this, '${esc(g.id)}', ${JSON.stringify(g.canonical_name).replace(/"/g, '&quot;')})"
+                        class="mt-1.5 h-4 w-4 accent-brand shrink-0" />
+                    <div class="min-w-0">
+                        <div class="text-lg font-bold text-gray-900 break-words">${esc(g.canonical_name)}</div>
+                        <div class="text-xs text-gray-400 font-mono">${esc(g.id)} &middot; ${g.merger_count} merger${g.merger_count === 1 ? '' : 's'}</div>
+                    </div>
+                </label>
                 <div class="flex gap-2 shrink-0">
                     <button onclick="renameGroup('${esc(g.id)}', ${JSON.stringify(g.canonical_name).replace(/"/g, '&quot;')})"
                         class="text-xs bg-gray-100 hover:bg-gray-200 px-2 py-1 rounded transition-colors">Rename</button>
@@ -490,7 +532,38 @@ function renderGroups() {
                 class="w-full text-sm bg-brand/5 text-brand hover:bg-brand hover:text-white border border-brand/20 px-3 py-1.5 rounded font-medium transition-colors">
                 + Add selected party(s)
             </button>
-        </div>`).join('');
+        </div>`;
+    }).join('');
+}
+
+function toggleGroupSelect(cb, id, name) {
+    if (cb.checked) selectedGroups.set(id, name);
+    else selectedGroups.delete(id);
+    renderGroups();
+    renderGroupSelectionBar();
+}
+
+function clearGroupSelection() { selectedGroups.clear(); renderGroups(); renderGroupSelectionBar(); }
+
+function renderGroupSelectionBar() {
+    const bar = document.getElementById('group-selection-bar');
+    if (selectedGroups.size < 2) { bar.classList.add('hidden'); return; }
+    bar.classList.remove('hidden');
+    document.getElementById('group-selection-count').textContent =
+        `${selectedGroups.size} groups selected`;
+}
+
+async function mergeSelectedGroups() {
+    const ids = [...selectedGroups.keys()];
+    if (ids.length < 2) return;
+    const names = [...selectedGroups.values()];
+    const def = names[0];
+    const name = prompt(`Canonical name for the merged group of ${ids.length} (${names.join(', ')}):`, def);
+    if (name === null) return;
+    if (!confirm(`Merge ${ids.length} groups into "${name.trim() || def}"? This cannot be undone.`)) return;
+    await api('/api/groups/merge', 'POST', { group_ids: ids, canonical_name: name.trim() });
+    selectedGroups.clear();
+    await load();
 }
 
 async function renameGroup(id, current) {

--- a/scripts/tools/related_parties.py
+++ b/scripts/tools/related_parties.py
@@ -273,8 +273,7 @@ def merge_groups_endpoint(req: MergeGroups) -> dict:
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=exc.args[0])
     save_parties_doc(doc)
-    kept_id = req.group_ids[0]
-    return {"status": "success", "group": _find_group(doc, kept_id)}
+    return {"status": "success", "group": _find_group(doc, req.group_ids[0])}
 
 
 @app.delete("/api/groups/{group_id}")


### PR DESCRIPTION
- related_parties.py: search box for the canonical-groups panel (name/id/
  member/ABN), plus multi-select + merge on existing groups (combines and
  de-dupes members, prompts for the merged canonical name).
- party_matching.py: extract dedupe_members and add merge_groups, shared
  by the tool and testable independently of FastAPI.
- detect_related_parties.py: add find_group_merge_candidates, which
  clusters members across all recorded groups (same identifier/name/
  name_variant/fuzzy signals as the ungrouped-party detector) and flags
  clusters spanning more than one group id. Exposed via
  --group-merge-candidates.