### PR TITLE
Group Blackbird Ventures entities as related parties

### DIFF
--- a/data/processed/related_parties.json
+++ b/data/processed/related_parties.json
@@ -1868,6 +1868,56 @@
           "identifier": "29 696 470 345"
         }
       ]
+    },
+    {
+      "id": "blackbird-ventures",
+      "canonical_name": "Blackbird Ventures",
+      "members": [
+        {
+          "name": "Blackbird Ventures Pty Ltd",
+          "identifier": "93 159 044 989"
+        },
+        {
+          "name": "Blackbird Aware Pty Limited",
+          "identifier": "623 194 383"
+        },
+        {
+          "name": "Blackbird CB Pty Limited",
+          "identifier": "697 959 701"
+        },
+        {
+          "name": "Blackbird FOF25 Pty Ltd as trustee for Blackbird Ventures 2025 Follow-On Fund Trust",
+          "identifier": "49 711 375 395"
+        },
+        {
+          "name": "Blackbird FSA Pty Ltd",
+          "identifier": "692 309 032"
+        },
+        {
+          "name": "Blackbird FSA Pty Ltd as trustee for Blackbird FSA Co-investment Trust",
+          "identifier": "99 526 258 209"
+        },
+        {
+          "name": "Blackbird Guardians Coinvestment Pty Ltd",
+          "identifier": "662 556 005"
+        },
+        {
+          "name": "Blackbird HP Pty Ltd",
+          "identifier": "621 829 534"
+        },
+        {
+          "name": "Blackbird Hotham Pty Ltd",
+          "identifier": "663 838 864"
+        },
+        {
+          "name": "Blackbird Purple Pty Ltd",
+          "identifier": "44 637 190 599"
+        },
+        {
+          "name": "Blackbird Southern Land Pty Ltd",
+          "identifier": "640 535 208"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Blackbird Ventures uses a distinct investment vehicle (Pty Ltd) per
deal/fund, so the various Blackbird-named parties across the register
are the same VC group under different ABNs, not unrelated entities.