### PR TITLE
Remove Siemens Mobility - MerMec (MN-01105) from frozen events

### DIFF
--- a/data/frozen_events_mergers.json
+++ b/data/frozen_events_mergers.json
@@ -8,12 +8,6 @@
       "Timeline extended by business days - following request for further information"
     ]
   },
-  "MN-01105": {
-    "_comment": "Event date missing from ACCC page (Siemens Mobility - MerMec - Questionnaire (13 Jul 2026)); freezing this event to preserve the automatically set date while later events still update from the page.",
-    "freeze_events": [
-      "Siemens Mobility - MerMec - Questionnaire"
-    ]
-  },
   "MN-40029": {
     "_comment": "Event date missing from ACCC page (Laundy-Woy Woy Hotel Third-party questionnaire (15 Jul 2026)); freezing this event to preserve the automatically set date while later events still update from the page.",
     "freeze_events": [


### PR DESCRIPTION
The event date is now present on the ACCC page, so the freeze is no
longer needed to preserve the automatically set date.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LpCF1dsahrAKfJ2oop6Awp