### PR TITLE
Fix vertically misaligned text in status badges

### DIFF
--- a/merger-tracker/frontend/src/components/AppealBadge.jsx
+++ b/merger-tracker/frontend/src/components/AppealBadge.jsx
@@ -5,7 +5,7 @@
 function AppealBadge({ className = '' }) {
   return (
     <span
-      className={`inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-indigo-50 text-indigo-700 border border-indigo-200/60 ${className}`}
+      className={`inline-flex items-center px-2 py-1 rounded-md text-xs font-medium leading-none bg-indigo-50 text-indigo-700 border border-indigo-200/60 ${className}`}
       role="status"
       aria-label="Under appeal at the Australian Competition Tribunal"
     >

--- a/merger-tracker/frontend/src/components/MergerCardBody.jsx
+++ b/merger-tracker/frontend/src/components/MergerCardBody.jsx
@@ -3,7 +3,7 @@ import { mergerPath } from '../utils/slug';
 
 // Shared chip base for the small inline badges (the top-right "New" flag and
 // any caller-supplied meta-row chips like "Waiver") laid over a card's style.
-export const CHIP_BASE_CLASS = 'inline-flex items-center rounded-md px-2 py-0.5';
+export const CHIP_BASE_CLASS = 'inline-flex items-center rounded-md px-2 py-1 leading-none';
 
 // Common body for the dashboard/Phase 2 card grids: an uppercase label row
 // (with an optional top-right chip), a title link using the stretched-link

--- a/merger-tracker/frontend/src/components/NewBadge.jsx
+++ b/merger-tracker/frontend/src/components/NewBadge.jsx
@@ -1,7 +1,7 @@
 function NewBadge() {
   return (
     <span
-      className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-semibold bg-blue-50 text-blue-700 border border-blue-200/60"
+      className="inline-flex items-center px-2 py-1 rounded-md text-xs font-semibold leading-none bg-blue-50 text-blue-700 border border-blue-200/60"
       role="status"
       aria-label="New item since last visit"
     >

--- a/merger-tracker/frontend/src/components/RefiledBadge.jsx
+++ b/merger-tracker/frontend/src/components/RefiledBadge.jsx
@@ -5,7 +5,7 @@
 function RefiledBadge({ className = '' }) {
   return (
     <span
-      className={`inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-amber-50 text-amber-700 border border-amber-200/60 ${className}`}
+      className={`inline-flex items-center px-2 py-1 rounded-md text-xs font-medium leading-none bg-amber-50 text-amber-700 border border-amber-200/60 ${className}`}
       role="status"
       aria-label="Subsequently refiled as a separate matter"
     >

--- a/merger-tracker/frontend/src/components/WaiverBadge.jsx
+++ b/merger-tracker/frontend/src/components/WaiverBadge.jsx
@@ -1,7 +1,7 @@
 function WaiverBadge({ className = '' }) {
   return (
     <span
-      className={`inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-waiver-pale text-waiver-dark border border-waiver-light/60 ${className}`}
+      className={`inline-flex items-center px-2 py-1 rounded-md text-xs font-medium leading-none bg-waiver-pale text-waiver-dark border border-waiver-light/60 ${className}`}
       role="status"
       aria-label="Merger type: Waiver application"
     >

--- a/merger-tracker/frontend/src/pages/Commentary.jsx
+++ b/merger-tracker/frontend/src/pages/Commentary.jsx
@@ -107,7 +107,7 @@ function Commentary() {
                               {comment.tags.map((tag, tagIdx) => (
                                 <span
                                   key={`tag-${tag}-${tagIdx}`}
-                                  className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-blue-100/80 text-blue-700"
+                                  className="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium leading-none bg-blue-100/80 text-blue-700"
                                 >
                                   {tag}
                                 </span>

--- a/merger-tracker/frontend/src/pages/MergerDetail.jsx
+++ b/merger-tracker/frontend/src/pages/MergerDetail.jsx
@@ -477,7 +477,7 @@ function MergerDetail() {
                         {comment.tags.map((tag, idx) => (
                           <span
                             key={`tag-${tag}-${idx}`}
-                            className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-blue-100/80 text-blue-700"
+                            className="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium leading-none bg-blue-100/80 text-blue-700"
                           >
                             {tag}
                           </span>

--- a/merger-tracker/frontend/src/pages/Mergers.jsx
+++ b/merger-tracker/frontend/src/pages/Mergers.jsx
@@ -675,7 +675,7 @@ function Mergers() {
                       {merger.anzsic_codes.map((code) => (
                         <span
                           key={`${merger.merger_id}-anzsic-${code.code || code.name}`}
-                          className="inline-flex items-center px-2 py-0.5 rounded-md text-xs bg-gray-50 text-gray-500 border border-gray-100"
+                          className="inline-flex items-center px-2 py-1 rounded-md text-xs leading-none bg-gray-50 text-gray-500 border border-gray-100"
                         >
                           {code.name}
                         </span>


### PR DESCRIPTION
The small status pills (Under appeal, Refiled, Waiver, New, tribunal/ACT
chips, commentary tags) rendered their text sitting high in the pill, with
a visible gap below. Cause: the `text-xs` recipe forces a 1rem line-height,
so the Inter glyphs (which reserve descender space these words don't use)
sat in the top of the line box.

Add `leading-none` and bump `py-0.5` to `py-1` on the shared badge family
so the text is optically centred while keeping the same ~20px pill height.