### PR TITLE
Stack date under title in New mergers digest table on mobile

### DIFF
--- a/merger-tracker/frontend/src/pages/Digest.jsx
+++ b/merger-tracker/frontend/src/pages/Digest.jsx
@@ -125,18 +125,25 @@ function DeterminationCell({ merger, colorKey, defaultDetermination, getDetermin
   );
 }
 
-function ClearedSection({ mergers, getDeterminationPdf }) {
-  const colorKey = DIGEST_COLOR_KEYS.CLEARED;
+function GroupedDeterminationSection({
+  id,
+  title,
+  emptyMessage,
+  colorKey,
+  mergers,
+  matchValues,
+  defaultDetermination,
+  getDeterminationPdf,
+  rowHoverClass,
+  groupHeaderBgClass,
+}) {
   const c = COLOR_CLASSES[colorKey];
   const columns = ['Merger', { label: 'Determination date', thClassName: 'hidden sm:table-cell' }, 'Determination'];
 
-  const phase2 = mergers.filter(m => m.phase_2_determination === MERGER_STATUS.APPROVED);
-  const phase1 = mergers.filter(
-    m => m.phase_1_determination === MERGER_STATUS.APPROVED && m.phase_2_determination !== MERGER_STATUS.APPROVED
-  );
-  const general = mergers.filter(
-    m => m.phase_2_determination !== MERGER_STATUS.APPROVED && m.phase_1_determination !== MERGER_STATUS.APPROVED
-  );
+  const isMatch = (value) => matchValues.includes(value);
+  const phase2 = mergers.filter(m => isMatch(m.phase_2_determination));
+  const phase1 = mergers.filter(m => isMatch(m.phase_1_determination) && !isMatch(m.phase_2_determination));
+  const general = mergers.filter(m => !isMatch(m.phase_2_determination) && !isMatch(m.phase_1_determination));
 
   const groups = [
     { label: 'Phase 2 – detailed assessment', items: phase2 },
@@ -145,7 +152,7 @@ function ClearedSection({ mergers, getDeterminationPdf }) {
   ].filter(g => g.items.length > 0);
 
   const renderRow = (merger) => (
-    <tr key={merger.merger_id} className="relative hover:bg-cleared-pale/40 transition-colors">
+    <tr key={merger.merger_id} className={`relative ${rowHoverClass} transition-colors`}>
       <MergerNameCell
         merger={merger}
         colorKey={colorKey}
@@ -166,23 +173,23 @@ function ClearedSection({ mergers, getDeterminationPdf }) {
       <DeterminationCell
         merger={merger}
         colorKey={colorKey}
-        defaultDetermination={MERGER_STATUS.APPROVED}
+        defaultDetermination={defaultDetermination}
         getDeterminationPdf={getDeterminationPdf}
       />
     </tr>
   );
 
   return (
-    <div id="mergers-approved" className={`bg-white rounded-2xl border-l-4 ${c.borderLeft} border-t border-r border-b border-gray-100 shadow-card overflow-hidden`}>
+    <div id={id} className={`bg-white rounded-2xl border-l-4 ${c.borderLeft} border-t border-r border-b border-gray-100 shadow-card overflow-hidden`}>
       <div className={`px-5 sm:px-6 py-4 border-b ${c.borderLight} bg-gradient-to-r ${c.headerBg} to-transparent`}>
         <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-gray-900">Mergers approved</h2>
+          <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
           <ScrollToTopButton />
         </div>
       </div>
       {mergers.length === 0 ? (
         <div className="px-5 sm:px-6 py-4">
-          <p className={`${c.emptyText} text-sm`}>No mergers approved this week</p>
+          <p className={`${c.emptyText} text-sm`}>{emptyMessage}</p>
         </div>
       ) : (
         <div className="overflow-x-auto">
@@ -204,7 +211,7 @@ function ClearedSection({ mergers, getDeterminationPdf }) {
               {groups.map((group) => (
                 <Fragment key={group.label}>
                   <tr>
-                    <td colSpan={3} className="px-5 sm:px-6 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider bg-cleared-pale/20 border-t border-gray-100">
+                    <td colSpan={3} className={`px-5 sm:px-6 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider ${groupHeaderBgClass} border-t border-gray-100`}>
                       {group.label}
                     </td>
                   </tr>
@@ -505,9 +512,17 @@ function Digest() {
             )}
           />
 
-          <ClearedSection
+          <GroupedDeterminationSection
+            id="mergers-approved"
+            title="Mergers approved"
+            emptyMessage="No mergers approved this week"
+            colorKey={DIGEST_COLOR_KEYS.CLEARED}
             mergers={digest.deals_cleared}
+            matchValues={[MERGER_STATUS.APPROVED]}
+            defaultDetermination={MERGER_STATUS.APPROVED}
             getDeterminationPdf={getDeterminationPdf}
+            rowHoverClass="hover:bg-cleared-pale/40"
+            groupHeaderBgClass="bg-cleared-pale/20"
           />
 
           {ceasedMergers.length > 0 && (
@@ -552,35 +567,17 @@ function Digest() {
             )}
           />
 
-          <DigestSection
+          <GroupedDeterminationSection
             id="mergers-declined"
             title="Mergers declined"
             emptyMessage="No mergers declined this week"
             colorKey={DIGEST_COLOR_KEYS.DECLINED}
             mergers={digest.deals_declined}
-            columns={['Merger', { label: 'Determination date', thClassName: 'hidden sm:table-cell' }, 'Determination']}
-            renderRow={(merger) => (
-              <tr key={merger.merger_id} className="relative hover:bg-declined-pale/40 transition-colors">
-                <MergerNameCell
-                  merger={merger}
-                  colorKey={DIGEST_COLOR_KEYS.DECLINED}
-                  hideWaiverBadge
-                  mobileMeta={
-                    <span>
-                      Determined {merger.determination_publication_date
-                        ? formatDate(merger.determination_publication_date)
-                        : 'N/A'}
-                    </span>
-                  }
-                />
-                <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600 hidden sm:table-cell">
-                  {merger.determination_publication_date
-                    ? formatDate(merger.determination_publication_date)
-                    : 'N/A'}
-                </td>
-                <DeterminationCell merger={merger} colorKey={DIGEST_COLOR_KEYS.DECLINED} defaultDetermination={MERGER_STATUS.NOT_APPROVED} getDeterminationPdf={getDeterminationPdf} />
-              </tr>
-            )}
+            matchValues={[MERGER_STATUS.NOT_APPROVED, MERGER_STATUS.DECLINED]}
+            defaultDetermination={MERGER_STATUS.NOT_APPROVED}
+            getDeterminationPdf={getDeterminationPdf}
+            rowHoverClass="hover:bg-declined-pale/40"
+            groupHeaderBgClass="bg-declined-pale/20"
           />
 
           {appealedMergers.length > 0 && (

--- a/merger-tracker/frontend/src/pages/Digest.jsx
+++ b/merger-tracker/frontend/src/pages/Digest.jsx
@@ -596,16 +596,33 @@ function Digest() {
             emptyMessage="No ongoing phase 1 mergers"
             colorKey={DIGEST_COLOR_KEYS.PHASE_1}
             mergers={digest.ongoing_phase_1}
-            columns={['Merger', 'Notification date', 'Determination due date', 'Summary']}
+            columns={['Merger', { label: 'Notification date', thClassName: 'hidden sm:table-cell' }, { label: 'Determination due date', thClassName: 'hidden sm:table-cell' }, 'Summary']}
             renderRow={(merger) => (
               <tr key={merger.merger_id} className="relative hover:bg-phase-1-pale/40 transition-colors">
-                <MergerNameCell merger={merger} colorKey={DIGEST_COLOR_KEYS.PHASE_1} />
-                <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                <MergerNameCell
+                  merger={merger}
+                  colorKey={DIGEST_COLOR_KEYS.PHASE_1}
+                  mobileMeta={
+                    <>
+                      <div>
+                        Notified {merger.effective_notification_datetime
+                          ? formatDate(merger.effective_notification_datetime)
+                          : 'N/A'}
+                      </div>
+                      <div>
+                        Determination due {merger.end_of_determination_period
+                          ? formatDate(merger.end_of_determination_period)
+                          : 'N/A'}
+                      </div>
+                    </>
+                  }
+                />
+                <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600 hidden sm:table-cell">
                   {merger.effective_notification_datetime
                     ? formatDate(merger.effective_notification_datetime)
                     : 'N/A'}
                 </td>
-                <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600 hidden sm:table-cell">
                   {merger.end_of_determination_period
                     ? formatDate(merger.end_of_determination_period)
                     : 'N/A'}
@@ -627,16 +644,33 @@ function Digest() {
             emptyMessage="No ongoing phase 2 mergers"
             colorKey={DIGEST_COLOR_KEYS.PHASE_2}
             mergers={digest.ongoing_phase_2}
-            columns={['Merger', 'Notification date', 'Determination due date', 'Summary']}
+            columns={['Merger', { label: 'Notification date', thClassName: 'hidden sm:table-cell' }, { label: 'Determination due date', thClassName: 'hidden sm:table-cell' }, 'Summary']}
             renderRow={(merger) => (
               <tr key={merger.merger_id} className="relative hover:bg-phase-2-pale/40 transition-colors">
-                <MergerNameCell merger={merger} colorKey={DIGEST_COLOR_KEYS.PHASE_2} />
-                <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                <MergerNameCell
+                  merger={merger}
+                  colorKey={DIGEST_COLOR_KEYS.PHASE_2}
+                  mobileMeta={
+                    <>
+                      <div>
+                        Notified {merger.effective_notification_datetime
+                          ? formatDate(merger.effective_notification_datetime)
+                          : 'N/A'}
+                      </div>
+                      <div>
+                        Determination due {merger.end_of_determination_period
+                          ? formatDate(merger.end_of_determination_period)
+                          : 'N/A'}
+                      </div>
+                    </>
+                  }
+                />
+                <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600 hidden sm:table-cell">
                   {merger.effective_notification_datetime
                     ? formatDate(merger.effective_notification_datetime)
                     : 'N/A'}
                 </td>
-                <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600 hidden sm:table-cell">
                   {merger.end_of_determination_period
                     ? formatDate(merger.end_of_determination_period)
                     : 'N/A'}

--- a/merger-tracker/frontend/src/pages/Digest.jsx
+++ b/merger-tracker/frontend/src/pages/Digest.jsx
@@ -77,7 +77,7 @@ function DigestSection({ id, title, emptyMessage, colorKey, mergers, columns, re
   );
 }
 
-function MergerNameCell({ merger, colorKey, mobileMeta }) {
+function MergerNameCell({ merger, colorKey, mobileMeta, hideWaiverBadge }) {
   const c = COLOR_CLASSES[colorKey];
   return (
     <td className="px-5 sm:px-6 py-4 text-sm text-gray-900">
@@ -89,7 +89,7 @@ function MergerNameCell({ merger, colorKey, mobileMeta }) {
         >
           {merger.merger_name}
         </Link>
-        {merger.is_waiver && <WaiverBadge className="relative z-10" />}
+        {merger.is_waiver && !hideWaiverBadge && <WaiverBadge className="relative z-10" />}
       </div>
       <div className="text-xs text-gray-500 mt-0.5">
         <span>{merger.merger_id}</span>
@@ -128,7 +128,7 @@ function DeterminationCell({ merger, colorKey, defaultDetermination, getDetermin
 function ClearedSection({ mergers, getDeterminationPdf }) {
   const colorKey = DIGEST_COLOR_KEYS.CLEARED;
   const c = COLOR_CLASSES[colorKey];
-  const columns = ['Merger', 'Determination date', 'Determination'];
+  const columns = ['Merger', { label: 'Determination date', thClassName: 'hidden sm:table-cell' }, 'Determination'];
 
   const phase2 = mergers.filter(m => m.phase_2_determination === MERGER_STATUS.APPROVED);
   const phase1 = mergers.filter(
@@ -146,8 +146,19 @@ function ClearedSection({ mergers, getDeterminationPdf }) {
 
   const renderRow = (merger) => (
     <tr key={merger.merger_id} className="relative hover:bg-cleared-pale/40 transition-colors">
-      <MergerNameCell merger={merger} colorKey={colorKey} />
-      <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+      <MergerNameCell
+        merger={merger}
+        colorKey={colorKey}
+        hideWaiverBadge
+        mobileMeta={
+          <span>
+            Determined {merger.determination_publication_date
+              ? formatDate(merger.determination_publication_date)
+              : 'N/A'}
+          </span>
+        }
+      />
+      <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600 hidden sm:table-cell">
         {merger.determination_publication_date
           ? formatDate(merger.determination_publication_date)
           : 'N/A'}
@@ -178,11 +189,15 @@ function ClearedSection({ mergers, getDeterminationPdf }) {
           <table className="min-w-full divide-y divide-gray-100">
             <thead>
               <tr className="bg-gray-50/80">
-                {columns.map((col) => (
-                  <th key={col} scope="col" className={`px-5 sm:px-6 py-3.5 text-left ${SECTION_HEADING}`}>
-                    {col}
-                  </th>
-                ))}
+                {columns.map((col) => {
+                  const label = typeof col === 'string' ? col : col.label;
+                  const thClassName = typeof col === 'string' ? '' : (col.thClassName || '');
+                  return (
+                    <th key={label} scope="col" className={`px-5 sm:px-6 py-3.5 text-left ${SECTION_HEADING} ${thClassName}`}>
+                      {label}
+                    </th>
+                  );
+                })}
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-50">
@@ -434,7 +449,7 @@ function Digest() {
         <DigestSignup />
 
         {/* Summary Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-6 gap-4 mb-8">
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4 mb-8">
           {summaryCards.map(({ id, colorKey, count, label }) => {
             const c = COLOR_CLASSES[colorKey];
             return (
@@ -543,11 +558,22 @@ function Digest() {
             emptyMessage="No mergers declined this week"
             colorKey={DIGEST_COLOR_KEYS.DECLINED}
             mergers={digest.deals_declined}
-            columns={['Merger', 'Determination date', 'Determination']}
+            columns={['Merger', { label: 'Determination date', thClassName: 'hidden sm:table-cell' }, 'Determination']}
             renderRow={(merger) => (
               <tr key={merger.merger_id} className="relative hover:bg-declined-pale/40 transition-colors">
-                <MergerNameCell merger={merger} colorKey={DIGEST_COLOR_KEYS.DECLINED} />
-                <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                <MergerNameCell
+                  merger={merger}
+                  colorKey={DIGEST_COLOR_KEYS.DECLINED}
+                  hideWaiverBadge
+                  mobileMeta={
+                    <span>
+                      Determined {merger.determination_publication_date
+                        ? formatDate(merger.determination_publication_date)
+                        : 'N/A'}
+                    </span>
+                  }
+                />
+                <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600 hidden sm:table-cell">
                   {merger.determination_publication_date
                     ? formatDate(merger.determination_publication_date)
                     : 'N/A'}

--- a/merger-tracker/frontend/src/pages/Digest.jsx
+++ b/merger-tracker/frontend/src/pages/Digest.jsx
@@ -56,11 +56,15 @@ function DigestSection({ id, title, emptyMessage, colorKey, mergers, columns, re
           <table className="min-w-full divide-y divide-gray-100">
             <thead>
               <tr className="bg-gray-50/80">
-                {columns.map((col) => (
-                  <th key={col} scope="col" className={`px-5 sm:px-6 py-3.5 text-left ${SECTION_HEADING}`}>
-                    {col}
-                  </th>
-                ))}
+                {columns.map((col) => {
+                  const label = typeof col === 'string' ? col : col.label;
+                  const thClassName = typeof col === 'string' ? '' : (col.thClassName || '');
+                  return (
+                    <th key={label} scope="col" className={`px-5 sm:px-6 py-3.5 text-left ${SECTION_HEADING} ${thClassName}`}>
+                      {label}
+                    </th>
+                  );
+                })}
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-50">
@@ -73,7 +77,7 @@ function DigestSection({ id, title, emptyMessage, colorKey, mergers, columns, re
   );
 }
 
-function MergerNameCell({ merger, colorKey }) {
+function MergerNameCell({ merger, colorKey, mobileMeta }) {
   const c = COLOR_CLASSES[colorKey];
   return (
     <td className="px-5 sm:px-6 py-4 text-sm text-gray-900">
@@ -90,6 +94,9 @@ function MergerNameCell({ merger, colorKey }) {
       <div className="text-xs text-gray-500 mt-0.5">
         <span>{merger.merger_id}</span>
       </div>
+      {mobileMeta && (
+        <div className="text-xs text-gray-500 mt-1 sm:hidden">{mobileMeta}</div>
+      )}
     </td>
   );
 }
@@ -453,11 +460,21 @@ function Digest() {
             emptyMessage="No new mergers this week"
             colorKey={DIGEST_COLOR_KEYS.NEW_MERGER}
             mergers={digest.new_deals_notified}
-            columns={['Merger', 'Notification date', 'Summary']}
+            columns={['Merger', { label: 'Notification date', thClassName: 'hidden sm:table-cell' }, 'Summary']}
             renderRow={(merger) => (
               <tr key={merger.merger_id} className="relative hover:bg-new-merger-pale/40 transition-colors">
-                <MergerNameCell merger={merger} colorKey={DIGEST_COLOR_KEYS.NEW_MERGER} />
-                <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                <MergerNameCell
+                  merger={merger}
+                  colorKey={DIGEST_COLOR_KEYS.NEW_MERGER}
+                  mobileMeta={
+                    <span>
+                      Notified {merger.effective_notification_datetime
+                        ? formatDate(merger.effective_notification_datetime)
+                        : 'N/A'}
+                    </span>
+                  }
+                />
+                <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600 hidden sm:table-cell">
                   {merger.effective_notification_datetime
                     ? formatDate(merger.effective_notification_datetime)
                     : 'N/A'}


### PR DESCRIPTION
On mobile, the New mergers table now shows the notification date beneath
the merger title (in the same cell) rather than in its own column, freeing
that space so the summary paragraph gets roughly double the width. Desktop
(sm and up) keeps the existing three-column layout.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PSsrBDggKpyphTkyyXZESM