### PR TITLE
Unfreeze Motorola Solutions - D-Fend Solutions merger events

### DIFF
--- a/data/frozen_events_mergers.json
+++ b/data/frozen_events_mergers.json
@@ -4,10 +4,6 @@
     "_comment": "ACCC events table has duplicate rows: 'Summary of Notice of Competition Concerns' listed twice (14 May and 25 May) for the same byte-identical re-uploaded document, and 'Timeline extended by ... business days' listed both with and without the '20' day count. Deduped to one entry each; freezing events to stop the duplicates reappearing from the still-buggy ACCC page.",
     "freeze_events": true
   },
-  "MN-05032": {
-    "_comment": "Event date(s) missing from ACCC page (Motorola Solutions - D-Fend Solutions - Questionnaire (8 Jul 2026)); freezing events to preserve the automatically set date(s).",
-    "freeze_events": true
-  },
   "MN-65023": {
     "_comment": "Event date(s) missing from ACCC page (Energy Bay - Centuria Capital third-party questionnaire (10 Jul 2026)); freezing events to preserve the automatically set date(s).",
     "freeze_events": true


### PR DESCRIPTION
Remove the MN-05032 override so events are scraped fresh from the
ACCC page again instead of being preserved from the frozen snapshot.