### PR TITLE
Add ongoing tribunal appeals section to weekly digest

### DIFF
--- a/data/digest-archive/digest-2026-07-20.json
+++ b/data/digest-archive/digest-2026-07-20.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-26T09:34:50.312350+10:00",
+  "generated_at": "2026-07-27T07:35:15.428096+10:00",
   "period_start": "2026-07-20T00:00:00+10:00",
   "period_end": "2026-07-26T23:59:59.999999+10:00",
   "new_deals_notified": [
@@ -4815,6 +4815,262 @@
       ],
       "under_appeal": false,
       "appeal": null
+    }
+  ],
+  "ongoing_tribunal_appeals": [
+    {
+      "merger_id": "MN-01068",
+      "merger_name": "Coles – supermarket and liquor site in Kalgoorlie, WA",
+      "url": "https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/coles-%E2%80%93-supermarket-and-liquor-site-in-kalgoorlie-wa",
+      "acquirers": [
+        {
+          "name": "COLES SUPERMARKETS AUSTRALIA PTY LTD",
+          "identifier_type": "ABN",
+          "identifier": "45 004 189 708"
+        }
+      ],
+      "targets": [
+        {
+          "name": "M Holdings 4 Pty Ltd",
+          "identifier_type": "ACN",
+          "identifier": "652 075 799"
+        }
+      ],
+      "effective_notification_datetime": "2025-11-27T12:00:00Z",
+      "determination_publication_date": "2026-07-01T12:00:00Z",
+      "end_of_determination_period": "2026-07-02T12:00:00Z",
+      "accc_determination": "Not approved",
+      "stage": "Phase 2 - detailed assessment",
+      "status": "Assessment completed",
+      "is_waiver": false,
+      "phase_1_determination": "Referred to phase 2",
+      "phase_1_determination_date": "2026-01-29T12:00:00Z",
+      "phase_2_determination": "Not approved",
+      "ceased_date": null,
+      "merger_description": "Coles Group Limited (Coles), via its subsidiary Coles Supermarkets Australia Pty Ltd, has signed a Letter of Offer to facilitate Coles acquiring a leasehold interest in a new neighbourhood centre at Lots 95-106 Great Western Highway, Somerville, Kalgoorlie (the **Property**).",
+      "events": [
+        {
+          "date": "2025-11-28T12:00:00Z",
+          "title": "Questionnaire – Coles - supermarket and liquor site in Kalgoorlie, WA",
+          "display_title": "Questionnaire released for Coles acquisition of supermarket and liquor site in Kalgoorlie, WA",
+          "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/Questionnaire%20%E2%80%93%20Coles%20-%20supermarket%20and%20liquor%20site%20in%20Kalgoorlie%2C%20WA%20-%2028.11.2025.docx",
+          "url_gh": "/mergers/MN-01068/Questionnaire – Coles - supermarket and liquor site in Kalgoorlie, WA - 28.11.2025.pdf",
+          "status": "removed",
+          "phase": null
+        },
+        {
+          "date": "2025-11-27T12:00:00Z",
+          "title": "Merger notified to ACCC",
+          "display_title": "Merger notified to ACCC",
+          "phase": "Phase 1"
+        },
+        {
+          "date": "2026-05-13T12:00:00Z",
+          "title": "Timeline extended by 6 business days – following request for further information",
+          "display_title": "Timeline extended by 6 business days – following request for further information",
+          "phase": null
+        },
+        {
+          "date": "2026-05-25T12:00:00Z",
+          "title": "Timeline extended by 4 business days – following request for further information",
+          "display_title": "Timeline extended by 4 business days – following request for further information",
+          "phase": null
+        },
+        {
+          "date": "2026-05-18T12:00:00Z",
+          "title": "Timeline extended by 4 business days – following request for further information",
+          "display_title": "Timeline extended by 4 business days – following request for further information",
+          "phase": null
+        },
+        {
+          "date": "2026-06-30T12:00:00Z",
+          "title": "Phase 2 determination - Statement of reasons",
+          "display_title": "Phase 2 determination - Statement of reasons",
+          "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/Coles%20Kalgoorlie%20-%20PUBLIC%20VERSION%20-%20FINAL%20-%20Phase%202%20-%20Statement%20of%20Reasons%20-%2030%20June%202026.pdf",
+          "determination_commission_division": null,
+          "determination_table_content": [
+            {
+              "item": "",
+              "details": "Combined Coles\nCombined Coles"
+            }
+          ],
+          "url_gh": "/mergers/MN-01068/Coles Kalgoorlie - PUBLIC VERSION - FINAL - Phase 2 - Statement of Reasons - 30 June 2026.pdf",
+          "status": "live",
+          "phase": "Phase 2"
+        },
+        {
+          "date": "2026-06-30T12:00:00Z",
+          "title": "Phase 2 determination - Summary of reasons",
+          "display_title": "Phase 2 determination - Summary of reasons",
+          "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/Coles%20Kalgoorlie%20-%20FINAL%20-%20Phase%202%20-%20Determination%20-%20Summary%20of%20Reasons%20-%20AR%20version%20-%2030%20June%202026_1.pdf",
+          "determination_commission_division": null,
+          "determination_table_content": [],
+          "url_gh": "/mergers/MN-01068/Coles Kalgoorlie - FINAL - Phase 2 - Determination - Summary of Reasons - AR version - 30 June 2026_1.pdf",
+          "status": "live",
+          "phase": "Phase 2"
+        },
+        {
+          "date": "2026-06-30T12:00:00Z",
+          "title": "Phase 2 determination",
+          "display_title": "Phase 2 - detailed assessment determination: Not approved",
+          "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/Coles%20Kalgoorlie%20-%20FINAL%20-%20Phase%202%20-%20Determination%20-%20AR%20version%20-%2030%20June%202026_0.pdf",
+          "determination_commission_division": "Determination made by a division of the Commission constituted by a direction issued pursuant to section 19 of the Act",
+          "determination_table_content": [
+            {
+              "item": "Determination",
+              "details": "made by a division of the Commission constituted by a direction issued pursuant to section 19 of the Act 1"
+            }
+          ],
+          "url_gh": "/mergers/MN-01068/Coles Kalgoorlie - FINAL - Phase 2 - Determination - AR version - 30 June 2026_0.pdf",
+          "status": "live",
+          "is_determination_event": true,
+          "phase": "Phase 2"
+        },
+        {
+          "date": "2026-03-06T12:00:00Z",
+          "title": "Summary of Notice of Competition Concerns",
+          "display_title": "Summary of Notice of Competition Concerns",
+          "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/Coles_Kalgoorlie%20-%20Final%20-%20Summary%20of%20Notice%20of%20Competition%20Concerns%20-%20March%202026_5.pdf",
+          "url_gh": "/mergers/MN-01068/Coles_Kalgoorlie - Final - Summary of Notice of Competition Concerns - March 2026_5.pdf",
+          "status": "live",
+          "phase": null
+        },
+        {
+          "date": "2026-01-29T12:00:00Z",
+          "title": "ACCC decided notification is subject to Phase 2 review",
+          "display_title": "ACCC decided notification is subject to Phase 2 review",
+          "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/%20Kalgoorlie%20-%20Decision%20to%20Proceed%20to%20Phase%202%20review%20-%2029%20January%202026_5.pdf",
+          "phase2_notice_matters_to_investigate": [
+            {
+              "heading": "Relevant areas of competition",
+              "items": [
+                "The extent convenience stores and small supermarkets compete with full-line supermarkets such as the Proposed Supermarket.",
+                "The extent to which consumers in Kalgoorlie routinely travel to do their grocery shopping, and how far they do so."
+              ]
+            },
+            {
+              "heading": "Potential over-supply of supermarket capacity that could induce the exit of effective competitors",
+              "items": [
+                "The level of market concentration in the south/south-western end of Kalgoorlie and Kalgoorlie generally before and after the Acquisition.",
+                "The competitive offerings of each supermarket competitor in Kalgoorlie (including but not limited to price, quality, product range and service) and the intensity with which they compete in the relevant markets.",
+                "Price, quality, product range and service differentials between the major and independent supermarkets in Kalgoorlie.",
+                "The likelihood and viability of new entry and expansion in Kalgoorlie to increase competitive intensity with the Proposed Supermarket, including further consideration of suitable supermarket sites, planning and zoning requirements, and likely population growth.",
+                "The profitability of Coles and independent supermarket(s) in Kalgoorlie should the Acquisition proceed.",
+                "The impact on the level of competitive constraint imposed by existing rival supermarkets in Kalgoorlie should the Acquisition proceed.",
+                "The effect on competition should one or more competitor supermarket(s) exit following the expansion of Coles via the Proposed Supermarket."
+              ]
+            },
+            {
+              "heading": "Creating, strengthening or entrenching a substantial degree of market power",
+              "items": [
+                "Whether or not Coles has, or is likely to have, substantial market power.",
+                "The likely economic rationale for Coles opening the Proposed Supermarket, including its dependence on the level and nature of future competition in the relevant market.",
+                "Whether the Acquisition is likely to reduce competitive constraint.",
+                "Whether the Acquisition would, in all the circumstances, be likely to have the effect of creating, strengthening or entrenching a substantial degree of power in the local market."
+              ]
+            }
+          ],
+          "phase2_notice_commission_division": null,
+          "url_gh": "/mergers/MN-01068/Kalgoorlie - Decision to Proceed to Phase 2 review - 29 January 2026_5.pdf",
+          "status": "live",
+          "phase": "Phase 2"
+        },
+        {
+          "date": "2026-07-21T12:00:00Z",
+          "title": "Directions",
+          "display_title": "Tribunal appeal – Directions",
+          "url": "https://www.competitiontribunal.gov.au/__data/assets/pdf_file/0020/600284/Directions.pdf",
+          "url_gh": "/mergers/MN-01068/Directions.pdf",
+          "is_appeal": true,
+          "appeal_filed_by": "-",
+          "appeal_confidentiality": "Non-confidential",
+          "tribunal_number": "ACT 1 of 2026",
+          "phase": null
+        },
+        {
+          "date": "2026-07-20T12:00:00Z",
+          "title": "Application for Leave to Intervene",
+          "display_title": "Tribunal appeal – Application for Leave to Intervene",
+          "url": "https://www.competitiontribunal.gov.au/__data/assets/pdf_file/0003/600285/OConnor-Fresh-IGA-Application-for-Leave-to-Intervene.pdf",
+          "url_gh": "/mergers/MN-01068/OConnor-Fresh-IGA-Application-for-Leave-to-Intervene.pdf",
+          "is_appeal": true,
+          "appeal_filed_by": "O'Connor Fresh IGA",
+          "appeal_confidentiality": "Non-confidential",
+          "tribunal_number": "ACT 1 of 2026",
+          "phase": null
+        },
+        {
+          "date": "2026-07-15T12:00:00Z",
+          "title": "Notice of address for service",
+          "display_title": "Tribunal appeal – Notice of address for service",
+          "url": "https://www.competitiontribunal.gov.au/__data/assets/pdf_file/0012/599808/Notice-of-Address-for-Service-ACCC.pdf",
+          "url_gh": "/mergers/MN-01068/Notice-of-Address-for-Service-ACCC.pdf",
+          "is_appeal": true,
+          "appeal_filed_by": "Australian Competition and Consumer Commission",
+          "appeal_confidentiality": "Non-confidential",
+          "tribunal_number": "ACT 1 of 2026",
+          "phase": null
+        },
+        {
+          "date": "2026-07-15T12:00:00Z",
+          "title": "Application for review",
+          "display_title": "Tribunal appeal – Application for review",
+          "url": "https://www.competitiontribunal.gov.au/__data/assets/pdf_file/0008/599732/Application-for-Review.pdf",
+          "url_gh": "/mergers/MN-01068/Application-for-Review.pdf",
+          "is_appeal": true,
+          "appeal_filed_by": "Coles Supermarkets",
+          "appeal_confidentiality": "Non-confidential",
+          "tribunal_number": "ACT 1 of 2026",
+          "phase": null
+        }
+      ],
+      "under_appeal": true,
+      "appeal": {
+        "tribunal_number": "ACT 1 of 2026",
+        "tribunal_url": "https://www.competitiontribunal.gov.au/current-matters/act-1-of-2026",
+        "appeal_type": "party_denial",
+        "appellant": "Coles",
+        "status": "current",
+        "outcome": null,
+        "effective_determination": null,
+        "filed_date": "2026-07-15",
+        "hearing_date": "2026-11-09",
+        "concluded_date": null,
+        "documents": [
+          {
+            "date": "2026-07-21",
+            "filed_by": "-",
+            "description": "Directions",
+            "confidentiality": "Non-confidential",
+            "url": "https://www.competitiontribunal.gov.au/__data/assets/pdf_file/0020/600284/Directions.pdf",
+            "url_gh": "/mergers/MN-01068/Directions.pdf"
+          },
+          {
+            "date": "2026-07-20",
+            "filed_by": "O'Connor Fresh IGA",
+            "description": "Application for Leave to Intervene",
+            "confidentiality": "Non-confidential",
+            "url": "https://www.competitiontribunal.gov.au/__data/assets/pdf_file/0003/600285/OConnor-Fresh-IGA-Application-for-Leave-to-Intervene.pdf",
+            "url_gh": "/mergers/MN-01068/OConnor-Fresh-IGA-Application-for-Leave-to-Intervene.pdf"
+          },
+          {
+            "date": "2026-07-15",
+            "filed_by": "Australian Competition and Consumer Commission",
+            "description": "Notice of address for service",
+            "confidentiality": "Non-confidential",
+            "url": "https://www.competitiontribunal.gov.au/__data/assets/pdf_file/0012/599808/Notice-of-Address-for-Service-ACCC.pdf",
+            "url_gh": "/mergers/MN-01068/Notice-of-Address-for-Service-ACCC.pdf"
+          },
+          {
+            "date": "2026-07-15",
+            "filed_by": "Coles Supermarkets",
+            "description": "Application for review",
+            "confidentiality": "Non-confidential",
+            "url": "https://www.competitiontribunal.gov.au/__data/assets/pdf_file/0008/599732/Application-for-Review.pdf",
+            "url_gh": "/mergers/MN-01068/Application-for-Review.pdf"
+          }
+        ]
+      }
     }
   ]
 }

--- a/merger-tracker/frontend/public/data/digest.json
+++ b/merger-tracker/frontend/public/data/digest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-26T09:34:50.312350+10:00",
+  "generated_at": "2026-07-27T07:35:15.428096+10:00",
   "period_start": "2026-07-20T00:00:00+10:00",
   "period_end": "2026-07-26T23:59:59.999999+10:00",
   "new_deals_notified": [
@@ -4815,6 +4815,262 @@
       ],
       "under_appeal": false,
       "appeal": null
+    }
+  ],
+  "ongoing_tribunal_appeals": [
+    {
+      "merger_id": "MN-01068",
+      "merger_name": "Coles – supermarket and liquor site in Kalgoorlie, WA",
+      "url": "https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/coles-%E2%80%93-supermarket-and-liquor-site-in-kalgoorlie-wa",
+      "acquirers": [
+        {
+          "name": "COLES SUPERMARKETS AUSTRALIA PTY LTD",
+          "identifier_type": "ABN",
+          "identifier": "45 004 189 708"
+        }
+      ],
+      "targets": [
+        {
+          "name": "M Holdings 4 Pty Ltd",
+          "identifier_type": "ACN",
+          "identifier": "652 075 799"
+        }
+      ],
+      "effective_notification_datetime": "2025-11-27T12:00:00Z",
+      "determination_publication_date": "2026-07-01T12:00:00Z",
+      "end_of_determination_period": "2026-07-02T12:00:00Z",
+      "accc_determination": "Not approved",
+      "stage": "Phase 2 - detailed assessment",
+      "status": "Assessment completed",
+      "is_waiver": false,
+      "phase_1_determination": "Referred to phase 2",
+      "phase_1_determination_date": "2026-01-29T12:00:00Z",
+      "phase_2_determination": "Not approved",
+      "ceased_date": null,
+      "merger_description": "Coles Group Limited (Coles), via its subsidiary Coles Supermarkets Australia Pty Ltd, has signed a Letter of Offer to facilitate Coles acquiring a leasehold interest in a new neighbourhood centre at Lots 95-106 Great Western Highway, Somerville, Kalgoorlie (the **Property**).",
+      "events": [
+        {
+          "date": "2025-11-28T12:00:00Z",
+          "title": "Questionnaire – Coles - supermarket and liquor site in Kalgoorlie, WA",
+          "display_title": "Questionnaire released for Coles acquisition of supermarket and liquor site in Kalgoorlie, WA",
+          "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/Questionnaire%20%E2%80%93%20Coles%20-%20supermarket%20and%20liquor%20site%20in%20Kalgoorlie%2C%20WA%20-%2028.11.2025.docx",
+          "url_gh": "/mergers/MN-01068/Questionnaire – Coles - supermarket and liquor site in Kalgoorlie, WA - 28.11.2025.pdf",
+          "status": "removed",
+          "phase": null
+        },
+        {
+          "date": "2025-11-27T12:00:00Z",
+          "title": "Merger notified to ACCC",
+          "display_title": "Merger notified to ACCC",
+          "phase": "Phase 1"
+        },
+        {
+          "date": "2026-05-13T12:00:00Z",
+          "title": "Timeline extended by 6 business days – following request for further information",
+          "display_title": "Timeline extended by 6 business days – following request for further information",
+          "phase": null
+        },
+        {
+          "date": "2026-05-25T12:00:00Z",
+          "title": "Timeline extended by 4 business days – following request for further information",
+          "display_title": "Timeline extended by 4 business days – following request for further information",
+          "phase": null
+        },
+        {
+          "date": "2026-05-18T12:00:00Z",
+          "title": "Timeline extended by 4 business days – following request for further information",
+          "display_title": "Timeline extended by 4 business days – following request for further information",
+          "phase": null
+        },
+        {
+          "date": "2026-06-30T12:00:00Z",
+          "title": "Phase 2 determination - Statement of reasons",
+          "display_title": "Phase 2 determination - Statement of reasons",
+          "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/Coles%20Kalgoorlie%20-%20PUBLIC%20VERSION%20-%20FINAL%20-%20Phase%202%20-%20Statement%20of%20Reasons%20-%2030%20June%202026.pdf",
+          "determination_commission_division": null,
+          "determination_table_content": [
+            {
+              "item": "",
+              "details": "Combined Coles\nCombined Coles"
+            }
+          ],
+          "url_gh": "/mergers/MN-01068/Coles Kalgoorlie - PUBLIC VERSION - FINAL - Phase 2 - Statement of Reasons - 30 June 2026.pdf",
+          "status": "live",
+          "phase": "Phase 2"
+        },
+        {
+          "date": "2026-06-30T12:00:00Z",
+          "title": "Phase 2 determination - Summary of reasons",
+          "display_title": "Phase 2 determination - Summary of reasons",
+          "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/Coles%20Kalgoorlie%20-%20FINAL%20-%20Phase%202%20-%20Determination%20-%20Summary%20of%20Reasons%20-%20AR%20version%20-%2030%20June%202026_1.pdf",
+          "determination_commission_division": null,
+          "determination_table_content": [],
+          "url_gh": "/mergers/MN-01068/Coles Kalgoorlie - FINAL - Phase 2 - Determination - Summary of Reasons - AR version - 30 June 2026_1.pdf",
+          "status": "live",
+          "phase": "Phase 2"
+        },
+        {
+          "date": "2026-06-30T12:00:00Z",
+          "title": "Phase 2 determination",
+          "display_title": "Phase 2 - detailed assessment determination: Not approved",
+          "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/Coles%20Kalgoorlie%20-%20FINAL%20-%20Phase%202%20-%20Determination%20-%20AR%20version%20-%2030%20June%202026_0.pdf",
+          "determination_commission_division": "Determination made by a division of the Commission constituted by a direction issued pursuant to section 19 of the Act",
+          "determination_table_content": [
+            {
+              "item": "Determination",
+              "details": "made by a division of the Commission constituted by a direction issued pursuant to section 19 of the Act 1"
+            }
+          ],
+          "url_gh": "/mergers/MN-01068/Coles Kalgoorlie - FINAL - Phase 2 - Determination - AR version - 30 June 2026_0.pdf",
+          "status": "live",
+          "is_determination_event": true,
+          "phase": "Phase 2"
+        },
+        {
+          "date": "2026-03-06T12:00:00Z",
+          "title": "Summary of Notice of Competition Concerns",
+          "display_title": "Summary of Notice of Competition Concerns",
+          "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/Coles_Kalgoorlie%20-%20Final%20-%20Summary%20of%20Notice%20of%20Competition%20Concerns%20-%20March%202026_5.pdf",
+          "url_gh": "/mergers/MN-01068/Coles_Kalgoorlie - Final - Summary of Notice of Competition Concerns - March 2026_5.pdf",
+          "status": "live",
+          "phase": null
+        },
+        {
+          "date": "2026-01-29T12:00:00Z",
+          "title": "ACCC decided notification is subject to Phase 2 review",
+          "display_title": "ACCC decided notification is subject to Phase 2 review",
+          "url": "https://www.accc.gov.au/system/files/public-merger-register/documents/%20Kalgoorlie%20-%20Decision%20to%20Proceed%20to%20Phase%202%20review%20-%2029%20January%202026_5.pdf",
+          "phase2_notice_matters_to_investigate": [
+            {
+              "heading": "Relevant areas of competition",
+              "items": [
+                "The extent convenience stores and small supermarkets compete with full-line supermarkets such as the Proposed Supermarket.",
+                "The extent to which consumers in Kalgoorlie routinely travel to do their grocery shopping, and how far they do so."
+              ]
+            },
+            {
+              "heading": "Potential over-supply of supermarket capacity that could induce the exit of effective competitors",
+              "items": [
+                "The level of market concentration in the south/south-western end of Kalgoorlie and Kalgoorlie generally before and after the Acquisition.",
+                "The competitive offerings of each supermarket competitor in Kalgoorlie (including but not limited to price, quality, product range and service) and the intensity with which they compete in the relevant markets.",
+                "Price, quality, product range and service differentials between the major and independent supermarkets in Kalgoorlie.",
+                "The likelihood and viability of new entry and expansion in Kalgoorlie to increase competitive intensity with the Proposed Supermarket, including further consideration of suitable supermarket sites, planning and zoning requirements, and likely population growth.",
+                "The profitability of Coles and independent supermarket(s) in Kalgoorlie should the Acquisition proceed.",
+                "The impact on the level of competitive constraint imposed by existing rival supermarkets in Kalgoorlie should the Acquisition proceed.",
+                "The effect on competition should one or more competitor supermarket(s) exit following the expansion of Coles via the Proposed Supermarket."
+              ]
+            },
+            {
+              "heading": "Creating, strengthening or entrenching a substantial degree of market power",
+              "items": [
+                "Whether or not Coles has, or is likely to have, substantial market power.",
+                "The likely economic rationale for Coles opening the Proposed Supermarket, including its dependence on the level and nature of future competition in the relevant market.",
+                "Whether the Acquisition is likely to reduce competitive constraint.",
+                "Whether the Acquisition would, in all the circumstances, be likely to have the effect of creating, strengthening or entrenching a substantial degree of power in the local market."
+              ]
+            }
+          ],
+          "phase2_notice_commission_division": null,
+          "url_gh": "/mergers/MN-01068/Kalgoorlie - Decision to Proceed to Phase 2 review - 29 January 2026_5.pdf",
+          "status": "live",
+          "phase": "Phase 2"
+        },
+        {
+          "date": "2026-07-21T12:00:00Z",
+          "title": "Directions",
+          "display_title": "Tribunal appeal – Directions",
+          "url": "https://www.competitiontribunal.gov.au/__data/assets/pdf_file/0020/600284/Directions.pdf",
+          "url_gh": "/mergers/MN-01068/Directions.pdf",
+          "is_appeal": true,
+          "appeal_filed_by": "-",
+          "appeal_confidentiality": "Non-confidential",
+          "tribunal_number": "ACT 1 of 2026",
+          "phase": null
+        },
+        {
+          "date": "2026-07-20T12:00:00Z",
+          "title": "Application for Leave to Intervene",
+          "display_title": "Tribunal appeal – Application for Leave to Intervene",
+          "url": "https://www.competitiontribunal.gov.au/__data/assets/pdf_file/0003/600285/OConnor-Fresh-IGA-Application-for-Leave-to-Intervene.pdf",
+          "url_gh": "/mergers/MN-01068/OConnor-Fresh-IGA-Application-for-Leave-to-Intervene.pdf",
+          "is_appeal": true,
+          "appeal_filed_by": "O'Connor Fresh IGA",
+          "appeal_confidentiality": "Non-confidential",
+          "tribunal_number": "ACT 1 of 2026",
+          "phase": null
+        },
+        {
+          "date": "2026-07-15T12:00:00Z",
+          "title": "Notice of address for service",
+          "display_title": "Tribunal appeal – Notice of address for service",
+          "url": "https://www.competitiontribunal.gov.au/__data/assets/pdf_file/0012/599808/Notice-of-Address-for-Service-ACCC.pdf",
+          "url_gh": "/mergers/MN-01068/Notice-of-Address-for-Service-ACCC.pdf",
+          "is_appeal": true,
+          "appeal_filed_by": "Australian Competition and Consumer Commission",
+          "appeal_confidentiality": "Non-confidential",
+          "tribunal_number": "ACT 1 of 2026",
+          "phase": null
+        },
+        {
+          "date": "2026-07-15T12:00:00Z",
+          "title": "Application for review",
+          "display_title": "Tribunal appeal – Application for review",
+          "url": "https://www.competitiontribunal.gov.au/__data/assets/pdf_file/0008/599732/Application-for-Review.pdf",
+          "url_gh": "/mergers/MN-01068/Application-for-Review.pdf",
+          "is_appeal": true,
+          "appeal_filed_by": "Coles Supermarkets",
+          "appeal_confidentiality": "Non-confidential",
+          "tribunal_number": "ACT 1 of 2026",
+          "phase": null
+        }
+      ],
+      "under_appeal": true,
+      "appeal": {
+        "tribunal_number": "ACT 1 of 2026",
+        "tribunal_url": "https://www.competitiontribunal.gov.au/current-matters/act-1-of-2026",
+        "appeal_type": "party_denial",
+        "appellant": "Coles",
+        "status": "current",
+        "outcome": null,
+        "effective_determination": null,
+        "filed_date": "2026-07-15",
+        "hearing_date": "2026-11-09",
+        "concluded_date": null,
+        "documents": [
+          {
+            "date": "2026-07-21",
+            "filed_by": "-",
+            "description": "Directions",
+            "confidentiality": "Non-confidential",
+            "url": "https://www.competitiontribunal.gov.au/__data/assets/pdf_file/0020/600284/Directions.pdf",
+            "url_gh": "/mergers/MN-01068/Directions.pdf"
+          },
+          {
+            "date": "2026-07-20",
+            "filed_by": "O'Connor Fresh IGA",
+            "description": "Application for Leave to Intervene",
+            "confidentiality": "Non-confidential",
+            "url": "https://www.competitiontribunal.gov.au/__data/assets/pdf_file/0003/600285/OConnor-Fresh-IGA-Application-for-Leave-to-Intervene.pdf",
+            "url_gh": "/mergers/MN-01068/OConnor-Fresh-IGA-Application-for-Leave-to-Intervene.pdf"
+          },
+          {
+            "date": "2026-07-15",
+            "filed_by": "Australian Competition and Consumer Commission",
+            "description": "Notice of address for service",
+            "confidentiality": "Non-confidential",
+            "url": "https://www.competitiontribunal.gov.au/__data/assets/pdf_file/0012/599808/Notice-of-Address-for-Service-ACCC.pdf",
+            "url_gh": "/mergers/MN-01068/Notice-of-Address-for-Service-ACCC.pdf"
+          },
+          {
+            "date": "2026-07-15",
+            "filed_by": "Coles Supermarkets",
+            "description": "Application for review",
+            "confidentiality": "Non-confidential",
+            "url": "https://www.competitiontribunal.gov.au/__data/assets/pdf_file/0008/599732/Application-for-Review.pdf",
+            "url_gh": "/mergers/MN-01068/Application-for-Review.pdf"
+          }
+        ]
+      }
     }
   ]
 }

--- a/merger-tracker/frontend/src/pages/Digest.jsx
+++ b/merger-tracker/frontend/src/pages/Digest.jsx
@@ -394,6 +394,7 @@ function Digest() {
 
   const ceasedMergers = digest.deals_assessment_ceased || [];
   const appealedMergers = digest.deals_appealed_to_tribunal || [];
+  const ongoingAppeals = digest.ongoing_tribunal_appeals || [];
 
   const summaryCards = [
     { id: 'new-mergers', colorKey: DIGEST_COLOR_KEYS.NEW_MERGER, count: digest.new_deals_notified.length, label: 'New deals notified' },
@@ -404,6 +405,7 @@ function Digest() {
     ...(appealedMergers.length > 0 ? [{ id: 'mergers-appealed', colorKey: DIGEST_COLOR_KEYS.TRIBUNAL_APPEAL, count: appealedMergers.length, label: 'Appealed to tribunal' }] : []),
     { id: 'ongoing-phase-1', colorKey: DIGEST_COLOR_KEYS.PHASE_1, count: digest.ongoing_phase_1.length, label: 'Ongoing phase 1' },
     { id: 'ongoing-phase-2', colorKey: DIGEST_COLOR_KEYS.PHASE_2, count: digest.ongoing_phase_2.length, label: 'Ongoing phase 2' },
+    ...(ongoingAppeals.length > 0 ? [{ id: 'ongoing-tribunal-appeals', colorKey: DIGEST_COLOR_KEYS.TRIBUNAL_APPEAL, count: ongoingAppeals.length, label: 'Ongoing tribunal appeals' }] : []),
   ];
 
   return (
@@ -634,6 +636,42 @@ function Digest() {
               </tr>
             )}
           />
+
+          {ongoingAppeals.length > 0 && (
+            <DigestSection
+              id="ongoing-tribunal-appeals"
+              title="Ongoing - tribunal appeals"
+              emptyMessage="No ongoing tribunal appeals"
+              colorKey={DIGEST_COLOR_KEYS.TRIBUNAL_APPEAL}
+              mergers={ongoingAppeals}
+              columns={['Merger', 'Filed', 'Hearing', 'Appeal']}
+              renderRow={(merger) => {
+                const appeal = merger.appeal || {};
+                return (
+                  <tr key={merger.merger_id} className="relative hover:bg-tribunal-appeal-pale/40 transition-colors">
+                    <MergerNameCell merger={merger} colorKey={DIGEST_COLOR_KEYS.TRIBUNAL_APPEAL} />
+                    <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                      {appeal.filed_date ? formatDate(appeal.filed_date) : 'N/A'}
+                    </td>
+                    <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                      {appeal.hearing_date ? formatDate(appeal.hearing_date) : 'TBC'}
+                    </td>
+                    <td className="px-5 sm:px-6 py-4 text-sm text-gray-600">
+                      <div>{APPEAL_TYPE_LABELS[appeal.appeal_type] || DEFAULT_APPEAL_LABEL}</div>
+                      {(appeal.tribunal_number || appeal.appellant) && (
+                        <div className="text-xs text-gray-500 mt-0.5">
+                          {[
+                            appeal.appellant ? `Lodged by ${appeal.appellant}` : null,
+                            appeal.tribunal_number,
+                          ].filter(Boolean).join(' · ')}
+                        </div>
+                      )}
+                    </td>
+                  </tr>
+                );
+              }}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/merger-tracker/frontend/src/pages/Digest.jsx
+++ b/merger-tracker/frontend/src/pages/Digest.jsx
@@ -434,7 +434,7 @@ function Digest() {
     ...(appealedMergers.length > 0 ? [{ id: 'mergers-appealed', colorKey: DIGEST_COLOR_KEYS.TRIBUNAL_APPEAL, count: appealedMergers.length, label: 'Appealed to tribunal' }] : []),
     { id: 'ongoing-phase-1', colorKey: DIGEST_COLOR_KEYS.PHASE_1, count: digest.ongoing_phase_1.length, label: 'Ongoing phase 1' },
     { id: 'ongoing-phase-2', colorKey: DIGEST_COLOR_KEYS.PHASE_2, count: digest.ongoing_phase_2.length, label: 'Ongoing phase 2' },
-    ...(ongoingAppeals.length > 0 ? [{ id: 'ongoing-tribunal-appeals', colorKey: DIGEST_COLOR_KEYS.TRIBUNAL_APPEAL, count: ongoingAppeals.length, label: 'Ongoing tribunal appeals' }] : []),
+    ...(ongoingAppeals.length > 0 ? [{ id: 'ongoing-tribunal-appeals', colorKey: DIGEST_COLOR_KEYS.TRIBUNAL_APPEAL, count: ongoingAppeals.length, label: 'Ongoing ACT appeals' }] : []),
   ];
 
   return (

--- a/merger-tracker/frontend/src/pages/Digest.jsx
+++ b/merger-tracker/frontend/src/pages/Digest.jsx
@@ -589,13 +589,17 @@ function Digest() {
               emptyMessage="No deals appealed to the tribunal this week"
               colorKey={DIGEST_COLOR_KEYS.TRIBUNAL_APPEAL}
               mergers={appealedMergers}
-              columns={['Merger', 'Filed', 'Appeal']}
+              columns={['Merger', { label: 'Filed', thClassName: 'hidden sm:table-cell' }, 'Appeal']}
               renderRow={(merger) => {
                 const appeal = merger.appeal || {};
                 return (
                   <tr key={merger.merger_id} className="relative hover:bg-tribunal-appeal-pale/40 transition-colors">
-                    <MergerNameCell merger={merger} colorKey={DIGEST_COLOR_KEYS.TRIBUNAL_APPEAL} />
-                    <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                    <MergerNameCell
+                      merger={merger}
+                      colorKey={DIGEST_COLOR_KEYS.TRIBUNAL_APPEAL}
+                      mobileMeta={<span>Filed {appeal.filed_date ? formatDate(appeal.filed_date) : 'N/A'}</span>}
+                    />
+                    <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600 hidden sm:table-cell">
                       {appeal.filed_date ? formatDate(appeal.filed_date) : 'N/A'}
                     </td>
                     <td className="px-5 sm:px-6 py-4 text-sm text-gray-600">
@@ -718,16 +722,25 @@ function Digest() {
               emptyMessage="No ongoing tribunal appeals"
               colorKey={DIGEST_COLOR_KEYS.TRIBUNAL_APPEAL}
               mergers={ongoingAppeals}
-              columns={['Merger', 'Filed', 'Hearing', 'Appeal']}
+              columns={['Merger', { label: 'Filed', thClassName: 'hidden sm:table-cell' }, { label: 'Hearing', thClassName: 'hidden sm:table-cell' }, 'Appeal']}
               renderRow={(merger) => {
                 const appeal = merger.appeal || {};
                 return (
                   <tr key={merger.merger_id} className="relative hover:bg-tribunal-appeal-pale/40 transition-colors">
-                    <MergerNameCell merger={merger} colorKey={DIGEST_COLOR_KEYS.TRIBUNAL_APPEAL} />
-                    <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                    <MergerNameCell
+                      merger={merger}
+                      colorKey={DIGEST_COLOR_KEYS.TRIBUNAL_APPEAL}
+                      mobileMeta={
+                        <>
+                          <div>Filed {appeal.filed_date ? formatDate(appeal.filed_date) : 'N/A'}</div>
+                          <div>Hearing {appeal.hearing_date ? formatDate(appeal.hearing_date) : 'TBC'}</div>
+                        </>
+                      }
+                    />
+                    <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600 hidden sm:table-cell">
                       {appeal.filed_date ? formatDate(appeal.filed_date) : 'N/A'}
                     </td>
-                    <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                    <td className="px-5 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-600 hidden sm:table-cell">
                       {appeal.hearing_date ? formatDate(appeal.hearing_date) : 'TBC'}
                     </td>
                     <td className="px-5 sm:px-6 py-4 text-sm text-gray-600">

--- a/scripts/generate_weekly_digest.py
+++ b/scripts/generate_weekly_digest.py
@@ -10,6 +10,7 @@ This script creates a summary showing:
 - Deals appealed to the Australian Competition Tribunal in the last week
 - Ongoing phase 1 deals
 - Ongoing phase 2 deals
+- Deals currently under appeal at the Australian Competition Tribunal
 
 To account for the discrepancy between when a decision is "made" and when it
 appears on the ACCC's acquisitions register (a decision dated Friday often
@@ -289,6 +290,7 @@ def generate_weekly_digest(
         'deals_appealed_to_tribunal': [],
         'ongoing_phase_1': [],
         'ongoing_phase_2': [],
+        'ongoing_tribunal_appeals': [],
     }
 
     for merger in mergers:
@@ -354,6 +356,12 @@ def generate_weekly_digest(
             stage == 'Phase 2 - detailed assessment'):
             digest['ongoing_phase_2'].append(create_merger_summary(merger))
 
+        # Deals with a *current* Australian Competition Tribunal appeal. Like
+        # the ongoing phase lists, this is a live snapshot (not week-scoped),
+        # so no dedup applies — a matter stays here until the appeal concludes.
+        if merger.get('under_appeal'):
+            digest['ongoing_tribunal_appeals'].append(create_merger_summary(merger))
+
     # Sort new deals by notification date (ascending)
     digest['new_deals_notified'].sort(
         key=lambda x: x.get('effective_notification_datetime') or ''
@@ -386,6 +394,11 @@ def generate_weekly_digest(
     )
     digest['ongoing_phase_2'].sort(
         key=lambda x: x.get('effective_notification_datetime') or ''
+    )
+
+    # Sort ongoing tribunal appeals by the date the appeal was filed (ascending)
+    digest['ongoing_tribunal_appeals'].sort(
+        key=lambda x: (x.get('appeal') or {}).get('filed_date') or ''
     )
 
     return digest
@@ -424,6 +437,7 @@ def main():
     print(f"  Appealed to tribunal (last week): {len(digest['deals_appealed_to_tribunal'])}")
     print(f"  Ongoing phase 1 deals: {len(digest['ongoing_phase_1'])}")
     print(f"  Ongoing phase 2 deals: {len(digest['ongoing_phase_2'])}")
+    print(f"  Ongoing tribunal appeals: {len(digest['ongoing_tribunal_appeals'])}")
 
 
 if __name__ == '__main__':

--- a/scripts/send_weekly_email.py
+++ b/scripts/send_weekly_email.py
@@ -195,6 +195,7 @@ def build_text_email(digest: dict) -> str:
     referred = digest.get("deals_referred_to_phase_2") or []
     ceased = digest.get("deals_assessment_ceased") or []
     appealed = digest.get("deals_appealed_to_tribunal") or []
+    ongoing_appeals = digest.get("ongoing_tribunal_appeals") or []
 
     lines = [
         "Australian Merger Tracker weekly digest",
@@ -217,8 +218,10 @@ def build_text_email(digest: dict) -> str:
     lines += [
         f"Ongoing phase 1      : {len(digest['ongoing_phase_1'])}",
         f"Ongoing phase 2      : {len(digest['ongoing_phase_2'])}",
-        "",
     ]
+    if ongoing_appeals:
+        lines.append(f"Under appeal         : {len(ongoing_appeals)}")
+    lines.append("")
 
     new_rows = [
         [m.get("merger_name", m["merger_id"]), format_date(m.get("effective_notification_datetime"))]
@@ -299,6 +302,20 @@ def build_text_email(digest: dict) -> str:
     lines.append(_text_section("ONGOING – PHASE 2 – DETAILED ASSESSMENT", ["Merger", "Notified"], phase2_rows, "No ongoing phase 2 mergers."))
     lines.append("")
 
+    if ongoing_appeals:
+        appeal_rows = [
+            [
+                m.get("merger_name", m["merger_id"]),
+                format_date((m.get("appeal") or {}).get("filed_date")),
+                format_date(hearing) if (hearing := (m.get("appeal") or {}).get("hearing_date")) else "TBC",
+                APPEAL_TYPE_LABELS.get((m.get("appeal") or {}).get("appeal_type"), "Tribunal appeal"),
+            ]
+            for m in ongoing_appeals
+        ]
+        lines.append(_text_section("ONGOING TRIBUNAL APPEALS", ["Merger", "Filed", "Hearing", "Type"], appeal_rows, ""))
+        lines.append("")
+        lines.append("")
+
     unsub_var = "{{{RESEND_UNSUBSCRIBE_URL}}}"
     footer = [
         "--",
@@ -355,6 +372,7 @@ def _counts(digest: dict) -> dict:
         "appealed": len(digest.get("deals_appealed_to_tribunal") or []),
         "p1": len(digest["ongoing_phase_1"]),
         "p2": len(digest["ongoing_phase_2"]),
+        "on_appeal": len(digest.get("ongoing_tribunal_appeals") or []),
     }
 
 
@@ -427,6 +445,12 @@ def build_lede(c: dict) -> str:
             f"on foot{split}."
         )
 
+    if c["on_appeal"]:
+        sentences.append(
+            f"{b(c['on_appeal'])} {pluralise(c['on_appeal'], 'matter remains', 'matters remain')} "
+            "under appeal at the tribunal."
+        )
+
     return " ".join(sentences)
 
 
@@ -446,6 +470,8 @@ def build_scoreboard(c: dict) -> str:
         (c["p1"], "PHASE 1", COLORS["phase_1"], "ongoing-phase-1"),
         (c["p2"], "PHASE 2", COLORS["phase_2"], "ongoing-phase-2"),
     ]
+    if c["on_appeal"]:
+        cells.append((c["on_appeal"], "ON APPEAL", COLORS["tribunal_appeal"], "ongoing-tribunal-appeals"))
     width = str(100 // len(cells)) + "%"
     tds = "".join(
         f'<td width="{width}" align="center" style="padding:10px 2px;">'
@@ -749,6 +775,50 @@ def build_pipeline(digest: dict) -> str:
             )
     return section_table(rows)
 
+
+def build_ongoing_appeals(mergers: list) -> str:
+    """Deals with a current appeal on foot at the Australian Competition
+    Tribunal — a live snapshot, not just this week's new filings."""
+    c = COLORS["tribunal_appeal"]
+    rows = section_head("Ongoing tribunal appeals", c["border"],
+                        f"{len(mergers)} on foot" if mergers else "")
+    if not mergers:
+        rows += empty_section_row("No matters are currently under appeal.")
+    else:
+        for i, m in enumerate(mergers):
+            divider = "" if i == len(mergers) - 1 else f"border-bottom:1px solid {ROW_LINE};"
+            appeal = m.get("appeal") or {}
+            type_label = APPEAL_TYPE_LABELS.get(appeal.get("appeal_type"), "Tribunal appeal")
+            hearing = (
+                f"Hearing {esc(format_date(appeal['hearing_date']))}"
+                if appeal.get("hearing_date") else ""
+            )
+            meta_bits = [x for x in (
+                type_label,
+                f"Filed {esc(format_date(appeal.get('filed_date')))}",
+                hearing,
+                esc(m.get("merger_id", "")),
+            ) if x]
+            detail_bits = []
+            if appeal.get("appellant"):
+                detail_bits.append(f"Lodged by {esc(appeal['appellant'])}")
+            if appeal.get("tribunal_number"):
+                detail_bits.append(esc(appeal["tribunal_number"]))
+            detail_html = (
+                f'<div style="font-size:12px;color:{BODY_TEXT};line-height:18px;'
+                f'margin-top:4px;">{" &middot; ".join(detail_bits)}</div>'
+                if detail_bits else ""
+            )
+            rows += (
+                f'<tr><td colspan="2" style="padding:13px 0 12px;{divider}">'
+                f'<a href="{merger_url(m)}" style="color:{c["dark"]};font-size:14px;'
+                f'font-weight:700;text-decoration:none;line-height:1.4;">{merger_name(m)}</a>'
+                f'<div style="margin-top:4px;">{chip("ON APPEAL", c["pale"], c["dark"])}'
+                f' <span style="font-size:11px;color:{FAINT};">{" &middot; ".join(meta_bits)}</span></div>'
+                f"{detail_html}</td></tr>"
+            )
+    return section_table(rows)
+
 # ---------------------------------------------------------------------------
 # Full email builder
 # ---------------------------------------------------------------------------
@@ -759,11 +829,13 @@ def build_html_email(digest: dict) -> str:
     c = _counts(digest)
 
     appealed = digest.get("deals_appealed_to_tribunal") or []
+    ongoing_appeals = digest.get("ongoing_tribunal_appeals") or []
     sections = (
         build_new_deals(digest["new_deals_notified"])
         + build_decisions(digest)
         + (build_tribunal_appeals(appealed) if appealed else "")
         + build_pipeline(digest)
+        + (build_ongoing_appeals(ongoing_appeals) if ongoing_appeals else "")
     )
 
     if show_feedback:
@@ -788,6 +860,8 @@ def build_html_email(digest: dict) -> str:
     if c["appealed"]:
         preheader_bits.append(f"{c['appealed']} appealed to tribunal")
     preheader_bits.append(f"{c['p1'] + c['p2']} ongoing")
+    if c["on_appeal"]:
+        preheader_bits.append(f"{c['on_appeal']} under appeal")
     preheader = ", ".join(preheader_bits) + "."
 
     # Resend replaces {{{RESEND_UNSUBSCRIBE_URL}}} with the real link

--- a/scripts/send_weekly_email.py
+++ b/scripts/send_weekly_email.py
@@ -312,7 +312,7 @@ def build_text_email(digest: dict) -> str:
             ]
             for m in ongoing_appeals
         ]
-        lines.append(_text_section("ONGOING TRIBUNAL APPEALS", ["Merger", "Filed", "Hearing", "Type"], appeal_rows, ""))
+        lines.append(_text_section("ONGOING ACT APPEALS", ["Merger", "Filed", "Hearing", "Type"], appeal_rows, ""))
         lines.append("")
         lines.append("")
 
@@ -780,7 +780,7 @@ def build_ongoing_appeals(mergers: list) -> str:
     """Deals with a current appeal on foot at the Australian Competition
     Tribunal — a live snapshot, not just this week's new filings."""
     c = COLORS["tribunal_appeal"]
-    rows = section_head("Ongoing tribunal appeals", c["border"],
+    rows = section_head("Ongoing ACT appeals", c["border"],
                         f"{len(mergers)} on foot" if mergers else "")
     if not mergers:
         rows += empty_section_row("No matters are currently under appeal.")

--- a/scripts/tests/test_generate_weekly_digest.py
+++ b/scripts/tests/test_generate_weekly_digest.py
@@ -521,6 +521,44 @@ class TestWeeklyDigestBuckets:
         digest = self._run([merger], monkeypatch, previous_digest=previous_digest)
         assert [m['merger_id'] for m in digest['ongoing_phase_1']] == ['MN-400']
 
+    # -----------------------------------------------------------------
+    # Ongoing tribunal appeals (current snapshot, not week-scoped)
+    # -----------------------------------------------------------------
+
+    def test_current_appeal_is_in_ongoing_snapshot(self, monkeypatch):
+        # An old filing date must not exclude a still-current appeal from the
+        # ongoing snapshot; unlike the week-scoped bucket, it is not time-scoped.
+        merger = self._appealed_merger('MN-40010', '2025-01-05')
+        digest = self._run([merger], monkeypatch)
+        assert [m['merger_id'] for m in digest['ongoing_tribunal_appeals']] == ['MN-40010']
+
+    def test_concluded_appeal_absent_from_ongoing_snapshot(self, monkeypatch):
+        # `under_appeal` is False for concluded matters, so they drop out of the
+        # ongoing snapshot even though the appeal record lingers.
+        merger = self._appealed_merger('MN-40011', '2025-01-05', under_appeal=False)
+        digest = self._run([merger], monkeypatch)
+        assert digest['ongoing_tribunal_appeals'] == []
+
+    def test_merger_without_appeal_absent_from_ongoing_snapshot(self, monkeypatch):
+        merger = {
+            'merger_id': 'MN-40012',
+            'merger_name': 'No appeal',
+            'status': merger_status.UNDER_ASSESSMENT,
+            'stage': 'Phase 1 - initial assessment',
+            'effective_notification_datetime': '2025-03-20T00:00:00Z',
+            'events': [],
+        }
+        digest = self._run([merger], monkeypatch)
+        assert digest['ongoing_tribunal_appeals'] == []
+
+    def test_ongoing_appeals_not_deduplicated(self, monkeypatch):
+        # Like the ongoing phase lists, the appeal snapshot reflects current
+        # state and ignores what last week's digest listed.
+        merger = self._appealed_merger('MN-40013', '2025-04-11')
+        previous_digest = {'ongoing_tribunal_appeals': [{'merger_id': 'MN-40013'}]}
+        digest = self._run([merger], monkeypatch, previous_digest=previous_digest)
+        assert [m['merger_id'] for m in digest['ongoing_tribunal_appeals']] == ['MN-40013']
+
 
 class TestMainWritesArchive:
     """main() should write both the live digest and a dated archive snapshot,


### PR DESCRIPTION
Surface deals currently under appeal at the Australian Competition
Tribunal as a live snapshot on the digest page, alongside the existing
ongoing phase 1/2 lists. This complements the week-scoped "appealed to
tribunal" bucket (new filings) with a standing view of all matters whose
appeal is still current.

- generate_weekly_digest.py: add an `ongoing_tribunal_appeals` bucket
  collecting mergers where `under_appeal` is true, sorted by filed date.
  Like the ongoing phase lists it is a current snapshot, so no week-scope
  or dedup applies.
- Digest.jsx: render a summary chip and table for the new bucket, shown
  only when there is at least one ongoing appeal.
- Regenerate digest.json / archive snapshot to include the new bucket.
- Add tests covering the snapshot's inclusion, exclusion of concluded
  appeals, and absence of dedup.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C5VeMMnm2Nsdh69svfi2aW