### PR TITLE
Add hidden press-and-hold Phase 2 referral estimate to the status badge

### DIFF
--- a/merger-tracker/frontend/src/components/Phase2OddsReveal.jsx
+++ b/merger-tracker/frontend/src/components/Phase2OddsReveal.jsx
@@ -89,7 +89,7 @@ function Phase2OddsReveal({ merger, children }) {
           className="absolute right-0 top-full mt-2 z-30 w-48 rounded-xl border border-amber-200/70 bg-white px-3 py-2.5 text-left shadow-lg animate-fade-in"
         >
           <span className="block text-[10px] font-semibold uppercase tracking-wider text-amber-600">
-            Est. Phase 2 referral
+            Est. probability of Phase 2 referral
           </span>
           {percent != null ? (
             <>

--- a/merger-tracker/frontend/src/components/Phase2OddsReveal.jsx
+++ b/merger-tracker/frontend/src/components/Phase2OddsReveal.jsx
@@ -32,7 +32,7 @@ function Phase2OddsReveal({ merger, children }) {
 
   // Only fetch the curve when the badge could actually reveal it — a falsy URL
   // pauses useFetchData, so ineligible matters make no network request.
-  const { data } = useFetchData(
+  const { data, error } = useFetchData(
     eligible ? API_ENDPOINTS.referralProbabilityByDay : null,
     { cacheKey: 'referral-probability-by-day' }
   );
@@ -83,7 +83,9 @@ function Phase2OddsReveal({ merger, children }) {
       onContextMenu={(e) => e.preventDefault()}
     >
       {children}
-      {revealed && (
+      {/* If the curve failed to load, stay silent rather than showing the
+          "estimating…" placeholder forever. */}
+      {revealed && !error && (
         <span
           role="status"
           className="absolute right-0 top-full mt-2 z-30 w-48 rounded-xl border border-amber-200/70 bg-white px-3 py-2.5 text-left shadow-lg animate-fade-in"

--- a/merger-tracker/frontend/src/components/Phase2OddsReveal.jsx
+++ b/merger-tracker/frontend/src/components/Phase2OddsReveal.jsx
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getBusinessDayProgress } from '../utils/businessDayProgress';
+import { useFetchData } from '../hooks/useFetchData';
+import { API_ENDPOINTS } from '../config';
+import { MERGER_STATUS, PHASES } from '../constants/mergerStatus';
+
+// How long the badge must be pressed before the hidden estimate appears.
+const LONG_PRESS_MS = 450;
+
+/**
+ * A quiet, undocumented flourish over the "Under assessment" tag: press and
+ * hold it (touch or mouse) on a Phase 1 matter that is still under assessment
+ * and it reveals that matter's estimated chance of being referred to Phase 2.
+ *
+ * The estimate reads referral-probability-by-day.json — a survival-style curve
+ * giving P(referred to Phase 2 | still undecided at business day N) — and
+ * indexes it by how many business days this matter has been running. The longer
+ * a live review sits undecided, the more the quick clearances have dropped out
+ * of the comparison pool, so the odds ratchet up.
+ *
+ * When the matter isn't an eligible Phase 1 assessment (waiver, Phase 2, already
+ * decided, or missing dates) the wrapper is inert and simply renders its child
+ * badge untouched.
+ */
+function Phase2OddsReveal({ merger, children }) {
+  const progress = getBusinessDayProgress(merger);
+  const eligible =
+    !!progress &&
+    merger?.status === MERGER_STATUS.UNDER_ASSESSMENT &&
+    !!merger?.stage &&
+    merger.stage.includes(PHASES.PHASE_1);
+
+  // Only fetch the curve when the badge could actually reveal it — a falsy URL
+  // pauses useFetchData, so ineligible matters make no network request.
+  const { data } = useFetchData(
+    eligible ? API_ENDPOINTS.referralProbabilityByDay : null,
+    { cacheKey: 'referral-probability-by-day' }
+  );
+
+  const [revealed, setRevealed] = useState(false);
+  const timerRef = useRef(null);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const startPress = useCallback(() => {
+    clearTimer();
+    timerRef.current = setTimeout(() => setRevealed(true), LONG_PRESS_MS);
+  }, [clearTimer]);
+
+  const endPress = useCallback(() => {
+    clearTimer();
+    setRevealed(false);
+  }, [clearTimer]);
+
+  // Tidy up a pending timer if the component unmounts mid-press.
+  useEffect(() => clearTimer, [clearTimer]);
+
+  if (!eligible) return children;
+
+  const probabilities = data?.probabilities;
+  // The curve is positional by business day; clamp into range so a review that
+  // has run longer than the longest completed one reuses the (capped) tail.
+  const probability =
+    Array.isArray(probabilities) && probabilities.length > 0
+      ? probabilities[Math.min(progress.elapsed, probabilities.length - 1)]
+      : null;
+  const percent = probability != null ? Math.round(probability * 100) : null;
+
+  return (
+    <span
+      className="relative inline-flex select-none touch-none [-webkit-touch-callout:none]"
+      onMouseDown={startPress}
+      onMouseUp={endPress}
+      onMouseLeave={endPress}
+      onTouchStart={startPress}
+      onTouchEnd={endPress}
+      onTouchCancel={endPress}
+      onContextMenu={(e) => e.preventDefault()}
+    >
+      {children}
+      {revealed && (
+        <span
+          role="status"
+          className="absolute right-0 top-full mt-2 z-30 w-48 rounded-xl border border-amber-200/70 bg-white px-3 py-2.5 text-left shadow-lg animate-fade-in"
+        >
+          <span className="block text-[10px] font-semibold uppercase tracking-wider text-amber-600">
+            Est. Phase 2 referral
+          </span>
+          {percent != null ? (
+            <>
+              <span className="block text-xl font-bold leading-tight text-gray-900">
+                {percent}%
+              </span>
+              <span className="block text-[11px] leading-snug text-gray-500">
+                at business day {progress.elapsed} of {progress.total}
+              </span>
+            </>
+          ) : (
+            <span className="block text-sm text-gray-400">estimating…</span>
+          )}
+        </span>
+      )}
+    </span>
+  );
+}
+
+export default Phase2OddsReveal;

--- a/merger-tracker/frontend/src/components/__tests__/Phase2OddsReveal.test.jsx
+++ b/merger-tracker/frontend/src/components/__tests__/Phase2OddsReveal.test.jsx
@@ -84,6 +84,29 @@ describe('Phase2OddsReveal', () => {
     expect(screen.queryByText('42%')).not.toBeInTheDocument();
   });
 
+  it('stays silent (no placeholder) when the curve fails to load', async () => {
+    // No cache seed + a fetch that rejects → useFetchData surfaces an error.
+    dataCache.clear(CACHE_KEY);
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValue(new Error('network down'));
+
+    renderBadge(phase1Merger);
+
+    // Let the rejected fetch settle into error state.
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    fireEvent.mouseDown(screen.getByTestId('badge'));
+    act(() => vi.advanceTimersByTime(450));
+
+    expect(screen.queryByText('42%')).not.toBeInTheDocument();
+    expect(screen.queryByText('estimating…')).not.toBeInTheDocument();
+
+    fetchSpy.mockRestore();
+  });
+
   it('stays inert for a waiver', () => {
     renderBadge({ ...phase1Merger, is_waiver: true, stage: 'Waiver application' });
 

--- a/merger-tracker/frontend/src/components/__tests__/Phase2OddsReveal.test.jsx
+++ b/merger-tracker/frontend/src/components/__tests__/Phase2OddsReveal.test.jsx
@@ -1,0 +1,95 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Phase2OddsReveal from '../Phase2OddsReveal';
+import { dataCache } from '../../utils/dataCache';
+
+const CACHE_KEY = 'referral-probability-by-day';
+
+// A Phase 1 matter notified 2026-05-18, evaluated as of 2026-06-01 → business
+// day 9 of 30 (see BusinessDayProgress.test.jsx for the same calculation).
+const phase1Merger = {
+  status: 'Under assessment',
+  stage: 'Phase 1 - initial assessment',
+  effective_notification_datetime: '2026-05-18T12:00:00Z',
+  end_of_determination_period: '2026-07-01T12:00:00Z',
+};
+
+function renderBadge(merger) {
+  return render(
+    <Phase2OddsReveal merger={merger}>
+      <span data-testid="badge">Under assessment</span>
+    </Phase2OddsReveal>
+  );
+}
+
+describe('Phase2OddsReveal', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-01T00:00:00Z'));
+    // Seed the cache so useFetchData resolves the curve synchronously (no fetch).
+    // Index 9 (the matter's business day) carries the distinctive 0.42.
+    const probabilities = Array.from({ length: 30 }, (_, i) => (i === 9 ? 0.42 : 0.05));
+    dataCache.set(CACHE_KEY, { probabilities });
+  });
+
+  afterEach(() => {
+    dataCache.clear(CACHE_KEY);
+    vi.useRealTimers();
+  });
+
+  it('reveals the Phase 2 referral estimate after a long press, then hides it on release', () => {
+    renderBadge(phase1Merger);
+
+    // Nothing shown until pressed and held.
+    expect(screen.queryByText('42%')).not.toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getByTestId('badge'));
+    act(() => vi.advanceTimersByTime(450));
+
+    expect(screen.getByText('42%')).toBeInTheDocument();
+    expect(screen.getByText('at business day 9 of 30')).toBeInTheDocument();
+
+    // Releasing the press dismisses the estimate.
+    fireEvent.mouseUp(screen.getByTestId('badge'));
+    expect(screen.queryByText('42%')).not.toBeInTheDocument();
+  });
+
+  it('does not reveal anything on a quick tap (press released before the hold delay)', () => {
+    renderBadge(phase1Merger);
+
+    fireEvent.mouseDown(screen.getByTestId('badge'));
+    act(() => vi.advanceTimersByTime(200));
+    fireEvent.mouseUp(screen.getByTestId('badge'));
+    act(() => vi.advanceTimersByTime(450));
+
+    expect(screen.queryByText('42%')).not.toBeInTheDocument();
+  });
+
+  it('stays inert for a Phase 2 matter (renders the child badge untouched)', () => {
+    renderBadge({ ...phase1Merger, stage: 'Phase 2 - detailed assessment' });
+
+    fireEvent.mouseDown(screen.getByTestId('badge'));
+    act(() => vi.advanceTimersByTime(450));
+
+    expect(screen.queryByText('42%')).not.toBeInTheDocument();
+    expect(screen.getByTestId('badge')).toBeInTheDocument();
+  });
+
+  it('stays inert once the matter is no longer under assessment', () => {
+    renderBadge({ ...phase1Merger, status: 'Assessment completed' });
+
+    fireEvent.mouseDown(screen.getByTestId('badge'));
+    act(() => vi.advanceTimersByTime(450));
+
+    expect(screen.queryByText('42%')).not.toBeInTheDocument();
+  });
+
+  it('stays inert for a waiver', () => {
+    renderBadge({ ...phase1Merger, is_waiver: true, stage: 'Waiver application' });
+
+    fireEvent.mouseDown(screen.getByTestId('badge'));
+    act(() => vi.advanceTimersByTime(450));
+
+    expect(screen.queryByText('42%')).not.toBeInTheDocument();
+  });
+});

--- a/merger-tracker/frontend/src/config.js
+++ b/merger-tracker/frontend/src/config.js
@@ -29,5 +29,6 @@ export const API_ENDPOINTS = {
   phase2: '/data/phase2.json',  // Current + completed Phase 2 matters with statutory milestones
   refiledNotifications: '/data/refiled-notifications.json',  // Waivers declined then re-filed as notifications
   extensions: '/data/extensions.json',  // Phase 1 timeline extensions (day counts + reasons)
+  referralProbabilityByDay: '/data/referral-probability-by-day.json',  // P(Phase 2 referral | still undecided at business day N), positional by day
   questionnaire: (id) => `/data/questionnaires/${id}.json`,  // Questionnaire data (lazy-loaded)
 };

--- a/merger-tracker/frontend/src/pages/MergerDetail.jsx
+++ b/merger-tracker/frontend/src/pages/MergerDetail.jsx
@@ -9,6 +9,7 @@ import TrackButton from '../components/TrackButton';
 import WaiverBadge from '../components/WaiverBadge';
 import AppealBadge from '../components/AppealBadge';
 import BusinessDayProgress from '../components/BusinessDayProgress';
+import Phase2OddsReveal from '../components/Phase2OddsReveal';
 import { getBusinessDayProgress } from '../utils/businessDayProgress';
 import SEO from '../components/SEO';
 import ExternalLinkIcon from '../components/ExternalLinkIcon';
@@ -301,12 +302,14 @@ function MergerDetail() {
             <div className="flex flex-col items-end gap-2 flex-shrink-0">
               <div className="flex items-center gap-2 flex-wrap justify-end">
                 {merger.under_appeal && <AppealBadge />}
-                <StatusBadge
-                  status={merger.status}
-                  determination={merger.accc_determination}
-                  hasConditions={merger.has_conditions}
-                  appeal={merger.appeal}
-                />
+                <Phase2OddsReveal merger={merger}>
+                  <StatusBadge
+                    status={merger.status}
+                    determination={merger.accc_determination}
+                    hasConditions={merger.has_conditions}
+                    appeal={merger.appeal}
+                  />
+                </Phase2OddsReveal>
               </div>
               <TrackButton
                 active={tracked}

--- a/scripts/static_data/durations.py
+++ b/scripts/static_data/durations.py
@@ -157,10 +157,10 @@ def referral_probability_by_day(mergers: list) -> dict:
     :data:`_MAX_REFERRAL_PROBABILITY` (0.99) so the tail — where a handful of
     long referred matters push the raw share to 1.0 — never reads as certainty.
 
-    The result is published to ``referral-probability-by-day.json`` but is not
-    consumed by the frontend yet — it is a building block for a future
-    per-merger "predicted Phase 2 risk" feature that would index this curve by
-    an open matter's elapsed business days.
+    The result is published to ``referral-probability-by-day.json`` and read by
+    the frontend's per-merger "predicted Phase 2 risk" reveal, which indexes
+    this curve by an open matter's elapsed business days
+    (``probabilities[elapsed_business_days]``).
 
     Measured over completed reviews only, since a still-open matter has no known
     outcome yet. Accepts the full merger list (waivers and in-progress matters


### PR DESCRIPTION
On a Phase 1 matter still under assessment, pressing and holding the
"Under assessment" tag (touch or mouse) reveals that matter's estimated
chance of being referred to Phase 2.

The estimate reads the existing referral-probability-by-day.json curve —
P(referred to Phase 2 | still undecided at business day N) — and indexes
it by how many business days the review has been running, so the odds
climb the longer a live matter sits undecided.

Implemented as a Phase2OddsReveal wrapper around StatusBadge in the
merger detail header. It is inert for anything that isn't an eligible
Phase 1 assessment (waivers, Phase 2, decided matters, or missing dates),
rendering the child badge untouched and skipping the data fetch entirely.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01G2VSHkZmZzGfuMonCFpsMs