### PR TITLE
Add a "Refiled" tag to recently notified mergers

### DIFF
--- a/data/output/cli/cli-bundle.json
+++ b/data/output/cli/cli-bundle.json
@@ -118616,7 +118616,8 @@
         "status": "Under assessment",
         "accc_determination": null,
         "effective_notification_datetime": "2026-07-13T12:00:00Z",
-        "is_waiver": false
+        "is_waiver": false,
+        "is_refiled": false
       },
       {
         "merger_id": "MN-90028",
@@ -118624,7 +118625,8 @@
         "status": "Under assessment",
         "accc_determination": null,
         "effective_notification_datetime": "2026-07-13T12:00:00Z",
-        "is_waiver": false
+        "is_waiver": false,
+        "is_refiled": true
       },
       {
         "merger_id": "MN-95025",
@@ -118632,7 +118634,8 @@
         "status": "Under assessment",
         "accc_determination": null,
         "effective_notification_datetime": "2026-07-13T12:00:00Z",
-        "is_waiver": false
+        "is_waiver": false,
+        "is_refiled": false
       },
       {
         "merger_id": "MN-01105",
@@ -118640,7 +118643,8 @@
         "status": "Under assessment",
         "accc_determination": null,
         "effective_notification_datetime": "2026-07-10T12:00:00Z",
-        "is_waiver": false
+        "is_waiver": false,
+        "is_refiled": false
       },
       {
         "merger_id": "MN-65023",
@@ -118648,7 +118652,8 @@
         "status": "Under assessment",
         "accc_determination": null,
         "effective_notification_datetime": "2026-07-10T12:00:00Z",
-        "is_waiver": false
+        "is_waiver": false,
+        "is_refiled": true
       },
       {
         "merger_id": "MN-95030",
@@ -118656,7 +118661,8 @@
         "status": "Under assessment",
         "accc_determination": null,
         "effective_notification_datetime": "2026-07-10T12:00:00Z",
-        "is_waiver": false
+        "is_waiver": false,
+        "is_refiled": false
       },
       {
         "merger_id": "MN-65028",
@@ -118664,7 +118670,8 @@
         "status": "Under assessment",
         "accc_determination": null,
         "effective_notification_datetime": "2026-07-09T12:00:00Z",
-        "is_waiver": false
+        "is_waiver": false,
+        "is_refiled": false
       },
       {
         "merger_id": "MN-05032",
@@ -118672,7 +118679,8 @@
         "status": "Under assessment",
         "accc_determination": null,
         "effective_notification_datetime": "2026-07-08T12:00:00Z",
-        "is_waiver": false
+        "is_waiver": false,
+        "is_refiled": false
       },
       {
         "merger_id": "MN-75029",
@@ -118680,7 +118688,8 @@
         "status": "Under assessment",
         "accc_determination": null,
         "effective_notification_datetime": "2026-07-08T12:00:00Z",
-        "is_waiver": false
+        "is_waiver": false,
+        "is_refiled": false
       },
       {
         "merger_id": "MN-30022",
@@ -118688,7 +118697,8 @@
         "status": "Under assessment",
         "accc_determination": null,
         "effective_notification_datetime": "2026-07-06T12:00:00Z",
-        "is_waiver": false
+        "is_waiver": false,
+        "is_refiled": false
       },
       {
         "merger_id": "MN-15027",
@@ -118696,7 +118706,8 @@
         "status": "Under assessment",
         "accc_determination": null,
         "effective_notification_datetime": "2026-07-03T12:00:00Z",
-        "is_waiver": false
+        "is_waiver": false,
+        "is_refiled": false
       },
       {
         "merger_id": "MN-80024",
@@ -118704,7 +118715,8 @@
         "status": "Under assessment",
         "accc_determination": null,
         "effective_notification_datetime": "2026-07-03T12:00:00Z",
-        "is_waiver": false
+        "is_waiver": false,
+        "is_refiled": false
       }
     ],
     "recent_determinations": [

--- a/data/output/cli/cli-manifest.json
+++ b/data/output/cli/cli-manifest.json
@@ -1,7 +1,7 @@
 {
-  "version": 462,
-  "generated_at": "2026-07-14T11:55:21Z",
+  "version": 463,
+  "generated_at": "2026-07-14T23:56:32Z",
   "merger_count": 442,
-  "bundle_sha256": "b3bf657e5c08fac68bb6229a5aa1dbc3197d97efba5cc815bf8eb98cc1ef1b4e",
+  "bundle_sha256": "9b86ad0c9257ec9ed2451ac75ba99025acc4d1f873d273edc7ff66ea3efb3e6a",
   "merger_manifest_sha256": "3417a442cb06b1c1ace54fc4e620b1549ad0df157d44640b8a4ffd10f720f23e"
 }

--- a/merger-tracker/frontend/public/data/phase2.json
+++ b/merger-tracker/frontend/public/data/phase2.json
@@ -9,7 +9,8 @@
       "end_of_determination_period": "2026-08-17T12:00:00Z",
       "determination": null,
       "determination_date": null,
-      "phase_2_inferred": false
+      "phase_2_inferred": false,
+      "is_refiled": false
     },
     {
       "merger_id": "MN-65005",
@@ -20,7 +21,8 @@
       "end_of_determination_period": "2026-09-23T12:00:00Z",
       "determination": null,
       "determination_date": null,
-      "phase_2_inferred": false
+      "phase_2_inferred": false,
+      "is_refiled": false
     },
     {
       "merger_id": "MN-01072",
@@ -31,7 +33,8 @@
       "end_of_determination_period": "2026-11-10T12:00:00Z",
       "determination": null,
       "determination_date": null,
-      "phase_2_inferred": false
+      "phase_2_inferred": false,
+      "is_refiled": false
     }
   ],
   "completed": [
@@ -44,7 +47,8 @@
       "end_of_determination_period": "2026-11-06T12:00:00Z",
       "determination": "Assessment ceased",
       "determination_date": "2026-07-10T12:00:00Z",
-      "phase_2_inferred": false
+      "phase_2_inferred": false,
+      "is_refiled": false
     },
     {
       "merger_id": "MN-01068",
@@ -55,7 +59,8 @@
       "end_of_determination_period": "2026-07-02T12:00:00Z",
       "determination": "Not approved",
       "determination_date": "2026-07-01T12:00:00Z",
-      "phase_2_inferred": false
+      "phase_2_inferred": false,
+      "is_refiled": false
     },
     {
       "merger_id": "MN-30002",
@@ -66,7 +71,8 @@
       "end_of_determination_period": "2026-10-08T12:00:00Z",
       "determination": "Assessment ceased",
       "determination_date": "2026-06-15T12:00:00Z",
-      "phase_2_inferred": false
+      "phase_2_inferred": false,
+      "is_refiled": true
     },
     {
       "merger_id": "MN-01019",
@@ -77,7 +83,8 @@
       "end_of_determination_period": "2026-06-05T12:00:00Z",
       "determination": "Approved",
       "determination_date": "2026-06-02T12:00:00Z",
-      "phase_2_inferred": false
+      "phase_2_inferred": false,
+      "is_refiled": false
     }
   ],
   "count": {

--- a/merger-tracker/frontend/public/data/stats.json
+++ b/merger-tracker/frontend/public/data/stats.json
@@ -90,7 +90,8 @@
       "status": "Under assessment",
       "accc_determination": null,
       "effective_notification_datetime": "2026-07-13T12:00:00Z",
-      "is_waiver": false
+      "is_waiver": false,
+      "is_refiled": false
     },
     {
       "merger_id": "MN-90028",
@@ -98,7 +99,8 @@
       "status": "Under assessment",
       "accc_determination": null,
       "effective_notification_datetime": "2026-07-13T12:00:00Z",
-      "is_waiver": false
+      "is_waiver": false,
+      "is_refiled": true
     },
     {
       "merger_id": "MN-95025",
@@ -106,7 +108,8 @@
       "status": "Under assessment",
       "accc_determination": null,
       "effective_notification_datetime": "2026-07-13T12:00:00Z",
-      "is_waiver": false
+      "is_waiver": false,
+      "is_refiled": false
     },
     {
       "merger_id": "MN-01105",
@@ -114,7 +117,8 @@
       "status": "Under assessment",
       "accc_determination": null,
       "effective_notification_datetime": "2026-07-10T12:00:00Z",
-      "is_waiver": false
+      "is_waiver": false,
+      "is_refiled": false
     },
     {
       "merger_id": "MN-65023",
@@ -122,7 +126,8 @@
       "status": "Under assessment",
       "accc_determination": null,
       "effective_notification_datetime": "2026-07-10T12:00:00Z",
-      "is_waiver": false
+      "is_waiver": false,
+      "is_refiled": true
     },
     {
       "merger_id": "MN-95030",
@@ -130,7 +135,8 @@
       "status": "Under assessment",
       "accc_determination": null,
       "effective_notification_datetime": "2026-07-10T12:00:00Z",
-      "is_waiver": false
+      "is_waiver": false,
+      "is_refiled": false
     },
     {
       "merger_id": "MN-65028",
@@ -138,7 +144,8 @@
       "status": "Under assessment",
       "accc_determination": null,
       "effective_notification_datetime": "2026-07-09T12:00:00Z",
-      "is_waiver": false
+      "is_waiver": false,
+      "is_refiled": false
     },
     {
       "merger_id": "MN-05032",
@@ -146,7 +153,8 @@
       "status": "Under assessment",
       "accc_determination": null,
       "effective_notification_datetime": "2026-07-08T12:00:00Z",
-      "is_waiver": false
+      "is_waiver": false,
+      "is_refiled": false
     },
     {
       "merger_id": "MN-75029",
@@ -154,7 +162,8 @@
       "status": "Under assessment",
       "accc_determination": null,
       "effective_notification_datetime": "2026-07-08T12:00:00Z",
-      "is_waiver": false
+      "is_waiver": false,
+      "is_refiled": false
     },
     {
       "merger_id": "MN-30022",
@@ -162,7 +171,8 @@
       "status": "Under assessment",
       "accc_determination": null,
       "effective_notification_datetime": "2026-07-06T12:00:00Z",
-      "is_waiver": false
+      "is_waiver": false,
+      "is_refiled": false
     },
     {
       "merger_id": "MN-15027",
@@ -170,7 +180,8 @@
       "status": "Under assessment",
       "accc_determination": null,
       "effective_notification_datetime": "2026-07-03T12:00:00Z",
-      "is_waiver": false
+      "is_waiver": false,
+      "is_refiled": false
     },
     {
       "merger_id": "MN-80024",
@@ -178,7 +189,8 @@
       "status": "Under assessment",
       "accc_determination": null,
       "effective_notification_datetime": "2026-07-03T12:00:00Z",
-      "is_waiver": false
+      "is_waiver": false,
+      "is_refiled": false
     }
   ],
   "recent_determinations": [

--- a/merger-tracker/frontend/public/data/upcoming-events.json
+++ b/merger-tracker/frontend/public/data/upcoming-events.json
@@ -3,16 +3,6 @@
     {
       "type": "consultation_due",
       "event_type_display": "Consultation responses due",
-      "date": "2026-07-14T12:00:00Z",
-      "merger_id": "MN-30022",
-      "merger_name": "VSA - SprayLine",
-      "status": "Under assessment",
-      "stage": "Phase 1 - initial assessment",
-      "effective_notification_datetime": "2026-07-06T12:00:00Z"
-    },
-    {
-      "type": "consultation_due",
-      "event_type_display": "Consultation responses due",
       "date": "2026-07-16T12:00:00Z",
       "merger_id": "MN-05032",
       "merger_name": "Motorola Solutions - D-Fend Solutions",
@@ -511,6 +501,6 @@
       "effective_notification_datetime": "2026-07-13T12:00:00Z"
     }
   ],
-  "count": 51,
+  "count": 50,
   "days_ahead": 60
 }

--- a/merger-tracker/frontend/src/components/Phase2CompletedCards.jsx
+++ b/merger-tracker/frontend/src/components/Phase2CompletedCards.jsx
@@ -2,7 +2,7 @@ import { calculateDuration } from '../utils/dates';
 import { DETERMINATION_LABELS } from '../constants/mergerStatus';
 import { getCardStyle } from '../constants/cardStyles';
 import CardCollapseGrid from './CardCollapseGrid';
-import MergerCardBody from './MergerCardBody';
+import MergerCardBody, { CHIP_BASE_CLASS } from './MergerCardBody';
 
 // Solid, determination-coloured cards for completed Phase 2 matters — echoing
 // the dashboard card grids. Each card surfaces just the outcome and the time
@@ -28,6 +28,11 @@ function Phase2CompletedCards({ matters }) {
                 <span aria-hidden="true">·</span>
                 <span className="tabular-nums">{duration} days in Phase 2</span>
               </>
+            )}
+            {item.is_refiled && (
+              <span className={`${CHIP_BASE_CLASS} font-medium ${style.chip}`}>
+                Refiled
+              </span>
             )}
           </MergerCardBody>
         );

--- a/merger-tracker/frontend/src/components/RecentMergersCards.jsx
+++ b/merger-tracker/frontend/src/components/RecentMergersCards.jsx
@@ -71,6 +71,11 @@ function RecentMergersCards({ mergers }) {
                 Waiver
               </span>
             )}
+            {merger.is_refiled && (
+              <span className={`${CHIP_BASE_CLASS} font-medium ${style.chip}`}>
+                Refiled
+              </span>
+            )}
           </MergerCardBody>
         )}
       />

--- a/scripts/static_data/loaders.py
+++ b/scripts/static_data/loaders.py
@@ -38,6 +38,16 @@ _RELATIONSHIP_LABELS = {
 }
 
 
+# Relationship values where the merger is the *earlier* matter that was later
+# re-filed as another (the source side of a pair) — flags the original matter,
+# e.g. a ceased Phase 2 assessment that was subsequently re-filed.
+FORWARD_REFILE_RELATIONSHIPS = frozenset(source for source, _ in _RELATIONSHIP_LABELS.values())
+
+# Relationship values where the merger is the *later*, re-filed matter (the
+# target side of a pair) — flags a notification as itself being a re-file.
+BACKWARD_REFILE_RELATIONSHIPS = frozenset(target for _, target in _RELATIONSHIP_LABELS.values())
+
+
 def build_relationship_map(data: dict) -> dict:
     """Turn related-merger ``pairs`` into a per-merger relationship lookup.
 

--- a/scripts/static_data/outputs/phase2.py
+++ b/scripts/static_data/outputs/phase2.py
@@ -10,6 +10,7 @@ from constants import merger_status
 
 from ..enrichment import is_phase_2_referral_event
 from ..filters import filter_notifications
+from ..loaders import FORWARD_REFILE_RELATIONSHIPS
 
 
 def _referral_date(merger: dict) -> str | None:
@@ -54,6 +55,10 @@ def _entry(merger: dict) -> dict:
         'determination': determination,
         'determination_date': determination_date,
         'phase_2_inferred': bool(merger.get('phase_2_inferred')),
+        # True for a matter (typically a ceased assessment) later re-filed as
+        # a separate notification — the opposite direction to stats.py's
+        # "recent mergers" is_refiled flag, which marks the re-filed matter.
+        'is_refiled': (merger.get('related_merger') or {}).get('relationship') in FORWARD_REFILE_RELATIONSHIPS,
     }
 
 

--- a/scripts/static_data/outputs/stats.py
+++ b/scripts/static_data/outputs/stats.py
@@ -8,11 +8,7 @@ from constants import merger_status
 from ..durations import collect_phase_1_durations, collect_waiver_durations
 from ..enrichment import is_phase_2_referral_event
 from ..filters import filter_notifications, filter_waivers
-
-# Relationship values (see static_data/loaders.py) where the current merger is
-# the later, re-filed matter — i.e. it's worth flagging as a re-file to a
-# reader browsing recently notified mergers.
-REFILED_RELATIONSHIPS = {'refiled_from', 'suspended_refiled_from'}
+from ..loaders import BACKWARD_REFILE_RELATIONSHIPS
 
 
 def generate(mergers: list) -> dict:
@@ -107,7 +103,7 @@ def generate(mergers: list) -> dict:
             "accc_determination": m.get('accc_determination'),
             "effective_notification_datetime": m.get('effective_notification_datetime'),
             "is_waiver": m.get('is_waiver', False),
-            "is_refiled": (m.get('related_merger') or {}).get('relationship') in REFILED_RELATIONSHIPS,
+            "is_refiled": (m.get('related_merger') or {}).get('relationship') in BACKWARD_REFILE_RELATIONSHIPS,
         }
         for m in sorted_mergers[:12]
     ]

--- a/scripts/static_data/outputs/stats.py
+++ b/scripts/static_data/outputs/stats.py
@@ -9,6 +9,11 @@ from ..durations import collect_phase_1_durations, collect_waiver_durations
 from ..enrichment import is_phase_2_referral_event
 from ..filters import filter_notifications, filter_waivers
 
+# Relationship values (see static_data/loaders.py) where the current merger is
+# the later, re-filed matter — i.e. it's worth flagging as a re-file to a
+# reader browsing recently notified mergers.
+REFILED_RELATIONSHIPS = {'refiled_from', 'suspended_refiled_from'}
+
 
 def generate(mergers: list) -> dict:
     """Return the stats.json payload for pre-enriched mergers."""
@@ -102,6 +107,7 @@ def generate(mergers: list) -> dict:
             "accc_determination": m.get('accc_determination'),
             "effective_notification_datetime": m.get('effective_notification_datetime'),
             "is_waiver": m.get('is_waiver', False),
+            "is_refiled": (m.get('related_merger') or {}).get('relationship') in REFILED_RELATIONSHIPS,
         }
         for m in sorted_mergers[:12]
     ]

--- a/scripts/tests/test_phase2.py
+++ b/scripts/tests/test_phase2.py
@@ -108,7 +108,7 @@ class TestReturnsValidShape:
         assert set(entry.keys()) == {
             'merger_id', 'merger_name', 'referral_date', 'nocc_date', 'nocc_issued',
             'end_of_determination_period', 'determination', 'determination_date',
-            'phase_2_inferred',
+            'phase_2_inferred', 'is_refiled',
         }
 
 
@@ -151,6 +151,26 @@ class TestCurrentVsCompleted:
         entry = payload['completed'][0]
         assert entry['determination'] == 'Assessment ceased'
         assert entry['determination_date'] == '2026-06-15T12:00:00Z'
+        assert entry['is_refiled'] is False
+
+    def test_ceased_phase2_matter_later_refiled_is_flagged(self):
+        # Mirrors MN-30002 (Peter Warren - Wakeling Automotive): a ceased
+        # Phase 2 assessment later re-filed as a separate notification.
+        ceased = _ceased_phase2('MN-30002')
+        ceased['related_merger'] = {
+            'merger_id': 'MN-90028',
+            'relationship': 'suspended_refiled_as',
+            'merger_name': 'Peter Warren - Wakeling Automotive',
+        }
+        mergers = [enrich_merger(ceased)]
+        payload = phase2.generate(mergers)
+        entry = payload['completed'][0]
+        assert entry['is_refiled'] is True
+
+    def test_completed_phase2_matter_not_refiled(self):
+        mergers = [enrich_merger(_completed_phase2('MN-0002'))]
+        payload = phase2.generate(mergers)
+        assert payload['completed'][0]['is_refiled'] is False
 
 
 class TestNoccFallsBackToComputedDueDate:

--- a/scripts/tests/test_static_data_outputs.py
+++ b/scripts/tests/test_static_data_outputs.py
@@ -163,6 +163,19 @@ class TestStatsGenerate:
         mining = next(i for i in payload['top_industries'] if i['name'] == 'Mining')
         assert mining['count'] == 2
 
+    def test_recent_mergers_flags_refiled_notifications(self):
+        mergers = _raw_fixture()
+        mergers[1]['related_merger'] = {
+            'merger_id': 'WA-0003',
+            'relationship': 'refiled_from',
+            'merger_name': 'Epsilon waiver',
+        }
+        enriched = [enrich_merger(m) for m in mergers]
+        payload = stats.generate(enriched)
+        by_id = {m['merger_id']: m for m in payload['recent_mergers']}
+        assert by_id['MN-0002']['is_refiled'] is True
+        assert by_id['MN-0001']['is_refiled'] is False
+
     def test_recent_determinations_includes_ceased_assessments(self):
         mergers = _raw_fixture()
         mergers.append({


### PR DESCRIPTION
stats.json's recent_mergers entries now carry is_refiled, true when the
merger's related_merger relationship shows it's a later re-filing (a
declined waiver re-filed as a notification, or a suspended matter
re-filed). The dashboard's "Recently notified mergers" cards surface
this as a chip alongside the existing "Waiver" chip.