### PR TITLE
Unfreeze MN-40029 events

### DIFF
--- a/data/frozen_events_mergers.json
+++ b/data/frozen_events_mergers.json
@@ -8,12 +8,6 @@
       "Timeline extended by business days - following request for further information"
     ]
   },
-  "MN-40029": {
-    "_comment": "Event date missing from ACCC page (Laundy-Woy Woy Hotel Third-party questionnaire (15 Jul 2026)); freezing this event to preserve the automatically set date while later events still update from the page.",
-    "freeze_events": [
-      "Laundy-Woy Woy Hotel Third-party questionnaire"
-    ]
-  },
   "MN-65026": {
     "_comment": "Event date(s) missing from ACCC page (McCarroll's - Kinghorn Motors and Country Motors - Questionnaire (22 Jul 2026)); freezing these specific events to preserve the automatically set date(s) while other events still update from the page.",
     "freeze_events": [


### PR DESCRIPTION
The ACCC page now carries the date for the "Laundy-Woy Woy Hotel
Third-party questionnaire" event, so the manual override that was
preserving it is no longer needed and future scrapes can update this
merger's events normally.