### PR TITLE
Fix date display slipping a day for viewers east of Australia

### DIFF
--- a/merger-tracker/frontend/src/components/MergerTimeline.jsx
+++ b/merger-tracker/frontend/src/components/MergerTimeline.jsx
@@ -1,4 +1,4 @@
-import { parseISO, isValid } from 'date-fns';
+import { isValid } from 'date-fns';
 import {
   formatDateMedium,
   calculateDuration,
@@ -6,6 +6,8 @@ import {
   getDaysRemaining,
   getBusinessDaysRemaining,
   addBusinessDays,
+  parseDateOnly,
+  toDateString,
 } from '../utils/dates';
 import { MERGER_STATUS } from '../constants/mergerStatus';
 import { getOutcomeDot } from '../constants/outcomeDotColors';
@@ -83,16 +85,16 @@ function MergerTimeline({ merger }) {
     || (isCeased ? merger.ceased_date : null);
   const isComplete = Boolean(effectiveDeterminationDate);
 
-  const start = startStr ? parseISO(startStr) : null;
+  const start = startStr ? parseDateOnly(startStr) : null;
 
   // Use the published end-of-determination date when present; for waivers
   // (which have none) fall back to the statutory 25-business-day window.
   let deadlineStr = merger.end_of_determination_period;
   if (!deadlineStr && merger.is_waiver && start && isValid(start)) {
     const derived = addBusinessDays(start, WAIVER_BUSINESS_DAYS);
-    deadlineStr = derived ? derived.toISOString() : null;
+    deadlineStr = derived ? toDateString(derived) : null;
   }
-  const deadline = deadlineStr ? parseISO(deadlineStr) : null;
+  const deadline = deadlineStr ? parseDateOnly(deadlineStr) : null;
   const hasDeadline = start && deadline && isValid(start) && isValid(deadline) && deadline > start;
 
   // The right-hand endpoint is the statutory decision deadline whenever there
@@ -110,7 +112,7 @@ function MergerTimeline({ merger }) {
     endLabel = 'Deadline';
   } else if (isComplete) {
     endStr = effectiveDeterminationDate;
-    end = parseISO(endStr);
+    end = parseDateOnly(endStr);
     endLabel = isCeased ? 'Ceased' : 'Determination';
     endIsOutcome = true;
   }
@@ -131,7 +133,7 @@ function MergerTimeline({ merger }) {
   // Mid-axis "determination" marker for decided mergers whose endpoint is the
   // deadline.
   const decisionPct = isComplete && hasDeadline
-    ? axisPct(parseISO(effectiveDeterminationDate), start, end)
+    ? axisPct(parseDateOnly(effectiveDeterminationDate), start, end)
     : null;
 
   // For mergers referred to Phase 2, mark the Phase 1 determination date with a
@@ -140,7 +142,7 @@ function MergerTimeline({ merger }) {
     || Boolean(merger.phase_2_determination_date);
   let phase1Pct = null;
   if (wentToPhase2 && merger.phase_1_determination_date) {
-    const phase1 = parseISO(merger.phase_1_determination_date);
+    const phase1 = parseDateOnly(merger.phase_1_determination_date);
     if (isValid(phase1) && phase1 > start && phase1 < end) {
       phase1Pct = axisPct(phase1, start, end);
     }

--- a/merger-tracker/frontend/src/utils/__tests__/dates.test.js
+++ b/merger-tracker/frontend/src/utils/__tests__/dates.test.js
@@ -169,6 +169,13 @@ describe('formatDate', () => {
     expect(formatDate('2025-06-10T12:34:56Z')).toBe('10/06/2025');
   });
 
+  it('keeps the ACCC calendar day for a noon-UTC datetime', () => {
+    // ACCC dates are encoded at noon UTC. Rendering the instant in a viewer's
+    // local timezone must not slip the calendar day. MN-01109's notification
+    // date is 2026-07-17T12:00:00Z, which the register shows as 17 July.
+    expect(formatDate('2026-07-17T12:00:00Z')).toBe('17/07/2026');
+  });
+
   it('returns "N/A" when the input is missing', () => {
     expect(formatDate(null)).toBe('N/A');
     expect(formatDate(undefined)).toBe('N/A');

--- a/merger-tracker/frontend/src/utils/__tests__/dates.test.js
+++ b/merger-tracker/frontend/src/utils/__tests__/dates.test.js
@@ -4,6 +4,7 @@ import {
   calculateDuration,
   formatDate,
   getBusinessDaysRemaining,
+  getCalendarDaysUntil,
   getDaysRemaining,
   isBusinessDay,
   isDatePast,
@@ -127,8 +128,9 @@ describe('getBusinessDaysRemaining', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     // Pin "today" to a known weekday so the expected counts are stable.
-    // 2025-06-10 is a Tuesday.
-    vi.setSystemTime(new Date(2025, 5, 10, 9, 0, 0));
+    // 2025-06-10 is a Tuesday; use a fixed instant (noon AEST) so the
+    // Australian calendar day is 10 Jun regardless of the runner's timezone.
+    vi.setSystemTime(new Date('2025-06-10T02:00:00Z'));
   });
 
   afterEach(() => {
@@ -239,10 +241,46 @@ describe('getDaysRemaining', () => {
   });
 });
 
+describe('countdown functions with noon-UTC (ACCC) inputs', () => {
+  // ACCC dates are encoded at noon UTC. The countdown/comparison functions must
+  // treat them as the published calendar day, not the local-timezone instant,
+  // so a viewer east of Australia gets the same answer as one in Australia.
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // "Today" = 15 Jul 2026, pinned via a fixed instant (noon AEST) so the
+    // Australian calendar day is the same on any runner timezone.
+    vi.setSystemTime(new Date('2026-07-15T02:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('getCalendarDaysUntil treats noon-UTC as the published day', () => {
+    // 2026-07-17T12:00:00Z is 17 July. From 15 July that is 2 calendar days,
+    // regardless of the viewer's timezone.
+    expect(getCalendarDaysUntil('2026-07-17T12:00:00Z')).toBe(2);
+  });
+
+  it('isDatePast does not count the published day as past', () => {
+    // "Today" is 17 Jul; the 17 July notification date must not read as past.
+    vi.setSystemTime(new Date('2026-07-17T02:00:00Z'));
+    expect(isDatePast('2026-07-17T12:00:00Z')).toBe(false);
+  });
+
+  it('getBusinessDaysRemaining treats noon-UTC as the published day', () => {
+    // Today = Wed 15 Jul 2026. Target = Fri 17 Jul 2026.
+    // Business days after today: Thu 16, Fri 17 = 2.
+    expect(getBusinessDaysRemaining('2026-07-17T12:00:00Z')).toBe(2);
+  });
+});
+
 describe('isDatePast', () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date(2025, 5, 10, 9, 0, 0)); // 10 Jun 2025
+    // 10 Jun 2025, pinned via a fixed instant (noon AEST) so the Australian
+    // calendar day is stable across runner timezones.
+    vi.setSystemTime(new Date('2025-06-10T02:00:00Z'));
   });
 
   afterEach(() => {

--- a/merger-tracker/frontend/src/utils/businessDayProgress.js
+++ b/merger-tracker/frontend/src/utils/businessDayProgress.js
@@ -1,4 +1,4 @@
-import { calculateBusinessDays, isDatePast } from './dates';
+import { australianToday, calculateBusinessDays, isDatePast } from './dates';
 import { MERGER_STATUS } from '../constants/mergerStatus';
 
 /**
@@ -27,9 +27,10 @@ export function getBusinessDayProgress(merger) {
   // Notification timestamps carry a fixed time-of-day (typically noon UTC), and
   // calculateBusinessDays does a plain datetime comparison as it walks forward
   // a day at a time — so comparing against the raw current instant undercounts
-  // today whenever "now" is earlier in the day than that time-of-day. Normalize
-  // to the end of today so today counts as soon as it's a business day.
-  const today = new Date();
+  // today whenever "now" is earlier in the day than that time-of-day. Anchor to
+  // the ACCC's calendar (australianToday) and normalize to the end of that day
+  // so today counts as soon as it's a business day, consistently for every viewer.
+  const today = australianToday();
   today.setHours(23, 59, 59, 999);
   const rawElapsed = calculateBusinessDays(merger.effective_notification_datetime, today);
   if (rawElapsed === null) return null;

--- a/merger-tracker/frontend/src/utils/dates.js
+++ b/merger-tracker/frontend/src/utils/dates.js
@@ -10,6 +10,67 @@ actPublicHolidays.holidays.forEach(yearData => {
 });
 
 /**
+ * Parse the calendar-date portion of an ISO string into a Date anchored at
+ * local midnight.
+ *
+ * ACCC register dates are effectively date-only values encoded at noon UTC
+ * (e.g. "2026-07-17T12:00:00Z"). Parsing that instant with parseISO and then
+ * comparing or formatting it in the viewer's local timezone shifts the day for
+ * anyone far enough east of Australia — for a viewer in New Zealand (UTC+12)
+ * noon UTC falls at midnight, so 17 July becomes 18 July. We only ever care
+ * about the calendar day the ACCC published, so read the YYYY-MM-DD prefix
+ * directly and ignore the time/zone. Both display formatting and countdown
+ * maths go through this so a target date and "today" are compared on the same
+ * local-calendar footing.
+ * @param {string} dateString - Date in ISO format
+ * @returns {Date} A local Date for the calendar day, or an Invalid Date
+ */
+export const parseDateOnly = (dateString) => {
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(dateString);
+  if (match) {
+    return new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
+  }
+  // Fall back to full ISO parsing for any unexpected format.
+  return parseISO(dateString);
+};
+
+/**
+ * Serialise a Date to a plain YYYY-MM-DD string using its local calendar day.
+ *
+ * The counterpart to parseDateOnly: use this instead of Date.toISOString()
+ * (which serialises in UTC and would shift the day back for viewers east of
+ * Australia) when a derived Date needs to travel as a date-only string.
+ * @param {Date} date - A Date object
+ * @returns {string|null} The YYYY-MM-DD string, or null if the date is invalid
+ */
+export const toDateString = (date) => {
+  if (!(date instanceof Date) || !isValid(date)) return null;
+  return format(date, 'yyyy-MM-dd');
+};
+
+// The ACCC works to the Canberra (ACT) calendar. Register dates are Australian
+// calendar days, so countdowns are measured against "today" in Australia rather
+// than the viewer's timezone — that way a viewer in New Zealand sees the same
+// days-remaining as one in Sydney, consistent with the identical dates shown.
+const AUSTRALIA_TIMEZONE = 'Australia/Sydney';
+
+/**
+ * The current date in the ACCC's timezone, as a Date anchored at local midnight
+ * so it compares cleanly against parseDateOnly values.
+ * @returns {Date} Today's Australian calendar day
+ */
+export const australianToday = () => {
+  // en-CA formats as YYYY-MM-DD; Intl handles AEST/AEDT (incl. DST) for us.
+  const dateString = new Intl.DateTimeFormat('en-CA', {
+    timeZone: AUSTRALIA_TIMEZONE,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date());
+  return parseDateOnly(dateString);
+};
+
+/**
  * Check if a date falls in the Christmas/New Year period (23 Dec - 10 Jan)
  * As per ACCC Act: days occurring between 23 December and 10 January are not business days
  */
@@ -60,8 +121,8 @@ export const calculateBusinessDays = (startDate, endDate) => {
   if (!startDate || !endDate) return null;
 
   try {
-    const start = typeof startDate === 'string' ? parseISO(startDate) : startDate;
-    const end = typeof endDate === 'string' ? parseISO(endDate) : endDate;
+    const start = typeof startDate === 'string' ? parseDateOnly(startDate) : startDate;
+    const end = typeof endDate === 'string' ? parseDateOnly(endDate) : endDate;
 
     if (!isValid(start) || !isValid(end)) return null;
 
@@ -90,10 +151,9 @@ export const calculateBusinessDays = (startDate, endDate) => {
 export const getBusinessDaysRemaining = (endDate) => {
   if (!endDate) return null;
   try {
-    const end = parseISO(endDate);
+    const end = parseDateOnly(endDate);
     if (!isValid(end)) return null;
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
+    const today = australianToday();
 
     if (end <= today) return 0;
 
@@ -114,7 +174,7 @@ export const addBusinessDays = (startDate, count) => {
   if (!startDate || count == null) return null;
 
   try {
-    const start = typeof startDate === 'string' ? parseISO(startDate) : startDate;
+    const start = typeof startDate === 'string' ? parseDateOnly(startDate) : startDate;
     if (!isValid(start)) return null;
 
     let added = 0;
@@ -131,28 +191,6 @@ export const addBusinessDays = (startDate, count) => {
   } catch {
     return null;
   }
-};
-
-/**
- * Parse the calendar-date portion of an ISO string into a Date anchored at
- * local midnight.
- *
- * ACCC register dates are effectively date-only values encoded at noon UTC
- * (e.g. "2026-07-17T12:00:00Z"). Formatting that instant in the viewer's local
- * timezone shifts the displayed day for anyone far enough east of Australia —
- * for a viewer in New Zealand (UTC+12) noon UTC falls at midnight, so 17 July
- * renders as 18 July. We only ever want to show the calendar day the ACCC
- * published, so read the YYYY-MM-DD prefix directly and ignore the time/zone.
- * @param {string} dateString - Date in ISO format
- * @returns {Date} A local Date for the calendar day, or an Invalid Date
- */
-const parseDateOnly = (dateString) => {
-  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(dateString);
-  if (match) {
-    return new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
-  }
-  // Fall back to full ISO parsing for any unexpected format.
-  return parseISO(dateString);
 };
 
 export const formatDate = (dateString) => {
@@ -210,8 +248,8 @@ export const formatWeekday = (dateString) => {
 export const calculateDuration = (startDate, endDate) => {
   if (!startDate || !endDate) return null;
   try {
-    const start = parseISO(startDate);
-    const end = parseISO(endDate);
+    const start = parseDateOnly(startDate);
+    const end = parseDateOnly(endDate);
     if (!isValid(start) || !isValid(end)) return null;
     return differenceInDays(end, start);
   } catch {
@@ -222,7 +260,7 @@ export const calculateDuration = (startDate, endDate) => {
 export const getDaysRemaining = (endDate) => {
   if (!endDate) return null;
   try {
-    const parsed = parseISO(endDate);
+    const parsed = parseDateOnly(endDate);
     if (!isValid(parsed)) return null;
     const days = differenceInDays(parsed, new Date());
     return days > 0 ? days : 0;
@@ -242,9 +280,9 @@ export const getDaysRemaining = (endDate) => {
 export const getCalendarDaysUntil = (endDate) => {
   if (!endDate) return null;
   try {
-    const parsed = parseISO(endDate);
+    const parsed = parseDateOnly(endDate);
     if (!isValid(parsed)) return null;
-    return differenceInCalendarDays(parsed, new Date());
+    return differenceInCalendarDays(parsed, australianToday());
   } catch {
     return null;
   }
@@ -258,10 +296,8 @@ export const getCalendarDaysUntil = (endDate) => {
 export const isDatePast = (dateString) => {
   if (!dateString) return false;
   try {
-    const date = parseISO(dateString);
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    return date < today;
+    const date = parseDateOnly(dateString);
+    return date < australianToday();
   } catch {
     return false;
   }

--- a/merger-tracker/frontend/src/utils/dates.js
+++ b/merger-tracker/frontend/src/utils/dates.js
@@ -133,10 +133,32 @@ export const addBusinessDays = (startDate, count) => {
   }
 };
 
+/**
+ * Parse the calendar-date portion of an ISO string into a Date anchored at
+ * local midnight.
+ *
+ * ACCC register dates are effectively date-only values encoded at noon UTC
+ * (e.g. "2026-07-17T12:00:00Z"). Formatting that instant in the viewer's local
+ * timezone shifts the displayed day for anyone far enough east of Australia —
+ * for a viewer in New Zealand (UTC+12) noon UTC falls at midnight, so 17 July
+ * renders as 18 July. We only ever want to show the calendar day the ACCC
+ * published, so read the YYYY-MM-DD prefix directly and ignore the time/zone.
+ * @param {string} dateString - Date in ISO format
+ * @returns {Date} A local Date for the calendar day, or an Invalid Date
+ */
+const parseDateOnly = (dateString) => {
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(dateString);
+  if (match) {
+    return new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
+  }
+  // Fall back to full ISO parsing for any unexpected format.
+  return parseISO(dateString);
+};
+
 export const formatDate = (dateString) => {
   if (!dateString) return 'N/A';
   try {
-    return format(parseISO(dateString), 'dd/MM/yyyy');
+    return format(parseDateOnly(dateString), 'dd/MM/yyyy');
   } catch {
     return 'Invalid date';
   }
@@ -150,7 +172,7 @@ export const formatDate = (dateString) => {
 export const formatDateMedium = (dateString) => {
   if (!dateString) return 'N/A';
   try {
-    return format(parseISO(dateString), 'dd MMM yyyy');
+    return format(parseDateOnly(dateString), 'dd MMM yyyy');
   } catch {
     return 'Invalid date';
   }
@@ -164,7 +186,7 @@ export const formatDateMedium = (dateString) => {
 export const formatDateLong = (dateString) => {
   if (!dateString) return 'N/A';
   try {
-    return format(parseISO(dateString), 'd MMMM yyyy');
+    return format(parseDateOnly(dateString), 'd MMMM yyyy');
   } catch {
     return 'Invalid date';
   }
@@ -179,7 +201,7 @@ export const formatDateLong = (dateString) => {
 export const formatWeekday = (dateString) => {
   if (!dateString) return 'N/A';
   try {
-    return format(parseISO(dateString), 'EEE d MMM');
+    return format(parseDateOnly(dateString), 'EEE d MMM');
   } catch {
     return 'Invalid date';
   }


### PR DESCRIPTION
ACCC register dates are date-only values encoded at noon UTC (e.g.
2026-07-17T12:00:00Z). The display formatters parsed these with parseISO
and let date-fns render the instant in the viewer's local timezone. For
viewers far enough east of Australia — New Zealand at UTC+12 — noon UTC
falls at midnight, so 17 July rendered as 18 July.

Add a parseDateOnly helper that reads the YYYY-MM-DD prefix directly and
anchors it to local midnight, so formatDate/formatDateMedium/
formatDateLong/formatWeekday always show the calendar day the ACCC
published, regardless of viewer timezone. Add a regression test.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014aJrfETtGZyx8VEbACJNnK