### PR TITLE
Add clearance rate and Phase 1 duration comparison to refiled notifications page

### DIFF
--- a/merger-tracker/frontend/public/data/refiled-notifications.json
+++ b/merger-tracker/frontend/public/data/refiled-notifications.json
@@ -126,5 +126,25 @@
   "count": {
     "current": 3,
     "completed": 7
+  },
+  "clearance_rate": {
+    "cleared": 7,
+    "not_cleared": 0,
+    "total": 7,
+    "rate": 1.0
+  },
+  "phase_duration": {
+    "average_days": 27.857142857142858,
+    "median_days": 26,
+    "average_business_days": 18.428571428571427,
+    "median_business_days": 17,
+    "completed_count": 7
+  },
+  "straight_phase_duration": {
+    "average_days": 29.703125,
+    "median_days": 26,
+    "average_business_days": 19.4296875,
+    "median_business_days": 17,
+    "completed_count": 128
   }
 }

--- a/merger-tracker/frontend/public/data/stats.json
+++ b/merger-tracker/frontend/public/data/stats.json
@@ -15,6 +15,12 @@
     "Approved": 253,
     "Not approved": 14
   },
+  "clearance_rate": {
+    "cleared": 129,
+    "not_cleared": 1,
+    "total": 130,
+    "rate": 0.992
+  },
   "phase_duration": {
     "average_days": 29.607407407407408,
     "median_days": 26,

--- a/merger-tracker/frontend/src/pages/RefiledNotifications.jsx
+++ b/merger-tracker/frontend/src/pages/RefiledNotifications.jsx
@@ -1,10 +1,11 @@
 import { Link } from 'react-router-dom';
 import { differenceInCalendarDays, parseISO, isValid } from 'date-fns';
-import { FaArrowRightArrowLeft, FaHourglassHalf, FaCalendarDays } from 'react-icons/fa6';
+import { FaArrowRightArrowLeft, FaHourglassHalf, FaCalendarDays, FaCircleCheck } from 'react-icons/fa6';
 import LoadingSpinner from '../components/LoadingSpinner';
 import ErrorMessage from '../components/ErrorMessage';
 import StatusBadge from '../components/StatusBadge';
 import StatCard from '../components/StatCard';
+import PhaseDurationComparison from '../components/PhaseDurationComparison';
 import SEO from '../components/SEO';
 import { API_ENDPOINTS } from '../config';
 import { useFetchData } from '../hooks/useFetchData';
@@ -163,6 +164,13 @@ function RefiledList({ pairs, showOutcome, emptyMessage }) {
 function RefiledNotifications() {
   const { data, loading, error } = useFetchData(API_ENDPOINTS.refiledNotifications, { cacheKey: 'refiled-notifications' });
 
+  // Overall Phase 1 clearance rate, for comparing refiled notifications
+  // against the market as a whole. Non-fatal if it fails to load.
+  const { data: statsData } = useFetchData(
+    data ? API_ENDPOINTS.stats : null,
+    data ? { cacheKey: 'dashboard-stats' } : {}
+  );
+
   if (loading) return <LoadingSpinner />;
   if (error) return <ErrorMessage error={error} />;
 
@@ -175,6 +183,16 @@ function RefiledNotifications() {
       .map((p) => calculateDuration(p.waiver_declined_date, p.notification_filed_date))
       .filter((d) => d !== null)
   );
+
+  const clearanceRate = data?.clearance_rate;
+  const overallClearanceRate = statsData?.clearance_rate;
+  const clearancePct = clearanceRate?.rate != null ? Math.round(clearanceRate.rate * 100) : null;
+  const overallClearancePct = overallClearanceRate?.rate != null
+    ? Math.round(overallClearanceRate.rate * 100)
+    : null;
+
+  const phaseDuration = data?.phase_duration;
+  const straightPhaseDuration = data?.straight_phase_duration;
 
   return (
     <>
@@ -190,16 +208,37 @@ function RefiledNotifications() {
           </h1>
         </header>
 
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
           <StatCard title="Waivers re-filed" value={totalPairs} icon={<FaArrowRightArrowLeft />} />
           <StatCard title="Awaiting a determination" value={current.length} icon={<FaHourglassHalf />} />
           <StatCard
             title="Median time to re-file"
             value={medianDaysToRefile !== null ? `${medianDaysToRefile} days` : 'N/A'}
-            subtitle="From waiver decline to re-filing"
             icon={<FaCalendarDays />}
           />
+          <StatCard
+            title="Clearance rate"
+            value={clearancePct !== null ? `${clearancePct}%` : 'N/A'}
+            subtitle={
+              clearancePct !== null && overallClearancePct !== null
+                ? `${overallClearancePct}% for Phase 1 reviews overall`
+                : undefined
+            }
+            icon={<FaCircleCheck />}
+          />
         </div>
+
+        {phaseDuration && (
+          <div className="mb-8">
+            <PhaseDurationComparison
+              duration={phaseDuration}
+              comparisons={
+                straightPhaseDuration ? [{ name: 'Filed as Phase 1 from the outset', duration: straightPhaseDuration }] : []
+              }
+              subjectLabel="Refiled from a waiver"
+            />
+          </div>
+        )}
 
         <section aria-labelledby="refiled-current-heading" className="mb-8">
           <h2 id="refiled-current-heading" className="text-lg font-semibold text-gray-900 mb-4">

--- a/scripts/static_data/outputs/refiled.py
+++ b/scripts/static_data/outputs/refiled.py
@@ -7,6 +7,17 @@ recorded in ``related_mergers.json``. Companion view to the Phase 2 tracker
 ``related_merger`` to each merger (see :func:`static_data.enrichment`).
 """
 
+from constants import merger_status
+
+from ..durations import collect_phase_1_durations
+from ..filters import filter_notifications
+
+#: Determinations that count as the merger being allowed to proceed, mirroring
+#: the cleared/declined split used elsewhere (e.g. OUTCOME_DOT_COLORS on the
+#: frontend, deals_cleared in the weekly digest).
+CLEARED_DETERMINATIONS = {merger_status.APPROVED, merger_status.NOT_OPPOSED}
+NOT_CLEARED_DETERMINATIONS = {merger_status.NOT_APPROVED, merger_status.DECLINED}
+
 
 def _entry(waiver: dict, notification: dict) -> dict:
     return {
@@ -23,16 +34,66 @@ def _entry(waiver: dict, notification: dict) -> dict:
     }
 
 
+def _clearance_rate(completed: list) -> dict:
+    """Cleared-vs-blocked split for completed refiled notifications.
+
+    Only counts determinations recognised as cleared or not cleared (see
+    :data:`CLEARED_DETERMINATIONS`), so a stray value can't silently distort
+    the rate.
+    """
+    cleared = sum(1 for e in completed if e['notification_determination'] in CLEARED_DETERMINATIONS)
+    not_cleared = sum(1 for e in completed if e['notification_determination'] in NOT_CLEARED_DETERMINATIONS)
+    total = cleared + not_cleared
+    return {
+        'cleared': cleared,
+        'not_cleared': not_cleared,
+        'total': total,
+        'rate': round(cleared / total, 3) if total else None,
+    }
+
+
+def _phase_duration(unique_mergers: list) -> dict | None:
+    """Phase 1 duration stats for a set of notification mergers.
+
+    Mirrors :func:`static_data.outputs.industries._phase_duration`. Measures
+    notification → Phase 1 end (referral date for matters sent to Phase 2, so
+    the Phase 2 clock never inflates the figures). Returns ``None`` when
+    there are no completed Phase 1 reviews in the set.
+    """
+    durations, business_durations = collect_phase_1_durations(unique_mergers)
+
+    if not durations and not business_durations:
+        return None
+
+    def _avg(values):
+        return sum(values) / len(values) if values else None
+
+    def _median(values):
+        return sorted(values)[len(values) // 2] if values else None
+
+    return {
+        "average_days": _avg(durations),
+        "median_days": _median(durations),
+        "average_business_days": _avg(business_durations),
+        "median_business_days": _median(business_durations),
+        "completed_count": len(business_durations),
+    }
+
+
 def generate(mergers: list) -> dict:
     """Return the refiled-notifications.json payload.
 
     ``current`` holds pairs whose notification hasn't been determined yet;
     ``completed`` holds pairs where the notification has a determination.
+    ``phase_duration`` / ``straight_phase_duration`` let the page compare how
+    long completed refiled notifications took in Phase 1 against notifications
+    that were filed as a Phase 1 review from the outset (i.e. everything else).
     """
     by_id = {m.get('merger_id'): m for m in mergers if m.get('merger_id')}
 
     current = []
     completed = []
+    completed_notifications = []
     for merger in mergers:
         related = merger.get('related_merger')
         if not related or related.get('relationship') != 'refiled_as':
@@ -43,6 +104,7 @@ def generate(mergers: list) -> dict:
         entry = _entry(merger, notification)
         if entry['notification_determination'] and entry['notification_determination_date']:
             completed.append(entry)
+            completed_notifications.append(notification)
         else:
             current.append(entry)
 
@@ -51,8 +113,16 @@ def generate(mergers: list) -> dict:
     # Completed: most recently determined first.
     completed.sort(key=lambda e: e['notification_determination_date'] or '', reverse=True)
 
+    refiled_ids = {e['notification_id'] for e in current} | {e['notification_id'] for e in completed}
+    straight_notifications = [
+        m for m in filter_notifications(mergers) if m.get('merger_id') not in refiled_ids
+    ]
+
     return {
         'current': current,
         'completed': completed,
         'count': {'current': len(current), 'completed': len(completed)},
+        'clearance_rate': _clearance_rate(completed),
+        'phase_duration': _phase_duration(completed_notifications),
+        'straight_phase_duration': _phase_duration(straight_notifications),
     }

--- a/scripts/static_data/outputs/stats.py
+++ b/scripts/static_data/outputs/stats.py
@@ -42,6 +42,29 @@ def generate(mergers: list) -> dict:
         if det:
             by_waiver_determination[det] += 1
 
+    # Clearance rate: share of notifications with a published final
+    # determination that were cleared (Approved / Not opposed) rather than
+    # blocked (Not approved / Declined). Still-open matters are excluded from
+    # both the numerator and denominator; determinations reached after a
+    # Phase 2 referral are included once published, since accc_determination
+    # holds the merger's final outcome regardless of which phase concluded it.
+    cleared = not_cleared = 0
+    for m in notification_mergers:
+        det = m.get('accc_determination')
+        if not (det and m.get('determination_publication_date')):
+            continue
+        if det in (merger_status.APPROVED, merger_status.NOT_OPPOSED):
+            cleared += 1
+        elif det in (merger_status.NOT_APPROVED, merger_status.DECLINED):
+            not_cleared += 1
+    clearance_total = cleared + not_cleared
+    clearance_rate_data = {
+        "cleared": cleared,
+        "not_cleared": not_cleared,
+        "total": clearance_total,
+        "rate": round(cleared / clearance_total, 3) if clearance_total else None,
+    }
+
     # Phase 1 durations (notifications only). Matters referred to Phase 2 are
     # measured to the referral date, not the later Phase 2 determination, so the
     # Phase 2 clock never inflates the Phase 1 figures.
@@ -196,6 +219,7 @@ def generate(mergers: list) -> dict:
         "by_status": dict(by_status),
         "by_determination": dict(by_determination),
         "by_waiver_determination": dict(by_waiver_determination),
+        "clearance_rate": clearance_rate_data,
         "phase_duration": phase_duration_data,
         "waiver_duration": waiver_duration_data,
         "top_industries": top_industries,

--- a/scripts/tests/test_refiled.py
+++ b/scripts/tests/test_refiled.py
@@ -59,7 +59,14 @@ class TestReturnsValidShape:
     def test_empty_input(self):
         payload = refiled.generate([])
         json.dumps(payload)
-        assert payload == {'current': [], 'completed': [], 'count': {'current': 0, 'completed': 0}}
+        assert payload == {
+            'current': [],
+            'completed': [],
+            'count': {'current': 0, 'completed': 0},
+            'clearance_rate': {'cleared': 0, 'not_cleared': 0, 'total': 0, 'rate': None},
+            'phase_duration': None,
+            'straight_phase_duration': None,
+        }
 
     def test_shape(self):
         mergers = [_waiver(), _current_notification()]
@@ -112,6 +119,52 @@ class TestCurrentVsCompleted:
         mergers = [_waiver(notification_id='MN-9999')]
         payload = refiled.generate(mergers)
         assert payload['count'] == {'current': 0, 'completed': 0}
+
+
+class TestClearanceRate:
+    def test_no_completed_pairs(self):
+        payload = refiled.generate([_waiver(), _current_notification()])
+        assert payload['clearance_rate'] == {'cleared': 0, 'not_cleared': 0, 'total': 0, 'rate': None}
+
+    def test_mixed_outcomes(self):
+        mergers = [
+            _waiver(merger_id='WA-0001', notification_id='MN-0001'),
+            _completed_notification(merger_id='MN-0001', waiver_id='WA-0001', determination='Approved'),
+            _waiver(merger_id='WA-0002', notification_id='MN-0002'),
+            _completed_notification(merger_id='MN-0002', waiver_id='WA-0002', determination='Not opposed'),
+            _waiver(merger_id='WA-0003', notification_id='MN-0003'),
+            _completed_notification(merger_id='MN-0003', waiver_id='WA-0003', determination='Declined'),
+        ]
+        payload = refiled.generate(mergers)
+        assert payload['clearance_rate'] == {'cleared': 2, 'not_cleared': 1, 'total': 3, 'rate': round(2 / 3, 3)}
+
+
+class TestPhaseDuration:
+    def test_refiled_and_straight_durations_are_kept_separate(self):
+        refiled_notification = _completed_notification(merger_id='MN-0002', waiver_id='WA-0002')
+        refiled_notification['phase_1_determination_date'] = '2025-04-15T09:00:00Z'
+        straight_notification = {
+            'merger_id': 'MN-9000',
+            'merger_name': 'Straight notification',
+            'status': 'Assessment completed',
+            'accc_determination': 'Approved',
+            'effective_notification_datetime': '2025-01-01T09:00:00Z',
+            'phase_1_determination_date': '2025-01-20T09:00:00Z',
+            'determination_publication_date': '2025-01-20T09:00:00Z',
+        }
+        mergers = [
+            _waiver(merger_id='WA-0002', notification_id='MN-0002'),
+            refiled_notification,
+            straight_notification,
+        ]
+        payload = refiled.generate(mergers)
+        assert payload['phase_duration']['completed_count'] == 1
+        assert payload['straight_phase_duration']['completed_count'] == 1
+
+    def test_no_completed_reviews_returns_none(self):
+        payload = refiled.generate([_waiver(), _current_notification()])
+        assert payload['phase_duration'] is None
+        assert payload['straight_phase_duration'] is None
 
 
 class TestSorting:

--- a/scripts/tests/test_static_data_outputs.py
+++ b/scripts/tests/test_static_data_outputs.py
@@ -138,9 +138,16 @@ class TestStatsGenerate:
         # Key shape
         assert set(payload.keys()) >= {
             'total_mergers', 'total_waivers', 'by_status', 'by_determination',
-            'by_waiver_determination', 'phase_duration', 'waiver_duration',
+            'by_waiver_determination', 'clearance_rate', 'phase_duration', 'waiver_duration',
             'top_industries', 'recent_mergers', 'recent_determinations',
         }
+
+    def test_clearance_rate_only_counts_determined_notifications(self):
+        payload = stats.generate(_enriched_fixture())
+        # Of the 3 notifications (MN-0001 approved, MN-0002 in-progress,
+        # MN-0004 suspended/undetermined), only MN-0001 has a published
+        # determination, and it's a clearance.
+        assert payload['clearance_rate'] == {'cleared': 1, 'not_cleared': 0, 'total': 1, 'rate': 1.0}
 
     def test_waiver_duration_baseline(self):
         payload = stats.generate(_enriched_fixture())


### PR DESCRIPTION
Removes the redundant "From waiver decline to re-filing" subtitle from the
median-time-to-refile stat chip, and adds a clearance rate stat (completed
refiled notifications only) compared against the overall Phase 1 clearance
rate. Also adds a Phase 1 duration comparison chart, reusing
PhaseDurationComparison, showing average/median duration for refiled-from-a-
waiver matters against notifications filed as Phase 1 from the outset.

scripts/static_data/outputs/refiled.py now computes clearance_rate,
phase_duration, and straight_phase_duration; stats.py exposes an overall
clearance_rate baseline for the same comparison used across industry/party
pages.