### PR TITLE
Fix questionnaire parser missing non-bold section headers

### DIFF
--- a/data/processed/questionnaire_data.json
+++ b/data/processed/questionnaire_data.json
@@ -1849,7 +1849,7 @@
       },
       {
         "number": 4,
-        "text": "For suppliers in the construction industry: a. describe the goods or services you supply in the construction industry and the geographic areas you operate in; and b. provide, for the 2025 financial year: i. total revenue from operations in the construction industry; ii. revenue from operations in the Queensland construction industry (if applicable); and iii. to the extent possible, provide a breakdown of your revenue in each of the items i. and ii. above by the different categories of 2 goods or services you supply in the construction industry (for example, civil contracting, construction haulage)."
+        "text": "For suppliers in the construction industry: a. describe the goods or services you supply in the construction industry and the geographic areas you operate in; and b. provide, for the 2025 financial year: i. total revenue from operations in the construction industry; ii. revenue from operations in the Queensland construction industry (if applicable); and iii. to the extent possible, provide a breakdown of your revenue in each of the items i. and ii. above by the different categories of goods or services you supply in the construction industry (for example, civil contracting, construction haulage)."
       }
     ],
     "questions_count": 4
@@ -2187,7 +2187,7 @@
       {
         "number": 12,
         "section": "Independent Repairers",
-        "text": "For independent repairers in the Campbelltown-Narellan-Smeaton Grange area, to what extent are you able to acquire OEM branded spare parts from 4 surrounding areas such as Sydney or the Illawarra, and if so, how quick, reliable and cost effective is the supply?"
+        "text": "For independent repairers in the Campbelltown-Narellan-Smeaton Grange area, to what extent are you able to acquire OEM branded spare parts from surrounding areas such as Sydney or the Illawarra, and if so, how quick, reliable and cost effective is the supply?"
       },
       {
         "number": 13,
@@ -3405,7 +3405,7 @@
       {
         "number": 2,
         "section": null,
-        "text": "Outline any concerns regarding the impact of the Acquisitions on competition. 2"
+        "text": "Outline any concerns regarding the impact of the Acquisitions on competition."
       },
       {
         "number": 3,
@@ -3587,7 +3587,7 @@
       },
       {
         "number": 2,
-        "text": "Provide any additional information or comments that you consider relevant to the ACCC\u2019s assessment of the Acquisition. OFFICIAL SENSITIVE"
+        "text": "Provide any additional information or comments that you consider relevant to the ACCC\u2019s assessment of the Acquisition."
       },
       {
         "number": 3,
@@ -5489,7 +5489,7 @@
       {
         "number": 2,
         "section": null,
-        "text": "Outline any concerns regarding the impact of the Acquisitions on competition. 2"
+        "text": "Outline any concerns regarding the impact of the Acquisitions on competition."
       },
       {
         "number": 3,
@@ -6186,22 +6186,27 @@
     "questions": [
       {
         "number": 1,
-        "text": "Provide a brief description of your business or organisation, including any commercial relationships with Salesforce and/or Contentful. 1 Alternative suppliers"
+        "section": null,
+        "text": "Provide a brief description of your business or organisation, including any commercial relationships with Salesforce and/or Contentful."
       },
       {
         "number": 2,
+        "section": "Alternative suppliers",
         "text": "List providers of Customer Relationships Management (CRM) software that could service your organisation\u2019s needs."
       },
       {
         "number": 3,
-        "text": "List providers of Content Management System (CMS) software that could service your organisation\u2019s needs. The Acquisition"
+        "section": "Alternative suppliers",
+        "text": "List providers of Content Management System (CMS) software that could service your organisation\u2019s needs."
       },
       {
         "number": 4,
+        "section": "The Acquisition",
         "text": "Outline any concerns regarding the effect of the Acquisition on competition, including if Salesforce and Contentful are close competitors and there are not many alternatives, or if one is a major supplier to competitors of the other."
       },
       {
         "number": 5,
+        "section": "The Acquisition",
         "text": "Provide any additional information or comments that you consider relevant to the ACCC\u2019s assessment of the Acquisition."
       }
     ],

--- a/merger-tracker/frontend/public/data/questionnaires/MN-25002.json
+++ b/merger-tracker/frontend/public/data/questionnaires/MN-25002.json
@@ -17,7 +17,7 @@
     },
     {
       "number": 4,
-      "text": "For suppliers in the construction industry: a. describe the goods or services you supply in the construction industry and the geographic areas you operate in; and b. provide, for the 2025 financial year: i. total revenue from operations in the construction industry; ii. revenue from operations in the Queensland construction industry (if applicable); and iii. to the extent possible, provide a breakdown of your revenue in each of the items i. and ii. above by the different categories of 2 goods or services you supply in the construction industry (for example, civil contracting, construction haulage)."
+      "text": "For suppliers in the construction industry: a. describe the goods or services you supply in the construction industry and the geographic areas you operate in; and b. provide, for the 2025 financial year: i. total revenue from operations in the construction industry; ii. revenue from operations in the Queensland construction industry (if applicable); and iii. to the extent possible, provide a breakdown of your revenue in each of the items i. and ii. above by the different categories of goods or services you supply in the construction industry (for example, civil contracting, construction haulage)."
     }
   ],
   "questions_count": 4

--- a/merger-tracker/frontend/public/data/questionnaires/MN-30002.json
+++ b/merger-tracker/frontend/public/data/questionnaires/MN-30002.json
@@ -71,7 +71,7 @@
     {
       "number": 12,
       "section": "Independent Repairers",
-      "text": "For independent repairers in the Campbelltown-Narellan-Smeaton Grange area, to what extent are you able to acquire OEM branded spare parts from 4 surrounding areas such as Sydney or the Illawarra, and if so, how quick, reliable and cost effective is the supply?"
+      "text": "For independent repairers in the Campbelltown-Narellan-Smeaton Grange area, to what extent are you able to acquire OEM branded spare parts from surrounding areas such as Sydney or the Illawarra, and if so, how quick, reliable and cost effective is the supply?"
     },
     {
       "number": 13,

--- a/merger-tracker/frontend/public/data/questionnaires/MN-50011.json
+++ b/merger-tracker/frontend/public/data/questionnaires/MN-50011.json
@@ -11,7 +11,7 @@
     {
       "number": 2,
       "section": null,
-      "text": "Outline any concerns regarding the impact of the Acquisitions on competition. 2"
+      "text": "Outline any concerns regarding the impact of the Acquisitions on competition."
     },
     {
       "number": 3,

--- a/merger-tracker/frontend/public/data/questionnaires/MN-50022.json
+++ b/merger-tracker/frontend/public/data/questionnaires/MN-50022.json
@@ -9,7 +9,7 @@
     },
     {
       "number": 2,
-      "text": "Provide any additional information or comments that you consider relevant to the ACCC\u2019s assessment of the Acquisition. OFFICIAL SENSITIVE"
+      "text": "Provide any additional information or comments that you consider relevant to the ACCC\u2019s assessment of the Acquisition."
     },
     {
       "number": 3,

--- a/merger-tracker/frontend/public/data/questionnaires/MN-85015.json
+++ b/merger-tracker/frontend/public/data/questionnaires/MN-85015.json
@@ -11,7 +11,7 @@
     {
       "number": 2,
       "section": null,
-      "text": "Outline any concerns regarding the impact of the Acquisitions on competition. 2"
+      "text": "Outline any concerns regarding the impact of the Acquisitions on competition."
     },
     {
       "number": 3,

--- a/merger-tracker/frontend/public/data/questionnaires/MN-95025.json
+++ b/merger-tracker/frontend/public/data/questionnaires/MN-95025.json
@@ -5,22 +5,27 @@
   "questions": [
     {
       "number": 1,
-      "text": "Provide a brief description of your business or organisation, including any commercial relationships with Salesforce and/or Contentful. 1 Alternative suppliers"
+      "section": null,
+      "text": "Provide a brief description of your business or organisation, including any commercial relationships with Salesforce and/or Contentful."
     },
     {
       "number": 2,
+      "section": "Alternative suppliers",
       "text": "List providers of Customer Relationships Management (CRM) software that could service your organisation\u2019s needs."
     },
     {
       "number": 3,
-      "text": "List providers of Content Management System (CMS) software that could service your organisation\u2019s needs. The Acquisition"
+      "section": "Alternative suppliers",
+      "text": "List providers of Content Management System (CMS) software that could service your organisation\u2019s needs."
     },
     {
       "number": 4,
+      "section": "The Acquisition",
       "text": "Outline any concerns regarding the effect of the Acquisition on competition, including if Salesforce and Contentful are close competitors and there are not many alternatives, or if one is a major supplier to competitors of the other."
     },
     {
       "number": 5,
+      "section": "The Acquisition",
       "text": "Provide any additional information or comments that you consider relevant to the ACCC\u2019s assessment of the Acquisition."
     }
   ],

--- a/scripts/parse_questionnaire.py
+++ b/scripts/parse_questionnaire.py
@@ -249,6 +249,57 @@ def _extract_subpoints(text: str) -> tuple:
     return _list_stem(text, a_match.start()), subpoints
 
 
+_CLASSIFICATION_MARKING_RE = re.compile(
+    r'^(OFFICIAL|SENSITIVE|PROTECTED|UNCLASSIFIED)(\s*[:\-–]\s*(OFFICIAL|SENSITIVE|PROTECTED|UNCLASSIFIED))*$'
+)
+
+
+def _is_noise_line(text: str) -> bool:
+    """
+    Return True for lines that are page furniture, not document content:
+    Australian government protective-marking headers/footers (OFFICIAL,
+    SENSITIVE, ...) and bare page numbers. These can appear mid-stream
+    (e.g. between a question and the next section header, split across a
+    page break) and must be dropped rather than appended as continuation
+    text or mistaken for a section header.
+    """
+    return bool(_CLASSIFICATION_MARKING_RE.match(text) or re.match(r'^\d{1,3}$', text))
+
+
+def _looks_like_unbolded_section_header(
+    text: str, next_text: Optional[str], prev_text: Optional[str]
+) -> bool:
+    """
+    Heuristic fallback for section headers that aren't bolded in the source
+    PDF (e.g. MN-95025's "Alternative suppliers" / "The Acquisition").
+
+    A short, capitalised, unpunctuated line immediately followed by a
+    numbered question is treated as a header rather than as continuation
+    text of the preceding question. Continuation lines that happen to
+    precede the next question (e.g. "…and continues on next line.") are
+    excluded because they end in sentence punctuation or start lowercase.
+
+    Also requires the preceding line to end a sentence (or be absent).
+    Without this, a word-wrapped line orphaned onto its own line right
+    before the next question (e.g. MN-75003's sub-point wrapping "...
+    Southern Highlands Private" / "Hospital" / "4. Are there...") would be
+    misread as a header rather than as the tail of the previous line.
+    """
+    if not next_text or not re.match(r'^\d+\.\s', next_text):
+        return False
+    if not text or re.match(r'^\d+\.', text):
+        return False
+    if not text[0].isupper():
+        return False
+    if text[-1] in '.,;:?!':
+        return False
+    if len(text.split()) > 8:
+        return False
+    if prev_text and not re.search(r'[.:?!]\s*$', prev_text):
+        return False
+    return True
+
+
 def extract_questions(lines: List[Dict]) -> List[Dict[str, str]]:
     """
     Extract the numbered questions from annotated lines.
@@ -315,9 +366,11 @@ def extract_questions(lines: List[Dict]) -> List[Dict[str, str]]:
                     break
             questions.append(q)
 
-    for line in lines[start_idx:]:
+    remaining_lines = lines[start_idx:]
+    for idx, line in enumerate(remaining_lines):
         text = line['text']
         is_bold = line['is_bold']
+        next_text = remaining_lines[idx + 1]['text'] if idx + 1 < len(remaining_lines) else None
 
         # Stop at the "Confidentiality" boilerplate that follows the questions.
         # (A bold "Confidentiality of responses" header is also caught as a
@@ -338,6 +391,12 @@ def extract_questions(lines: List[Dict]) -> List[Dict[str, str]]:
         # its second section header ends the parse.
         if re.match(r'^(Note:|Please note)', text, re.IGNORECASE):
             prev_was_section_header = False
+            continue
+
+        # Skip page furniture (protective-marking headers/footers, bare page
+        # numbers) without touching state — it can appear mid-question or
+        # between a question and the following section header.
+        if _is_noise_line(text):
             continue
 
         # Skip lines that fall inside a detected table region. Save the current
@@ -380,6 +439,23 @@ def extract_questions(lines: List[Dict]) -> List[Dict[str, str]]:
                 current_question_num = None
                 current_question_text = []
             # Consecutive bold lines = multi-line section header, concatenate
+            if prev_was_section_header and current_section:
+                current_section = current_section + ' ' + text
+            else:
+                current_section = text
+            has_sections = True
+            prev_was_section_header = True
+            continue
+
+        # Non-bold section header (e.g. MN-95025, where headers aren't
+        # bolded in the source PDF). Detected structurally by position
+        # (immediately precedes a numbered question) rather than font.
+        prev_text = current_question_text[-1] if current_question_text else None
+        if not re.match(r'^\d+\.', text) and _looks_like_unbolded_section_header(text, next_text, prev_text):
+            if current_question_num is not None:
+                save_current_question()
+                current_question_num = None
+                current_question_text = []
             if prev_was_section_header and current_section:
                 current_section = current_section + ' ' + text
             else:

--- a/scripts/tests/test_pipeline.py
+++ b/scripts/tests/test_pipeline.py
@@ -921,6 +921,64 @@ class TestExtractQuestions:
         assert result[0]['number'] == 1
         assert result[2]['section'] == 'Questions for suppliers of ITOM software'
 
+    def test_unbolded_section_header_detected(self):
+        """MN-95025: section headers aren't bolded in this PDF. A short,
+        capitalised, unpunctuated line directly followed by a numbered
+        question is treated as a header rather than glued onto the
+        previous question's text."""
+        lines = _lines(
+            ("Questions", True),
+            "1. Provide a brief description of your business or organisation,",
+            "including any commercial relationships with Salesforce and/or Contentful.",
+            "Alternative suppliers",
+            "2. List providers of CRM software that could service your needs.",
+            "3. List providers of CMS software that could service your needs.",
+            "The Acquisition",
+            "4. Outline any concerns regarding the effect on competition.",
+        )
+        result = extract_questions(lines)
+        assert [q['number'] for q in result] == [1, 2, 3, 4]
+        assert result[0]['section'] is None
+        assert result[1]['section'] == 'Alternative suppliers'
+        assert result[2]['section'] == 'Alternative suppliers'
+        assert result[3]['section'] == 'The Acquisition'
+        assert 'Alternative suppliers' not in result[0]['text']
+
+    def test_unbolded_header_not_confused_with_wrapped_word(self):
+        """MN-75003: a single word orphaned onto its own line by word-wrap
+        (mid-sentence, no preceding sentence terminator) must stay part of
+        the previous question, not be misread as a section header, even
+        though it directly precedes the next numbered question."""
+        lines = _lines(
+            ("Questions", True),
+            "1. Which of the following hospitals compete with each other:",
+            "a. National Capital Private Hospital and Ramsay's Southern Highlands Private",
+            "Hospital",
+            "2. Are there any other Ramsay-owned businesses that compete?",
+        )
+        result = extract_questions(lines)
+        assert [q['number'] for q in result] == [1, 2]
+        assert 'section' not in result[1] or result[1]['section'] is None
+        assert 'Southern Highlands Private Hospital' in result[0]['text']
+
+    def test_page_furniture_dropped_mid_question(self):
+        """Bare page numbers and OFFICIAL/SENSITIVE protective markings can
+        appear mid-question (page breaks) and must be dropped, not appended
+        to the question text."""
+        lines = _lines(
+            ("Questions", True),
+            "1. Outline any concerns regarding the impact on competition.",
+            "2",
+            "2. Provide any additional information or comments.",
+            "OFFICIAL",
+            "SENSITIVE",
+            "3. Provide a brief description of your business.",
+        )
+        result = extract_questions(lines)
+        assert [q['number'] for q in result] == [1, 2, 3]
+        assert result[0]['text'] == 'Outline any concerns regarding the impact on competition.'
+        assert result[1]['text'] == 'Provide any additional information or comments.'
+
 
 class TestExtractQuestionsFromText:
     """Tests for the plain-text fallback used when font data is unavailable."""


### PR DESCRIPTION
MN-95025's questionnaire PDF has section headers ("Alternative
suppliers", "The Acquisition") that aren't bolded, so the existing
bold-only header detection glued them onto the preceding question's
text along with a stray page-number footer.

Add a structural fallback: a short, capitalised, unpunctuated line
immediately followed by a numbered question is treated as a header,
but only when the preceding line ends a sentence — this excludes
word-wrapped continuation lines (e.g. MN-75003's sub-point wrapping)
that would otherwise be misread as headers.

Also drop page furniture (bare page numbers, OFFICIAL/SENSITIVE
protective markings) that can appear mid-question between page
breaks, instead of letting it leak into question text.

Regenerated the cached questionnaire data (and downstream frontend
JSON) only for the matters whose parse actually changes under the
fix: MN-95025, MN-25002, MN-30002, MN-50011, MN-50022, MN-85015.