### PR TITLE
Fix analysis Phase 1 overall stats to match industry pages

### DIFF
--- a/merger-tracker/frontend/public/data/analysis.json
+++ b/merger-tracker/frontend/public/data/analysis.json
@@ -64,7 +64,7 @@
       {
         "business_days": 46,
         "calendar_days": 66,
-        "in_progress": true
+        "in_progress": false
       },
       {
         "business_days": 26,
@@ -119,7 +119,7 @@
       {
         "business_days": 46,
         "calendar_days": 66,
-        "in_progress": true
+        "in_progress": false
       },
       {
         "business_days": 16,
@@ -279,12 +279,12 @@
       {
         "business_days": 58,
         "calendar_days": 89,
-        "in_progress": true
+        "in_progress": false
       },
       {
         "business_days": 27,
         "calendar_days": 40,
-        "in_progress": true
+        "in_progress": false
       },
       {
         "business_days": 17,
@@ -499,7 +499,7 @@
       {
         "business_days": 29,
         "calendar_days": 44,
-        "in_progress": true
+        "in_progress": false
       },
       {
         "business_days": 15,
@@ -664,7 +664,7 @@
       {
         "business_days": 52,
         "calendar_days": 77,
-        "in_progress": true
+        "in_progress": false
       },
       {
         "business_days": 28,
@@ -713,18 +713,18 @@
       }
     ],
     "stats": {
-      "average": 18.6,
+      "average": 19.6,
       "median": 17.0,
       "min": 15,
       "max": 59,
-      "count": 136
+      "count": 142
     },
     "calendar_stats": {
-      "average": 28.4,
+      "average": 29.9,
       "median": 26.0,
       "min": 21,
       "max": 103,
-      "count": 136
+      "count": 142
     }
   },
   "waiver_duration": {

--- a/scripts/static_data/outputs/analysis.py
+++ b/scripts/static_data/outputs/analysis.py
@@ -428,10 +428,21 @@ def generate(mergers: list) -> dict:
     waiver_mergers = filter_waivers(mergers)
 
     # --- Phase 1 duration analysis (notifications only) ---
-    phase1_durations = []
-    phase1_business_days = []
-    phase1_calendar_days = []
+    # Overall figures are collected via the shared helper so they match
+    # stats.json and the per-industry bars (industry_phase1_duration) exactly —
+    # all three now cover the same population of completed Phase 1 reviews.
+    #
+    # A completed Phase 1 review is any notification whose Phase 1 has concluded
+    # (see phase_1_end_date). Crucially that includes matters referred to Phase
+    # 2: their Phase 1 was concluded *by* the referral, so they are counted even
+    # while their Phase 2 review — and thus their final determination — is still
+    # open. Gating on determination_publication_date (as this block used to)
+    # wrongly dropped those referred-but-Phase-2-pending matters, leaving the
+    # overall bar computed over a smaller population than every other Phase 1
+    # duration figure on the site.
+    phase1_calendar_days, phase1_business_days = collect_phase_1_durations(notification_mergers)
 
+    phase1_durations = []
     for m in notification_mergers:
         start = m.get('effective_notification_datetime')
         # Measure to the Phase 1 end. For matters referred to Phase 2 this is the
@@ -448,15 +459,13 @@ def generate(mergers: list) -> dict:
         if bus_days is None:
             continue
 
-        in_progress = m.get('determination_publication_date') is None
-        if not in_progress:
-            phase1_business_days.append(bus_days)
-            if cal_days is not None:
-                phase1_calendar_days.append(cal_days)
         phase1_durations.append({
             "business_days": bus_days,
             "calendar_days": cal_days,
-            "in_progress": in_progress,
+            # Every retained entry is a completed Phase 1 review — matters still
+            # in Phase 1 have no phase_1_end_date and are skipped above — so none
+            # are in progress. Kept for the ECDF's expected schema.
+            "in_progress": False,
         })
 
     phase1_stats = {}

--- a/scripts/tests/test_static_data_outputs.py
+++ b/scripts/tests/test_static_data_outputs.py
@@ -482,6 +482,103 @@ def _referred_then_completed_phase_2_raw():
     }
 
 
+def _referred_still_in_phase_2_raw():
+    """A matter referred to Phase 2 whose Phase 2 is still open.
+
+    Phase 1 concluded at the referral (2026-01-20) so it is a *completed* Phase
+    1 review, but no final determination has been published yet
+    (``determination_publication_date`` is ``None``). This is the case the
+    analysis overall figures used to silently drop.
+    """
+    return {
+        'merger_id': 'MN-7001',
+        'merger_name': 'Referred, Phase 2 still running',
+        'status': 'Under assessment',
+        'accc_determination': None,
+        'stage': 'Phase 2 - detailed assessment',
+        'effective_notification_datetime': '2025-10-10T12:00:00Z',
+        'determination_publication_date': None,
+        'page_modified_datetime': '2026-01-20T12:30:00Z',
+        'anzsic_codes': [{'code': '0600', 'name': 'Mining'}],
+        'acquirers': ['Nu'],
+        'targets': ['Xi'],
+        'other_parties': [],
+        'url': 'https://example.com/MN-7001',
+        'events': [
+            {'title': 'Merger notified to ACCC', 'date': '2025-10-10T12:00:00Z'},
+            {'title': 'Decision to Proceed to a Phase 2 review', 'date': '2026-01-20T12:00:00Z'},
+        ],
+    }
+
+
+class TestAnalysisOverallMatchesStatsPopulation:
+    """The analysis overall Phase 1 figures must cover the same population as
+    stats.json and the analysis per-industry bars.
+
+    Regression test for the overall bar being computed only over matters with a
+    published ``determination_publication_date``, which dropped matters referred
+    to Phase 2 that were still in Phase 2 — even though their Phase 1 had
+    concluded (at referral) and every other Phase 1 duration figure on the site
+    counted them. The result was an overall average that didn't line up with the
+    "All industries" baseline on the industry pages (stats.json) or with the
+    chart's own per-industry bars.
+    """
+
+    def test_referred_still_open_matter_is_counted_in_overall(self):
+        enriched = enrich_merger(_referred_still_in_phase_2_raw())
+        payload = analysis.generate([enriched])
+        # Its Phase 1 concluded at referral, so it counts as one completed review.
+        assert payload['phase1_duration']['stats']['count'] == 1
+        assert payload['phase1_duration']['stats']['average'] is not None
+
+    def test_overall_matches_stats_and_industry_bars(self):
+        # A mix: one cleared-in-Phase-1 matter, one referred-then-concluded, and
+        # one referred-still-open. All three are completed Phase 1 reviews.
+        raws = [
+            _referred_then_completed_phase_2_raw(),
+            _referred_still_in_phase_2_raw(),
+            {
+                'merger_id': 'MN-7002',
+                'merger_name': 'Cleared in Phase 1',
+                'status': 'Assessment completed',
+                'accc_determination': 'Approved',
+                'stage': 'Phase 1 - preliminary assessment',
+                'effective_notification_datetime': '2025-11-03T12:00:00Z',
+                'determination_publication_date': '2025-11-20T12:00:00Z',
+                'page_modified_datetime': '2025-11-20T12:30:00Z',
+                'anzsic_codes': [{'code': '0600', 'name': 'Mining'}],
+                'acquirers': ['Al'],
+                'targets': ['Be'],
+                'other_parties': [],
+                'url': 'https://example.com/MN-7002',
+                'events': [
+                    {'title': 'Merger notified to ACCC', 'date': '2025-11-03T12:00:00Z'},
+                    {'title': 'Phase 1 - Determination', 'date': '2025-11-20T12:00:00Z'},
+                ],
+            },
+        ]
+        enriched = [enrich_merger(r) for r in raws]
+
+        analysis_payload = analysis.generate(enriched)
+        stats_payload = stats.generate(enriched)
+
+        overall = analysis_payload['phase1_duration']['stats']
+        # All three matters are completed Phase 1 reviews, so the count and
+        # average must match the stats.json baseline exactly.
+        assert overall['count'] == 3
+        assert overall['average'] == round(
+            stats_payload['phase_duration']['average_business_days'], 1
+        )
+        assert overall['median'] == stats_payload['phase_duration']['median_business_days']
+
+        # And the single ANZSIC division present must agree with the overall bar,
+        # since every matter is tagged to Mining (0600 → division B).
+        industry_bars = analysis_payload['industry_phase1_duration']
+        assert len(industry_bars) == 1
+        assert industry_bars[0]['count'] == overall['count']
+        assert industry_bars[0]['average_business_days'] == overall['average']
+
+
 class TestPhase1DurationExcludesPhase2Clock:
     """A Phase-2-referred matter must be measured to the referral date, never
     to the later Phase 2 determination, which would inflate Phase 1 durations.


### PR DESCRIPTION
The Analysis page's overall Phase 1 duration figure was computed over a
different population than every other Phase 1 duration figure on the site,
so it did not line up with the "All industries" baseline on the industry
detail pages (nor with the analysis chart's own per-industry bars).

The overall block in analysis.generate() gated each matter on
determination_publication_date being set, which silently dropped matters
referred to Phase 2 whose Phase 2 review is still open. Those matters have
a *completed* Phase 1 (concluded at the referral), and stats.json,
industries.py and the analysis per-industry bars all count them via the
shared collect_phase_1_durations helper. The overall bar was the only
outlier.

Compute the overall stats via collect_phase_1_durations so all three cover
the same completed-Phase-1 population. This moves the overall figure from
18.6 business days (n=136) to 19.6 (n=142), matching stats.json. The
per-matter durations list (consumed by the ECDF) no longer carries a
misleading in_progress flag: every retained entry is a completed Phase 1
review, so none are in progress.

Adds a regression test asserting the analysis overall figures, stats.json
and the per-industry bars agree for a referred-still-open matter.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C88AYxJnMVfQ36mxNFQjVq