### PR TITLE
Link Peter Warren - Wakeling Automotive refiling

### DIFF
--- a/data/output/mergers.json
+++ b/data/output/mergers.json
@@ -17451,6 +17451,11 @@
       "ceased_date": "2026-06-15T12:00:00Z",
       "competition_concerns_notice_date": "2026-07-08T12:00:00Z",
       "has_questionnaire": true,
+      "related_merger": {
+        "merger_id": "MN-90028",
+        "relationship": "suspended_refiled_as",
+        "merger_name": "Peter Warren - Wakeling Automotive"
+      },
       "similar_mergers": [
         {
           "merger_id": "MN-90006",
@@ -43872,44 +43877,12 @@
       "public_benefits_determination": null,
       "public_benefits_determination_date": null,
       "has_questionnaire": true,
+      "related_merger": {
+        "merger_id": "MN-30002",
+        "relationship": "suspended_refiled_from",
+        "merger_name": "Peter Warren - Wakeling Automotive"
+      },
       "similar_mergers": [
-        {
-          "merger_id": "MN-30002",
-          "merger_name": "Peter Warren - Wakeling Automotive",
-          "status": "Assessment ceased",
-          "accc_determination": null,
-          "acquirers": [
-            {
-              "name": "PETER WARREN AUTOMOTIVE HOLDINGS LIMITED",
-              "identifier_type": "ABN",
-              "identifier": "57 615 674 185",
-              "party_page": {
-                "id": "peter-warren-automotive-holdings-limited",
-                "name": "Peter Warren Automotive Holdings Limited"
-              }
-            }
-          ],
-          "targets": [
-            {
-              "name": "Paul Wakeling Motor Group Pty Ltd",
-              "identifier_type": "ABN",
-              "identifier": "47 119 908 780",
-              "party_page": {
-                "id": "paul-wakeling-motor-group-pty-ltd",
-                "name": "Paul Wakeling Motor Group Pty Ltd"
-              }
-            },
-            {
-              "name": "WOLLONGONG CITY MOTORS PTY LTD",
-              "identifier_type": "ABN",
-              "identifier": "22 002 019 598",
-              "party_page": {
-                "id": "wollongong-city-motors-pty-ltd",
-                "name": "Wollongong City Motors Pty Ltd"
-              }
-            }
-          ]
-        },
         {
           "merger_id": "WA-30010",
           "merger_name": "MAG South Coast - Country Motor Company / Kinghorn Motors",

--- a/data/processed/related_mergers.json
+++ b/data/processed/related_mergers.json
@@ -10,6 +10,7 @@
     { "from": "WA-10008", "to": "MN-40020", "type": "waiver_refiled" },
     { "from": "WA-25010", "to": "MN-80021", "type": "waiver_refiled" },
     { "from": "WA-85016", "to": "MN-40017", "type": "waiver_refiled" },
-    { "from": "WA-01094", "to": "MN-65023", "type": "waiver_refiled" }
+    { "from": "WA-01094", "to": "MN-65023", "type": "waiver_refiled" },
+    { "from": "MN-30002", "to": "MN-90028", "type": "suspended_refiled" }
   ]
 }

--- a/merger-tracker/frontend/public/data/mergers/MN-30002.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-30002.json
@@ -195,6 +195,11 @@
   "ceased_date": "2026-06-15T12:00:00Z",
   "competition_concerns_notice_date": "2026-07-08T12:00:00Z",
   "has_questionnaire": true,
+  "related_merger": {
+    "merger_id": "MN-90028",
+    "relationship": "suspended_refiled_as",
+    "merger_name": "Peter Warren - Wakeling Automotive"
+  },
   "similar_mergers": [
     {
       "merger_id": "MN-90006",

--- a/merger-tracker/frontend/public/data/mergers/MN-90028.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-90028.json
@@ -137,44 +137,12 @@
   "public_benefits_determination": null,
   "public_benefits_determination_date": null,
   "has_questionnaire": true,
+  "related_merger": {
+    "merger_id": "MN-30002",
+    "relationship": "suspended_refiled_from",
+    "merger_name": "Peter Warren - Wakeling Automotive"
+  },
   "similar_mergers": [
-    {
-      "merger_id": "MN-30002",
-      "merger_name": "Peter Warren - Wakeling Automotive",
-      "status": "Assessment ceased",
-      "accc_determination": null,
-      "acquirers": [
-        {
-          "name": "PETER WARREN AUTOMOTIVE HOLDINGS LIMITED",
-          "identifier_type": "ABN",
-          "identifier": "57 615 674 185",
-          "party_page": {
-            "id": "peter-warren-automotive-holdings-limited",
-            "name": "Peter Warren Automotive Holdings Limited"
-          }
-        }
-      ],
-      "targets": [
-        {
-          "name": "Paul Wakeling Motor Group Pty Ltd",
-          "identifier_type": "ABN",
-          "identifier": "47 119 908 780",
-          "party_page": {
-            "id": "paul-wakeling-motor-group-pty-ltd",
-            "name": "Paul Wakeling Motor Group Pty Ltd"
-          }
-        },
-        {
-          "name": "WOLLONGONG CITY MOTORS PTY LTD",
-          "identifier_type": "ABN",
-          "identifier": "22 002 019 598",
-          "party_page": {
-            "id": "wollongong-city-motors-pty-ltd",
-            "name": "Wollongong City Motors Pty Ltd"
-          }
-        }
-      ]
-    },
     {
       "merger_id": "WA-30010",
       "merger_name": "MAG South Coast - Country Motor Company / Kinghorn Motors",


### PR DESCRIPTION
MN-30002 (Phase 2, ceased 2026-06-16) was re-filed as MN-90028
(notified 2026-07-13, same acquirer/targets).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DdXNXT3LyjQDgtYoBFvzfY