### PR TITLE
Auto-freeze only the specific events with missing dates, not the whole list

### DIFF
--- a/scripts/extract_mergers.py
+++ b/scripts/extract_mergers.py
@@ -1114,13 +1114,15 @@ def _is_catchable_event(title):
 
 
 def auto_fix_missing_event_dates(all_mergers_data, frozen_events_mergers):
-    """Detect catchable events with empty dates, set a date, and freeze the merger.
+    """Detect catchable events with empty dates, set a date, and freeze those events.
 
     Catchable event types: questionnaire, remedy offer (see _CATCHABLE_EVENT_KEYWORDS).
 
     For each merger not already frozen that has a catchable event with no date:
       1. Tries to extract the date from the event title; falls back to today at noon UTC.
-      2. Adds the merger to frozen_events_mergers.json so future scrapes preserve the date.
+      2. Adds a selective freeze to frozen_events_mergers.json listing only those
+         specific events (``freeze_events: [title, ...]``) so future scrapes preserve
+         the auto-set date(s) while every other event still updates from the page.
       3. Writes issue content to MISSING_EVENT_DATES_PATH for the pipeline to create
          GitHub issues asking the user to confirm the auto-set date is correct.
 
@@ -1188,12 +1190,19 @@ def auto_fix_missing_event_dates(all_mergers_data, frozen_events_mergers):
             f"{fe['event_title']} ({fe['date_display']})"
             for fe in item['fixed_events']
         )
+        # Freeze only the specific events whose dates we auto-set, not the whole
+        # list, so later events (e.g. a Phase 2 determination) still flow through
+        # from the scraped page. Dedupe titles while preserving order.
+        frozen_titles = list(dict.fromkeys(
+            fe['event_title'] for fe in item['fixed_events']
+        ))
         frozen_data[mid] = {
             "_comment": (
                 f"Event date(s) missing from ACCC page ({event_summaries}); "
-                "freezing events to preserve the automatically set date(s)."
+                "freezing these specific events to preserve the automatically set "
+                "date(s) while other events still update from the page."
             ),
-            "freeze_events": True,
+            "freeze_events": frozen_titles,
         }
 
     with open(FROZEN_EVENTS_MERGERS_PATH, 'w', encoding='utf-8') as f:
@@ -1217,7 +1226,8 @@ def auto_fix_missing_event_dates(all_mergers_data, frozen_events_mergers):
         body = (
             f"One or more events for **{name}** had no date on the ACCC page.\n\n"
             f"The pipeline automatically set the date(s) and froze "
-            f"the merger's events to prevent future scrapes from clearing them.\n\n"
+            f"those specific event(s) to prevent future scrapes from clearing them "
+            f"(other events for this merger still update from the ACCC page).\n\n"
             f"### Details\n\n"
             f"| Merger | [{name}]({url}) |\n"
             f"|--------|---------------|\n"

--- a/scripts/tests/test_pipeline.py
+++ b/scripts/tests/test_pipeline.py
@@ -350,6 +350,72 @@ class TestParseFreezeSpec:
         assert overrides == {"MN-3": {"status": "Approved"}}
 
 
+class TestAutoFixMissingEventDates:
+    """auto_fix_missing_event_dates sets dates on catchable events with no date,
+    and selectively freezes only those events (not the whole list) so later
+    events still update, while still writing the GitHub-issue payload."""
+
+    QUESTIONNAIRE = "Acme - Target - Questionnaire (13 Jul 2026)"
+    OTHER = "Merger notified to ACCC"
+
+    def _merger(self):
+        return {
+            "merger_id": "MN-77777",
+            "merger_name": "Acme / Target",
+            "url": "https://accc.gov.au/.../acme-target",
+            "events": [
+                {"date": "", "title": self.QUESTIONNAIRE},
+                {"date": "2026-06-01T12:00:00Z", "title": self.OTHER},
+            ],
+        }
+
+    def _run(self, tmp_path, mergers):
+        frozen_path = tmp_path / "frozen_events_mergers.json"
+        missing_path = tmp_path / "missing_event_dates.json"
+        with unittest.mock.patch.object(
+            extract_mergers, "FROZEN_EVENTS_MERGERS_PATH", str(frozen_path)
+        ), unittest.mock.patch.object(
+            extract_mergers, "MISSING_EVENT_DATES_PATH", str(missing_path)
+        ):
+            newly_frozen = extract_mergers.auto_fix_missing_event_dates(mergers, {})
+        frozen = json.loads(frozen_path.read_text()) if frozen_path.exists() else {}
+        missing = json.loads(missing_path.read_text()) if missing_path.exists() else {}
+        return newly_frozen, frozen, missing
+
+    def test_freezes_only_the_fixed_event_titles(self, tmp_path):
+        merger = self._merger()
+        newly_frozen, frozen, missing = self._run(tmp_path, [merger])
+
+        assert newly_frozen == {"MN-77777"}
+        # Selective freeze: a list of titles, not True / whole-list freeze.
+        spec = frozen["MN-77777"]["freeze_events"]
+        assert spec == [self.QUESTIONNAIRE]
+        assert spec is not True
+        # The catchable event picked up the date parsed from its title.
+        assert merger["events"][0]["date"] == "2026-07-13T12:00:00Z"
+        # The other event is untouched (and not frozen).
+        assert self.OTHER not in spec
+
+    def test_still_writes_github_issue_payload(self, tmp_path):
+        _, _, missing = self._run(tmp_path, [self._merger()])
+        assert len(missing["issues"]) == 1
+        issue = missing["issues"][0]
+        assert issue["merger_id"] == "MN-77777"
+        assert "MN-77777" in issue["title"]
+        assert issue["body"]
+
+    def test_no_catchable_events_writes_nothing(self, tmp_path):
+        merger = {
+            "merger_id": "MN-88888",
+            "merger_name": "No Questionnaire Co",
+            "events": [{"date": "", "title": self.OTHER}],
+        }
+        newly_frozen, frozen, missing = self._run(tmp_path, [merger])
+        assert newly_frozen == set()
+        assert frozen == {}
+        assert missing == {}
+
+
 # ---------------------------------------------------------------------------
 # _add_synthetic_events: determination outcome goes on the instrument
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The pipeline's missing-event-date catch (auto_fix_missing_event_dates)
wrote "freeze_events": true when it auto-set a date for a catchable event
(questionnaire, remedy offer), which froze the merger's ENTIRE event list.
That blocked every later event — e.g. a subsequent Phase 2 determination —
from ever updating off the scraped ACCC page.

Now it emits a selective freeze listing only the titles of the events whose
dates it fixed (the freeze_events: [title, ...] form added in #731), so those
specific events keep their auto-set dates while all other events for the
merger still update normally. The GitHub-issue payload written to
missing_event_dates.json is unchanged, so the confirmation issue is still
opened; its body now notes the freeze is scoped to those events.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PaWTz9vfhaga8aeXvypP22