### PR TITLE
Fix chart caption overflow on industry page mobile

### DIFF
--- a/merger-tracker/frontend/src/components/PhaseDurationComparison.jsx
+++ b/merger-tracker/frontend/src/components/PhaseDurationComparison.jsx
@@ -18,7 +18,7 @@ function Bar({ widthPct, value, barClass, valueClass, caption, delta }) {
         </span>
       </div>
       <div className="flex items-center justify-between gap-2 mt-1">
-        <p className="text-[11px] text-gray-500 truncate">{caption}</p>
+        <p className="text-[11px] text-gray-500 truncate min-w-0" title={typeof caption === 'string' ? caption : undefined}>{caption}</p>
         {delta}
       </div>
     </>
@@ -75,7 +75,7 @@ function MetricComparison({ label, current, comparisons, subjectLabel }) {
   const barShades = ['bg-gray-400', 'bg-gray-300'];
 
   return (
-    <div>
+    <div className="min-w-0">
       <p className={`${SECTION_HEADING} mb-2.5`}>
         {label}
       </p>


### PR DESCRIPTION
Long parent industry names in the duration-comparison chart captions
forced the grid columns wider than the viewport on mobile, pushing the
bars off-screen. The captions already had `truncate`, but truncation
never took effect because the flex/grid ancestors defaulted to
`min-width: auto` and refused to shrink below their content.

Add `min-w-0` to the caption element and its containing grid column so
the ellipsis truncation works, and add a `title` so the full name is
still available on hover.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YLfRh6Pb1mrL3L2UfqHPxn