### PR TITLE
Show "Due today" instead of "Overdue" on the deadline's own day

### DIFF
--- a/merger-tracker/frontend/src/components/MergerTimeline.jsx
+++ b/merger-tracker/frontend/src/components/MergerTimeline.jsx
@@ -8,6 +8,7 @@ import {
   addBusinessDays,
   parseDateOnly,
   toDateString,
+  australianToday,
 } from '../utils/dates';
 import { MERGER_STATUS } from '../constants/mergerStatus';
 import { getOutcomeDot } from '../constants/outcomeDotColors';
@@ -149,12 +150,20 @@ function MergerTimeline({ merger }) {
   }
 
   // Progress + "today" marker, only while the assessment is still running.
+  // Overdue is judged on calendar days (ACCC's Australian "today") rather than
+  // the raw current instant, so the deadline's own day reads as "due today"
+  // instead of "overdue" from the moment it ticks over at local midnight.
   let todayPct = null;
   let overdue = false;
+  let dueToday = false;
   if (!isComplete) {
     const now = new Date();
-    if (now >= end) {
+    const today = australianToday();
+    if (today > end) {
       overdue = true;
+    } else if (today.getTime() === end.getTime()) {
+      dueToday = true;
+      todayPct = axisPct(now, start, end);
     } else if (now > start) {
       todayPct = axisPct(now, start, end);
     }
@@ -187,13 +196,17 @@ function MergerTimeline({ merger }) {
     : null;
 
   // Note under the end date: total duration when the axis ends on the
-  // determination itself, or an overdue flag when the deadline has passed.
+  // determination itself, or an overdue/due-today flag when the deadline has
+  // arrived.
   let endNote = null;
   let endNoteClass = 'text-gray-500';
   if (endIsOutcome && durationStr) {
     endNote = durationStr;
   } else if (overdue) {
     endNote = 'Overdue';
+    endNoteClass = 'font-medium text-amber-600';
+  } else if (dueToday) {
+    endNote = 'Due today';
     endNoteClass = 'font-medium text-amber-600';
   }
 

--- a/merger-tracker/frontend/src/components/__tests__/MergerTimeline.test.jsx
+++ b/merger-tracker/frontend/src/components/__tests__/MergerTimeline.test.jsx
@@ -137,6 +137,40 @@ describe('MergerTimeline', () => {
     expect(screen.getByText('Today')).toBeInTheDocument();
   });
 
+  it('shows "Due today" rather than "Overdue" on the deadline\'s own calendar day', () => {
+    // "Now" is pinned to 2026-06-01T00:00:00Z in beforeEach, which is after
+    // local midnight on the deadline day everywhere behind UTC (including
+    // Australia/Sydney) — so a naive instant comparison would already read
+    // as overdue even though the deadline day hasn't finished yet.
+    render(
+      <MergerTimeline
+        merger={{
+          effective_notification_datetime: '2026-04-01T12:00:00Z',
+          end_of_determination_period: '2026-06-01T12:00:00Z',
+          status: 'Under assessment',
+        }}
+      />
+    );
+
+    expect(screen.getByText('Due today')).toBeInTheDocument();
+    expect(screen.queryByText('Overdue')).not.toBeInTheDocument();
+  });
+
+  it('shows "Overdue" once the deadline day has fully passed', () => {
+    render(
+      <MergerTimeline
+        merger={{
+          effective_notification_datetime: '2026-04-01T12:00:00Z',
+          end_of_determination_period: '2026-05-20T12:00:00Z',
+          status: 'Under assessment',
+        }}
+      />
+    );
+
+    expect(screen.getByText('Overdue')).toBeInTheDocument();
+    expect(screen.queryByText('Due today')).not.toBeInTheDocument();
+  });
+
   it('falls back to a labelled view when no proportional axis is available', () => {
     render(
       <MergerTimeline


### PR DESCRIPTION
MergerTimeline compared the raw current instant against the deadline's
local midnight, so any merger under assessment read as overdue from
the moment its due date began — even hours before the day was over
(e.g. MN-70020). Compare calendar days via australianToday() instead,
and only show "Overdue" once the deadline day has fully passed.