### PR TITLE
Consolidate duplicated helpers across pipeline scripts (DRY)

### DIFF
--- a/scripts/constants/site.py
+++ b/scripts/constants/site.py
@@ -1,0 +1,16 @@
+"""Site-wide constants: the GitHub repository slug and public site URLs.
+
+Single source of truth for values that scripts embed in generated PR/issue
+bodies and reports (previously copy-pasted per script).
+"""
+
+#: GitHub repository slug, used to build links to blobs, branches and workflows.
+REPO = "nwbort/accc-mergers"
+
+#: Base URL for merger detail pages on the public site.
+MERGERS_FYI_BASE = "https://mergers.fyi/mergers"
+
+
+def mergers_fyi_url(merger_id: str) -> str:
+    """Return the public mergers.fyi detail-page URL for a merger."""
+    return f"{MERGERS_FYI_BASE}/{merger_id}"

--- a/scripts/cutoff.py
+++ b/scripts/cutoff.py
@@ -12,7 +12,6 @@ This module can be used by:
 
 import json
 import os
-import sys
 from datetime import datetime, timedelta
 from date_utils import parse_iso_datetime
 from constants import merger_status

--- a/scripts/detect_duplicates.py
+++ b/scripts/detect_duplicates.py
@@ -33,14 +33,14 @@ from datetime import datetime, timezone
 from difflib import SequenceMatcher
 from pathlib import Path
 
+from constants.site import REPO as _REPO, mergers_fyi_url
+from date_utils import parse_iso_datetime
+
 SCRIPT_DIR = Path(__file__).parent
 REPO_ROOT = SCRIPT_DIR.parent
 DEFAULT_INPUT = REPO_ROOT / "data" / "processed" / "mergers.json"
 
 SIMILARITY_THRESHOLD = 0.80
-
-_REPO = "nwbort/accc-mergers"
-_MERGERS_FYI_BASE = "https://mergers.fyi/mergers"
 
 
 def normalise_title(title: str) -> str:
@@ -127,12 +127,8 @@ def titles_are_different_event_types(a: str, b: str) -> bool:
 
 def parse_date(raw: str):
     """Return a date-only string (YYYY-MM-DD) or None."""
-    if not raw:
-        return None
-    try:
-        return datetime.fromisoformat(raw.replace("Z", "+00:00")).strftime("%Y-%m-%d")
-    except ValueError:
-        return None
+    dt = parse_iso_datetime(raw)
+    return dt.strftime("%Y-%m-%d") if dt else None
 
 
 def dates_within_one_day(date1: str, date2: str) -> bool:
@@ -320,10 +316,6 @@ def print_human_report(report: dict) -> None:
 # ---------------------------------------------------------------------------
 # Helpers for GitHub issue generation
 # ---------------------------------------------------------------------------
-
-def mergers_fyi_url(merger_id: str) -> str:
-    return f"{_MERGERS_FYI_BASE}/{merger_id}"
-
 
 def _json_github_url(branch: str, line: int | None = None) -> str:
     base = f"https://github.com/{_REPO}/blob/{branch}/data/processed/mergers.json"
@@ -631,7 +623,8 @@ def main() -> None:
     with args.input.open() as fh:
         raw = json.load(fh)
 
-    # Support both a bare list and the { "mergers": [...] } wrapper
+    # Keep the raw document so --apply-fixes can write it back in its
+    # original shape (bare list or { "mergers": [...] } wrapper).
     mergers: list[dict] = raw if isinstance(raw, list) else raw.get("mergers", [])
 
     report = build_report(mergers)

--- a/scripts/detect_related_mergers.py
+++ b/scripts/detect_related_mergers.py
@@ -51,6 +51,10 @@ from difflib import SequenceMatcher
 from pathlib import Path
 
 from constants import merger_status
+from constants.site import REPO as _REPO, mergers_fyi_url
+from date_utils import parse_iso_datetime as parse_date
+from merger_filters import load_mergers
+from party_matching import normalise_name
 
 SCRIPT_DIR = Path(__file__).parent
 REPO_ROOT = SCRIPT_DIR.parent
@@ -64,31 +68,18 @@ NAME_SIMILARITY_THRESHOLD = 0.75
 WAIVER_REFILED = "waiver_refiled"
 SUSPENDED_REFILED = "suspended_refiled"
 
-_REPO = "nwbort/accc-mergers"
-_MERGERS_FYI_BASE = "https://mergers.fyi/mergers"
 _RELATED_PATH = "data/processed/related_mergers.json"
 
 
 # ---------------------------------------------------------------------------
 # Normalisation helpers
+#
+# Name normalisation is shared with party_matching.normalise_name. The
+# identifier normalisation below is deliberately looser than
+# party_matching.normalise_identifier (whitespace-only stripping, no
+# placeholder filtering) because it feeds set-intersection matching between
+# a waiver's and a notification's own recorded entities.
 # ---------------------------------------------------------------------------
-
-_COMPANY_SUFFIXES = re.compile(
-    r"\b(pty|ltd|limited|inc|llc|l\.l\.c\.|gmbh|b\.v\.|bv|nv|plc|co|corp|"
-    r"corporation|holdings|group|international|australia|the trustee for|trustee for)\b",
-    re.IGNORECASE,
-)
-
-
-def normalise_name(name: str) -> str:
-    """Lower-case, strip company suffixes and punctuation for fuzzy match."""
-    if not name:
-        return ""
-    out = name.lower()
-    out = _COMPANY_SUFFIXES.sub(" ", out)
-    out = re.sub(r"[^\w\s]", " ", out)
-    out = re.sub(r"\s+", " ", out).strip()
-    return out
 
 
 def normalise_identifier(identifier: str) -> str:
@@ -122,15 +113,6 @@ def best_name_similarity(a_names: list[str], b_names: list[str]) -> float:
             if s > best:
                 best = s
     return best
-
-
-def parse_date(raw: str | None):
-    if not raw:
-        return None
-    try:
-        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
-    except ValueError:
-        return None
 
 
 # ---------------------------------------------------------------------------
@@ -353,10 +335,6 @@ def find_candidates(
 # Reporting helpers
 # ---------------------------------------------------------------------------
 
-def mergers_fyi_url(merger_id: str) -> str:
-    return f"{_MERGERS_FYI_BASE}/{merger_id}"
-
-
 def _format_signals(signals: dict) -> str:
     bits = []
     if signals["acq_id_overlap"]:
@@ -544,9 +522,7 @@ def main() -> int:
         print(f"ERROR: mergers file not found: {args.mergers}", file=sys.stderr)
         return 2
 
-    with args.mergers.open() as fh:
-        raw = json.load(fh)
-    mergers = raw if isinstance(raw, list) else raw.get("mergers", [])
+    mergers = load_mergers(args.mergers)
 
     known = load_related_pairs(args.related)
     candidates = find_candidates(mergers, known, args.threshold)

--- a/scripts/detect_related_parties.py
+++ b/scripts/detect_related_parties.py
@@ -55,6 +55,8 @@ from collections import defaultdict
 from difflib import SequenceMatcher
 from pathlib import Path
 
+from constants.site import REPO as _REPO, mergers_fyi_url
+from merger_filters import load_mergers
 from party_matching import (
     build_group_lookups,
     match_party,
@@ -70,8 +72,6 @@ DEFAULT_PARTIES = REPO_ROOT / "data" / "processed" / "related_parties.json"
 
 DEFAULT_FUZZY_THRESHOLD = 0.88
 
-_REPO = "nwbort/accc-mergers"
-_MERGERS_FYI_BASE = "https://mergers.fyi/mergers"
 _PARTIES_PATH = "data/processed/related_parties.json"
 
 # Tokens too generic to count as a "distinctive" shared token for fuzzy linking.
@@ -521,10 +521,6 @@ _SIGNAL_BLURB = {
 }
 
 
-def mergers_fyi_url(merger_id: str) -> str:
-    return f"{_MERGERS_FYI_BASE}/{merger_id}"
-
-
 def print_summary(candidates: list[dict]) -> None:
     if not candidates:
         print("No new related-party candidates found.")
@@ -641,9 +637,7 @@ def main() -> int:
         print(f"ERROR: mergers file not found: {args.mergers}", file=sys.stderr)
         return 2
 
-    with args.mergers.open() as fh:
-        raw = json.load(fh)
-    mergers = raw if isinstance(raw, list) else raw.get("mergers", [])
+    mergers = load_mergers(args.mergers)
 
     groups = []
     if args.parties.exists():

--- a/scripts/extract_mergers.py
+++ b/scripts/extract_mergers.py
@@ -24,6 +24,7 @@ from parse_questionnaire import (
     _NEG_CACHE_KEY as _Q_NEG_CACHE_KEY,
 )
 from normalization import normalize_determination
+from constants.site import REPO, mergers_fyi_url
 from cutoff import should_skip_merger, get_skipped_merger_ids, is_waiver_merger
 from date_utils import parse_text_to_iso, parse_iso_datetime
 from static_data.enrichment import is_phase_2_referral_event
@@ -1134,15 +1135,14 @@ def auto_fix_missing_event_dates(all_mergers_data, frozen_events_mergers):
         json.dump(frozen_data, f, indent=2)
 
     # Build GitHub issue content
-    _repo = "nwbort/accc-mergers"
     issues = []
     for item in newly_frozen:
         mid = item['merger_id']
         name = item['merger_name']
         url = item['merger_url']
         fixed_events = item['fixed_events']
-        mergers_fyi_url = f"https://mergers.fyi/mergers/{mid}"
-        frozen_json_url = f"https://github.com/{_repo}/blob/main/data/frozen_events_mergers.json"
+        fyi_url = mergers_fyi_url(mid)
+        frozen_json_url = f"https://github.com/{REPO}/blob/main/data/frozen_events_mergers.json"
 
         event_rows = ''.join(
             f"| {fe['event_title']} | {fe['date_display']} | "
@@ -1167,7 +1167,7 @@ def auto_fix_missing_event_dates(all_mergers_data, frozen_events_mergers):
             f"- If any are wrong, update the date in "
             f"[`data/frozen_events_mergers.json`]({frozen_json_url}) and "
             f"`data/processed/mergers.json` with the correct value.\n\n"
-            f"[View on mergers.fyi]({mergers_fyi_url})"
+            f"[View on mergers.fyi]({fyi_url})"
         )
         issues.append({
             'merger_id': mid,
@@ -1212,7 +1212,6 @@ def detect_inferred_phase_2(all_mergers_data):
     ``enrich_merger`` (the static-data output); it is never written back to
     mergers.json, so ``merger['stage']`` here always reflects the register.
     """
-    _repo = "nwbort/accc-mergers"
     to_open = []
     confirmed = []
 
@@ -1234,7 +1233,7 @@ def detect_inferred_phase_2(all_mergers_data):
 
         name = merger.get('merger_name', '')
         url = merger.get('url', '')
-        mergers_fyi_url = f"https://mergers.fyi/mergers/{merger_id}"
+        fyi_url = mergers_fyi_url(merger_id)
         body = (
             f"**{name}** has a Phase 2 notice on the ACCC register, but the matter's "
             f"stage still shows **Phase 1**.\n\n"
@@ -1251,7 +1250,7 @@ def detect_inferred_phase_2(all_mergers_data):
             f"the stage to Phase 2.\n"
             f"- If the parties drop out and the merger never proceeds to Phase 2, close "
             f"this issue manually.\n\n"
-            f"[View on mergers.fyi]({mergers_fyi_url})"
+            f"[View on mergers.fyi]({fyi_url})"
         )
         to_open.append({
             'merger_id': merger_id,

--- a/scripts/extract_mergers.py
+++ b/scripts/extract_mergers.py
@@ -25,7 +25,7 @@ from parse_questionnaire import (
 )
 from normalization import normalize_determination
 from constants.site import REPO, mergers_fyi_url
-from cutoff import should_skip_merger, get_skipped_merger_ids, is_waiver_merger
+from cutoff import get_skipped_merger_ids, is_waiver_merger
 from date_utils import parse_text_to_iso, parse_iso_datetime
 from static_data.enrichment import is_phase_2_referral_event
 from constants import merger_status

--- a/scripts/fix_missing_notification_dates.py
+++ b/scripts/fix_missing_notification_dates.py
@@ -29,13 +29,14 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+from constants.site import REPO as _REPO, mergers_fyi_url
+from merger_filters import load_mergers
+
 SCRIPT_DIR = Path(__file__).parent
 REPO_ROOT = SCRIPT_DIR.parent
 DEFAULT_MERGERS = REPO_ROOT / "data" / "processed" / "mergers.json"
 DEFAULT_KNOWN_DATES = REPO_ROOT / "data" / "known_notification_dates.json"
 
-_REPO = "nwbort/accc-mergers"
-_MERGERS_FYI_BASE = "https://mergers.fyi/mergers"
 _KNOWN_DATES_PATH = "data/known_notification_dates.json"
 
 
@@ -115,7 +116,7 @@ def build_pr_body(candidates: list[dict], date: str) -> str:
         lines.append("")
         lines.append(f"Defaulted notification date: **{c['date']}**")
         lines.append("")
-        lines.append(f"[View on mergers.fyi]({_MERGERS_FYI_BASE}/{c['merger_id']})")
+        lines.append(f"[View on mergers.fyi]({mergers_fyi_url(c['merger_id'])})")
         lines.append("")
     lines.extend([
         "---",
@@ -147,8 +148,7 @@ def main() -> int:
         print(f"ERROR: mergers file not found: {args.mergers}", file=sys.stderr)
         return 2
 
-    with args.mergers.open() as fh:
-        mergers = json.load(fh)
+    mergers = load_mergers(args.mergers)
 
     known_dates = {}
     if args.known_dates.exists():

--- a/scripts/generate_rss_feed.py
+++ b/scripts/generate_rss_feed.py
@@ -73,7 +73,7 @@ def generate_atom_xml(entries: list) -> str:
         f'  <id>{SITE_URL}/</id>',
         f'  <updated>{feed_updated}</updated>',
         f'  <author><name>{escape(AUTHOR_NAME)}</name></author>',
-        f'  <generator>Australian Merger Tracker</generator>',
+        '  <generator>Australian Merger Tracker</generator>',
     ]
 
     for entry in entries:

--- a/scripts/generate_similar_mergers.py
+++ b/scripts/generate_similar_mergers.py
@@ -38,6 +38,9 @@ from datetime import datetime, timezone
 from difflib import SequenceMatcher
 from pathlib import Path
 
+from merger_filters import load_mergers
+from party_matching import normalise_name as _normalise_name
+
 SCRIPT_DIR = Path(__file__).parent
 REPO_ROOT = SCRIPT_DIR.parent
 DEFAULT_MERGERS = REPO_ROOT / "data" / "processed" / "mergers.json"
@@ -48,14 +51,10 @@ MAX_RESULTS = 3
 SCORE_THRESHOLD = 0.30
 
 # ---------------------------------------------------------------------------
-# Normalisation helpers (mirrors detect_related_mergers.py)
+# Normalisation helpers (name normalisation shared via party_matching;
+# identifier normalisation mirrors detect_related_mergers.py — see the note
+# there on why it is looser than party_matching.normalise_identifier)
 # ---------------------------------------------------------------------------
-
-_COMPANY_SUFFIXES = re.compile(
-    r"\b(pty|ltd|limited|inc|llc|l\.l\.c\.|gmbh|b\.v\.|bv|nv|plc|co|corp|"
-    r"corporation|holdings|group|international|australia|the trustee for|trustee for)\b",
-    re.IGNORECASE,
-)
 
 # Generic business words that shouldn't drive party similarity
 _WORD_STOP = frozenset({
@@ -64,16 +63,6 @@ _WORD_STOP = frozenset({
     'media', 'finance', 'financial', 'digital', 'retail', 'network', 'trust',
     'fund', 'asset', 'assets', 'super', 'super', 'pension',
 })
-
-
-def _normalise_name(name: str) -> str:
-    if not name:
-        return ""
-    out = name.lower()
-    out = _COMPANY_SUFFIXES.sub(" ", out)
-    out = re.sub(r"[^\w\s]", " ", out)
-    out = re.sub(r"\s+", " ", out).strip()
-    return out
 
 
 def _normalise_identifier(identifier: str) -> str:
@@ -174,12 +163,6 @@ def find_similar(
 # I/O helpers
 # ---------------------------------------------------------------------------
 
-def _load_mergers(path: Path) -> list[dict]:
-    with open(path, encoding="utf-8") as f:
-        raw = json.load(f)
-    return raw if isinstance(raw, list) else raw.get("mergers", [])
-
-
 def _load_existing(path: Path) -> dict:
     if not path.exists():
         return {}
@@ -251,7 +234,7 @@ def main() -> int:
         print(f"ERROR: mergers file not found: {args.mergers}", file=sys.stderr)
         return 2
 
-    all_mergers = _load_mergers(args.mergers)
+    all_mergers = load_mergers(args.mergers)
     merger_index = {m.get("merger_id"): m for m in all_mergers if m.get("merger_id")}
 
     # Related-merger pairs are already surfaced via related_merger; exclude each

--- a/scripts/generate_weekly_digest.py
+++ b/scripts/generate_weekly_digest.py
@@ -30,10 +30,10 @@ Outputs:
 """
 
 import json
-from datetime import datetime, timedelta, time
+from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 from pathlib import Path
-from typing import Dict, List, Any, Optional, Set
+from typing import Dict, Any, Optional, Set
 from constants import merger_status
 from date_utils import parse_iso_datetime
 from merger_filters import filter_active, load_mergers
@@ -388,7 +388,7 @@ def main():
 
     print(f"Digest generated: {OUTPUT_PATH}")
     print(f"Archive snapshot: {archive_path}")
-    print(f"\nSummary:")
+    print("\nSummary:")
     print(f"  New deals notified (last week): {len(digest['new_deals_notified'])}")
     print(f"  Deals cleared (last week): {len(digest['deals_cleared'])}")
     print(f"  Deals referred to phase 2 (last week): {len(digest['deals_referred_to_phase_2'])}")

--- a/scripts/parse_determination.py
+++ b/scripts/parse_determination.py
@@ -6,7 +6,7 @@ Parse determination PDFs to extract commission division information and table co
 import pdfplumber
 import re
 import json
-from typing import Optional, Dict, List, Tuple
+from typing import Optional, Dict, List
 from pathlib import Path
 
 

--- a/scripts/parse_questionnaire.py
+++ b/scripts/parse_questionnaire.py
@@ -347,7 +347,6 @@ def extract_questions(lines: List[Dict]) -> List[Dict[str, str]]:
 
     def save_current_question():
         """Helper to save the current question to the list."""
-        nonlocal current_question_num, current_question_text
         if current_question_num is not None:
             full_text = ' '.join(current_question_text).strip()
             full_text = re.sub(r'\s+', ' ', full_text)

--- a/scripts/party_matching.py
+++ b/scripts/party_matching.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import re
 
 # Company-form suffixes and boilerplate words that carry no identifying signal.
-# Kept deliberately in sync with the equivalent list in detect_related_mergers.py.
+# Single source of truth — detect_related_mergers.py imports normalise_name too.
 _COMPANY_SUFFIXES = re.compile(
     r"\b(pty|ltd|limited|inc|llc|l\.l\.c\.|gmbh|b\.v\.|bv|nv|plc|co|corp|"
     r"corporation|holdings|group|international|australia|"

--- a/scripts/static_data/loaders.py
+++ b/scripts/static_data/loaders.py
@@ -3,6 +3,8 @@
 import json
 from pathlib import Path
 
+from merger_filters import load_mergers as _load_mergers
+
 SCRIPT_DIR = Path(__file__).resolve().parent.parent
 REPO_ROOT = SCRIPT_DIR.parent
 MERGERS_JSON = REPO_ROOT / "data" / "processed" / "mergers.json"
@@ -18,16 +20,10 @@ TRIBUNAL_APPEALS_JSON = REPO_ROOT / "data" / "processed" / "tribunal_appeals.jso
 def load_mergers() -> list:
     """Load mergers list from the processed mergers.json file.
 
-    Accepts both the raw-list format and the ``{"mergers": [...]}`` wrapper.
+    Delegates to the canonical loader in :mod:`merger_filters`, which
+    accepts both the raw-list format and the ``{"mergers": [...]}`` wrapper.
     """
-    with open(MERGERS_JSON, 'r', encoding='utf-8') as f:
-        data = json.load(f)
-
-    if isinstance(data, list):
-        return data
-    if isinstance(data, dict) and 'mergers' in data:
-        return data['mergers']
-    raise ValueError("Unexpected mergers.json format")
+    return _load_mergers(MERGERS_JSON)
 
 
 # Relationship labels emitted for each pair type, as (source_label,

--- a/scripts/static_data/outputs/extensions.py
+++ b/scripts/static_data/outputs/extensions.py
@@ -15,7 +15,6 @@ import re
 
 from constants import merger_status
 from merger_filters import filter_notifications
-from static_data.business_days import calculate_business_days
 from static_data.enrichment import is_phase_2_referral_event
 
 # The standard Phase 1 statutory window, in business days, before any extension.

--- a/scripts/static_data/outputs/upcoming_events.py
+++ b/scripts/static_data/outputs/upcoming_events.py
@@ -5,7 +5,6 @@ determination period ends within ``days_ahead`` days. Excludes waivers and
 suspended mergers using :func:`static_data.filters.exclude_for_public_output`.
 """
 
-from collections import defaultdict  # noqa: F401  (kept for parity with original module)
 from datetime import datetime, timedelta, timezone
 
 from constants import merger_status  # noqa: F401  (kept for parity)

--- a/scripts/tests/test_pipeline.py
+++ b/scripts/tests/test_pipeline.py
@@ -5,7 +5,7 @@ import sys
 import os
 import json
 import unittest.mock
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
 
 # Add scripts directory to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
@@ -1453,7 +1453,6 @@ from static_data.enrichment import (
     extract_phase_from_event,
     is_phase_2_referral_event,
 )
-from static_data.loaders import load_questionnaire_data
 from static_data.outputs.commentary import generate as generate_commentary_json
 from static_data.outputs.industries import generate_index as generate_industries_json
 from static_data.outputs.questionnaires import generate as generate_questionnaire_files

--- a/scripts/tests/test_utils.py
+++ b/scripts/tests/test_utils.py
@@ -3,7 +3,6 @@
 import sys
 import os
 import unittest.mock
-from datetime import datetime
 
 # Add scripts directory to path so we can import modules directly
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))

--- a/scripts/tools/advisors.py
+++ b/scripts/tools/advisors.py
@@ -31,6 +31,9 @@ from pydantic import BaseModel
 import uvicorn
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+# Allow imports from the parent scripts/ directory too.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from merger_filters import load_mergers as _load_mergers_from  # noqa: E402
 from advisors_crypto import (  # noqa: E402
     ADVISORS_ENC,
     ADVISORS_JSON,
@@ -39,8 +42,6 @@ from advisors_crypto import (  # noqa: E402
     load_advisors as _crypto_load,
     save_advisors as _crypto_save,
 )
-
-import json  # noqa: E402  (still used for mergers.json)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 MERGERS_JSON = REPO_ROOT / "data" / "processed" / "mergers.json"
@@ -58,9 +59,7 @@ _SESSION: dict = {"passphrase": None}
 # ── helpers ────────────────────────────────────────────────────────────────
 
 def _load_mergers() -> list:
-    with MERGERS_JSON.open() as fh:
-        data = json.load(fh)
-    return data if isinstance(data, list) else data.get("mergers", [])
+    return _load_mergers_from(MERGERS_JSON)
 
 
 def _is_unlocked() -> bool:

--- a/scripts/tools/advisors.py
+++ b/scripts/tools/advisors.py
@@ -36,7 +36,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from merger_filters import load_mergers as _load_mergers_from  # noqa: E402
 from advisors_crypto import (  # noqa: E402
     ADVISORS_ENC,
-    ADVISORS_JSON,
     ENV_PASSPHRASE,
     AdvisorsCryptoError,
     load_advisors as _crypto_load,

--- a/scripts/tools/commentary.py
+++ b/scripts/tools/commentary.py
@@ -6,27 +6,27 @@ Run with: python scripts/tools/commentary.py
 """
 
 import json
+import sys
 from pathlib import Path
 from typing import List, Optional
+
+# Allow imports from the parent scripts/ directory.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 import uvicorn
 
+from merger_filters import load_mergers as _load_mergers
+
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
-MERGERS_JSON = REPO_ROOT / "data" / "processed" / "mergers.json"
 COMMENTARY_JSON = REPO_ROOT / "data" / "processed" / "commentary.json"
 
 app = FastAPI()
 
 
 # ── helpers ────────────────────────────────────────────────────────────────
-
-def _load_mergers() -> list:
-    with MERGERS_JSON.open() as fh:
-        data = json.load(fh)
-    return data if isinstance(data, list) else data.get("mergers", [])
 
 
 def _load_commentary() -> dict:

--- a/scripts/tools/related_parties.py
+++ b/scripts/tools/related_parties.py
@@ -44,8 +44,6 @@ from party_matching import (
     dedupe_members,
     match_party,
     merge_groups,
-    normalise_identifier,
-    normalise_name,
 )
 from slug import slugify
 

--- a/scripts/tools/related_parties.py
+++ b/scripts/tools/related_parties.py
@@ -38,6 +38,7 @@ from detect_related_parties import (
     _title_case_name,
     collect_party_records,
 )
+from merger_filters import load_mergers as _load_mergers_from
 from party_matching import (
     build_group_lookups,
     dedupe_members,
@@ -56,9 +57,7 @@ app = FastAPI()
 # ---------------------------------------------------------------------------
 
 def load_mergers() -> list[dict]:
-    with DEFAULT_MERGERS.open() as fh:
-        raw = json.load(fh)
-    return raw if isinstance(raw, list) else raw.get("mergers", [])
+    return _load_mergers_from(DEFAULT_MERGERS)
 
 
 def load_parties_doc() -> dict:

--- a/scripts/tools/resolver.py
+++ b/scripts/tools/resolver.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel
 import uvicorn
 
 from detect_duplicates import build_report, DEFAULT_INPUT
+from merger_filters import load_mergers
 
 app = FastAPI()
 
@@ -31,10 +32,7 @@ def index():
 @app.get("/api/report")
 def get_report():
     """Generate the duplicate report on the fly."""
-    with DEFAULT_INPUT.open() as fh:
-        raw = json.load(fh)
-    mergers = raw if isinstance(raw, list) else raw.get("mergers", [])
-    return build_report(mergers)
+    return build_report(load_mergers(DEFAULT_INPUT))
 
 @app.post("/api/remove")
 def remove_event(req: RemoveRequest):


### PR DESCRIPTION
- Add constants/site.py as single source for the repo slug and
  mergers.fyi URL, replacing five copy-pasted definitions
  (detect_duplicates, detect_related_mergers, detect_related_parties,
  fix_missing_notification_dates, extract_mergers — where one copy
  was already dead code)
- Route ad-hoc mergers.json loaders through the canonical
  merger_filters.load_mergers (detect scripts, static_data.loaders,
  generate_similar_mergers, admin tools); detect_duplicates keeps its
  raw load since --apply-fixes writes the document back in its
  original shape
- Import normalise_name/_COMPANY_SUFFIXES from party_matching instead
  of keeping two 'deliberately in sync' copies in
  detect_related_mergers and generate_similar_mergers
- Replace two local parse_date reimplementations with
  date_utils.parse_iso_datetime

No behaviour change: 790 tests pass and regenerated static data is
byte-identical.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EJdC9o4TFSqCqjpQWhaE63