### PR TITLE
Prerender merger detail pages at build time for SEO canonicals

### DIFF
--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -5,6 +5,11 @@ on:
     paths:
       - 'merger-tracker/frontend/**'
       - '.github/workflows/frontend-test.yml'
+      # The slugify sync test (src/utils/__tests__/slug.test.js) also validates
+      # the inline copy in functions/ against the shared golden fixture, so run
+      # it when either of those change too.
+      - 'functions/**'
+      - 'slug-cases.json'
   workflow_dispatch:
 
 jobs:

--- a/functions/mergers/[matter]/[[path]].js
+++ b/functions/mergers/[matter]/[[path]].js
@@ -10,8 +10,12 @@ function isBotRequest(request) {
 // Build the readable slug for a merger name. MUST stay in sync with
 // merger-tracker/frontend/src/utils/slug.js and scripts/slug.py so the OG
 // canonical matches the SPA's <link rel="canonical"> and the sitemap entry.
+// slugify/mergerPath are exported solely so the sync test in
+// merger-tracker/frontend/src/utils/__tests__/slug.test.js can assert this copy
+// hasn't drifted; Cloudflare Pages only invokes `onRequest`, so the extra named
+// exports are inert at runtime.
 const MAX_SLUG_LENGTH = 80;
-function slugify(name) {
+export function slugify(name) {
   if (!name) return '';
   return String(name)
     .toLowerCase()
@@ -21,7 +25,7 @@ function slugify(name) {
     .replace(/-+$/g, '');
 }
 
-function mergerPath(id, name) {
+export function mergerPath(id, name) {
   const slug = slugify(name);
   return slug ? `/mergers/${id}/${slug}` : `/mergers/${id}`;
 }

--- a/merger-tracker/frontend/prerender.js
+++ b/merger-tracker/frontend/prerender.js
@@ -1,0 +1,227 @@
+// Build-time prerendering for merger detail pages.
+//
+// The frontend is a client-side React SPA: `vite build` emits a single
+// `index.html` that every route shares, and the per-page <title>, description
+// and <link rel="canonical"> are only injected once JavaScript runs (via
+// react-helmet-async in src/components/SEO.jsx). Search engines do most of
+// their duplicate-clustering and canonical selection on the *raw* HTML, before
+// the deferred render pass — and because every merger URL returns byte-for-byte
+// identical HTML, Google clusters unrelated mergers together and picks an
+// arbitrary URL as the cluster's canonical (e.g. WA-35022 -> MN-10007).
+//
+// This Vite plugin fixes that at the source. After the bundle is written it
+// stamps a static, differentiated HTML file into `dist/mergers/{id}/{slug}/`
+// for every merger, carrying the correct title, description, canonical, Open
+// Graph/Twitter tags, JSON-LD and a real body summary in the raw markup. The
+// file still boots the SPA (the module script is untouched), so `createRoot`
+// replaces the prerendered #root on mount and users get the full interactive
+// page. Crawlers and users receive the same HTML — no cloaking.
+
+import { readFileSync, writeFileSync, readdirSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { mergerPath } from './src/utils/slug.js';
+
+const SITE_URL = 'https://mergers.fyi';
+// Per-merger data files are named by matter id, e.g. MN-01016.json / WA-70017.json.
+const MATTER_FILE_RE = /^(MN|WA)-\d+\.json$/i;
+
+function escapeHtml(str) {
+  return String(str ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// A human-readable date for the body summary, e.g. "15 August 2025". Falls back
+// to an empty string when the value is missing or unparseable.
+function formatDate(value) {
+  if (!value) return '';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleDateString('en-AU', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+function partyNames(parties) {
+  return (parties ?? []).map((p) => p.name).filter(Boolean);
+}
+
+// The <title> and description here MUST mirror what src/pages/MergerDetail.jsx
+// passes to <SEO> so the prerendered head matches the client-rendered head.
+function pageMeta(merger) {
+  const acquirers = partyNames(merger.acquirers);
+  const targets = partyNames(merger.targets);
+  const title = `${merger.merger_name} | Australian Merger Tracker`;
+  const description =
+    merger.merger_description ||
+    `ACCC merger review: ${acquirers.join(', ')} acquiring ${targets.join(', ')}. Status: ${merger.status}`;
+  return { title, description, acquirers, targets };
+}
+
+function buildStructuredData(merger, canonicalUrl) {
+  const acquirers = partyNames(merger.acquirers);
+  const targets = partyNames(merger.targets);
+  const modifiedTime =
+    merger.determination_publication_date || merger.effective_notification_datetime;
+
+  const articleSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: merger.merger_name,
+    description:
+      merger.merger_description ||
+      `Merger between ${acquirers.join(', ')} and ${targets.join(', ')}`,
+    datePublished: merger.effective_notification_datetime,
+    dateModified: modifiedTime,
+    mainEntityOfPage: { '@type': 'WebPage', '@id': canonicalUrl },
+    author: { '@type': 'Person', name: 'Nick Twort', url: SITE_URL },
+    publisher: {
+      '@type': 'Organization',
+      name: 'Australian Merger Tracker',
+      url: SITE_URL,
+      logo: { '@type': 'ImageObject', url: `${SITE_URL}/og-image.png` },
+    },
+    about: [
+      ...acquirers.map((name) => ({ '@type': 'Organization', name })),
+      ...targets.map((name) => ({ '@type': 'Organization', name })),
+    ],
+  };
+
+  const breadcrumbSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: SITE_URL },
+      { '@type': 'ListItem', position: 2, name: 'Mergers', item: `${SITE_URL}/mergers` },
+      { '@type': 'ListItem', position: 3, name: merger.merger_name, item: canonicalUrl },
+    ],
+  };
+
+  return [articleSchema, breadcrumbSchema];
+}
+
+// A small, real body rendered into #root so the raw HTML carries unique,
+// crawlable content. React (createRoot) replaces it wholesale on mount, so it
+// never has to match the live DOM — it only has to be accurate and unique.
+function buildBody(merger, canonicalUrl, meta) {
+  const list = (names) =>
+    names.length
+      ? `<ul>${names.map((n) => `<li>${escapeHtml(n)}</li>`).join('')}</ul>`
+      : '';
+
+  const facts = [
+    ['Status', merger.status],
+    ['ACCC determination', merger.accc_determination],
+    ['Stage', merger.stage],
+    ['Notified', formatDate(merger.effective_notification_datetime)],
+    ['Determination published', formatDate(merger.determination_publication_date)],
+  ].filter(([, v]) => v);
+
+  return `<div id="root"><main>
+<nav aria-label="Breadcrumb"><a href="/">Home</a> / <a href="/mergers">Mergers</a> / ${escapeHtml(merger.merger_name)}</nav>
+<article>
+<h1>${escapeHtml(merger.merger_name)}</h1>
+<p>${escapeHtml(meta.description)}</p>
+<dl>${facts.map(([k, v]) => `<dt>${escapeHtml(k)}</dt><dd>${escapeHtml(v)}</dd>`).join('')}</dl>
+${meta.acquirers.length ? `<section><h2>Acquirers</h2>${list(meta.acquirers)}</section>` : ''}
+${meta.targets.length ? `<section><h2>Targets</h2>${list(meta.targets)}</section>` : ''}
+<p><a href="${escapeHtml(canonicalUrl)}">View full merger details on mergers.fyi</a></p>
+</article>
+</main></div>`;
+}
+
+// Produce the per-merger HTML by stamping page-specific values into the shared
+// built template. Tag-targeted regexes keep this resilient to unrelated changes
+// in index.html (inlined CSS, hashed script names, etc.).
+function renderPage(template, merger) {
+  const path = mergerPath(merger.merger_id, merger.merger_name);
+  const canonicalUrl = `${SITE_URL}${path}`;
+  const meta = pageMeta(merger);
+  const title = escapeHtml(meta.title);
+  const description = escapeHtml(meta.description);
+  const structuredData = buildStructuredData(merger, canonicalUrl);
+  const publishedTime = merger.effective_notification_datetime;
+  const modifiedTime =
+    merger.determination_publication_date || merger.effective_notification_datetime;
+
+  const headExtras = [
+    `<link rel="canonical" href="${escapeHtml(canonicalUrl)}" />`,
+    '<meta property="og:locale" content="en_AU" />',
+    publishedTime
+      ? `<meta property="article:published_time" content="${escapeHtml(publishedTime)}" />`
+      : '',
+    modifiedTime
+      ? `<meta property="article:modified_time" content="${escapeHtml(modifiedTime)}" />`
+      : '',
+    `<script type="application/ld+json">${JSON.stringify(structuredData)}</script>`,
+  ]
+    .filter(Boolean)
+    .join('\n    ');
+
+  return template
+    .replace(/<title>[\s\S]*?<\/title>/, `<title>${title}</title>`)
+    .replace(/<meta name="description"[^>]*>/, `<meta name="description" content="${description}" />`)
+    .replace(/<meta property="og:type"[^>]*>/, '<meta property="og:type" content="article" />')
+    .replace(/<meta property="og:title"[^>]*>/, `<meta property="og:title" content="${title}" />`)
+    .replace(/<meta property="og:description"[^>]*>/, `<meta property="og:description" content="${description}" />`)
+    .replace(/<meta property="og:url"[^>]*>/, `<meta property="og:url" content="${escapeHtml(canonicalUrl)}" />`)
+    .replace(/<meta name="twitter:title"[^>]*>/, `<meta name="twitter:title" content="${title}" />`)
+    .replace(/<meta name="twitter:description"[^>]*>/, `<meta name="twitter:description" content="${description}" />`)
+    .replace(/<\/head>/, `    ${headExtras}\n  </head>`)
+    .replace(/<div id="root"><\/div>/, buildBody(merger, canonicalUrl, meta));
+}
+
+export default function prerenderMergers() {
+  let outDir;
+  let publicDir;
+
+  return {
+    name: 'prerender-mergers',
+    apply: 'build',
+    enforce: 'post',
+    configResolved(config) {
+      outDir = config.build.outDir;
+      publicDir = config.publicDir;
+    },
+    closeBundle() {
+      const template = readFileSync(join(outDir, 'index.html'), 'utf8');
+      const dataDir = join(publicDir, 'data', 'mergers');
+
+      let files;
+      try {
+        files = readdirSync(dataDir).filter((f) => MATTER_FILE_RE.test(f));
+      } catch {
+        this.warn(`prerender-mergers: no merger data at ${dataDir}, skipping`);
+        return;
+      }
+
+      let count = 0;
+      for (const file of files) {
+        let merger;
+        try {
+          merger = JSON.parse(readFileSync(join(dataDir, file), 'utf8'));
+        } catch (err) {
+          this.warn(`prerender-mergers: skipping ${file}: ${err.message}`);
+          continue;
+        }
+        if (!merger.merger_id || !merger.merger_name) continue;
+
+        // Emit at the slugged path (which matches the sitemap and canonical);
+        // fall back to the bare-id directory when no slug can be derived.
+        const path = mergerPath(merger.merger_id, merger.merger_name);
+        const outFile = join(outDir, path.replace(/^\//, ''), 'index.html');
+        mkdirSync(dirname(outFile), { recursive: true });
+        writeFileSync(outFile, renderPage(template, merger));
+        count++;
+      }
+
+      this.info(`prerender-mergers: wrote ${count} merger page(s)`);
+    },
+  };
+}

--- a/merger-tracker/frontend/src/utils/__tests__/slug.test.js
+++ b/merger-tracker/frontend/src/utils/__tests__/slug.test.js
@@ -1,0 +1,77 @@
+/* global process */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+import { slugify, mergerPath, industryPath, partyPath } from '../slug.js';
+// The inline copy the Pages Function ships to social/OG bots. It exports
+// slugify/mergerPath solely so this test can prove it hasn't drifted from the
+// SPA copy — see the note in that file.
+import { slugify as fnSlugify, mergerPath as fnMergerPath } from '../../../../../functions/mergers/[matter]/[[path]].js';
+
+// Golden fixture shared with scripts/tests/test_slug.py — the single source of
+// truth that pins all three slugify implementations together. Read via node fs
+// (Vitest runs with the frontend project dir as cwd, so the repo root is two
+// levels up) rather than an import, so Vite's module-graph fs allowlist and
+// JSON-import handling don't come into it.
+const repoRoot = resolve(process.cwd(), '..', '..');
+const fixture = JSON.parse(readFileSync(resolve(repoRoot, 'slug-cases.json'), 'utf8'));
+const cases = fixture.cases;
+
+describe('slugify (SPA)', () => {
+  it('has a non-empty golden fixture', () => {
+    expect(Array.isArray(cases)).toBe(true);
+    expect(cases.length).toBeGreaterThan(0);
+  });
+
+  it.each(cases)('matches the golden slug for "$name"', ({ name, slug }) => {
+    expect(slugify(name)).toBe(slug);
+  });
+
+  it('handles null/undefined without throwing', () => {
+    expect(slugify(undefined)).toBe('');
+    expect(slugify(null)).toBe('');
+  });
+});
+
+// If this block fails, the Pages Function's inline slugify has drifted from the
+// SPA's — which is exactly what silently breaks canonical URLs (the bug this
+// suite guards against). Fix by copying src/utils/slug.js's algorithm back into
+// functions/mergers/[matter]/[[path]].js.
+describe('slugify (Pages Function inline copy) stays in sync with the SPA', () => {
+  it.each(cases)('agrees on the golden slug for "$name"', ({ name, slug }) => {
+    expect(fnSlugify(name)).toBe(slug);
+  });
+
+  it('agrees with the SPA slugify across every fixture name', () => {
+    for (const { name } of cases) {
+      expect(fnSlugify(name)).toBe(slugify(name));
+    }
+  });
+
+  it('builds identical merger paths', () => {
+    expect(fnMergerPath('WA-35022', 'Hexagon - Waygate Technologies')).toBe(
+      mergerPath('WA-35022', 'Hexagon - Waygate Technologies'),
+    );
+    // Bare-id fallback when no slug can be derived.
+    expect(fnMergerPath('MN-10007', '!!!')).toBe(mergerPath('MN-10007', '!!!'));
+  });
+});
+
+describe('mergerPath / industryPath / partyPath', () => {
+  it('appends the slug when one can be derived', () => {
+    expect(mergerPath('WA-35022', 'Hexagon - Waygate Technologies')).toBe(
+      '/mergers/WA-35022/hexagon-waygate-technologies',
+    );
+  });
+
+  it('falls back to the bare id when the name yields no slug', () => {
+    expect(mergerPath('MN-10007', '!!!')).toBe('/mergers/MN-10007');
+    expect(mergerPath('MN-10007', '')).toBe('/mergers/MN-10007');
+  });
+
+  it('URL-encodes the code/id segment', () => {
+    expect(industryPath('06/10', 'Coal Mining')).toBe('/industries/06%2F10/coal-mining');
+    expect(partyPath('a/b', 'Some Party')).toBe('/parties/a%2Fb/some-party');
+  });
+});

--- a/merger-tracker/frontend/vite.config.js
+++ b/merger-tracker/frontend/vite.config.js
@@ -1,6 +1,7 @@
 /// <reference types="vitest" />
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import prerenderMergers from './prerender.js'
 
 // Inlines the build CSS into index.html so first paint isn't blocked on a
 // separate stylesheet round-trip. The SPA only ships one CSS chunk and it's
@@ -23,7 +24,7 @@ function inlineCss() {
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), inlineCss()],
+  plugins: [react(), inlineCss(), prerenderMergers()],
   build: {
     rollupOptions: {
       output: {

--- a/scripts/tests/test_slug.py
+++ b/scripts/tests/test_slug.py
@@ -1,0 +1,56 @@
+"""Pins scripts/slug.py's slugify to the shared golden fixture.
+
+The slug algorithm is hand-copied into three places — this module
+(``scripts/slug.py``, used to build the sitemap), the SPA copy in
+``merger-tracker/frontend/src/utils/slug.js`` (rendered links, canonical tags
+and the build-time prerender), and the inline copy in
+``functions/mergers/[matter]/[[path]].js`` (the OG handler). If they diverge,
+the sitemap, canonical tags and rendered URLs disagree and search engines pick
+the wrong canonical page.
+
+``slug-cases.json`` at the repo root is the single source of truth binding all
+three. The JS side asserts against it in
+``merger-tracker/frontend/src/utils/__tests__/slug.test.js``; this file does the
+same for the Python copy. Change the algorithm -> update all three and
+regenerate the fixture.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Import scripts/slug.py the same way the other tests here reach scripts modules.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from slug import merger_path, slugify  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE = json.loads((REPO_ROOT / "slug-cases.json").read_text(encoding="utf-8"))
+CASES = FIXTURE["cases"]
+
+
+def test_fixture_is_non_empty():
+    assert isinstance(CASES, list)
+    assert CASES, "slug-cases.json has no cases"
+
+
+@pytest.mark.parametrize("case", CASES, ids=[c["slug"] or "<empty>" for c in CASES])
+def test_slugify_matches_golden_fixture(case):
+    assert slugify(case["name"]) == case["slug"]
+
+
+def test_slugify_handles_empty_and_none():
+    assert slugify("") == ""
+    assert slugify(None) == ""
+
+
+def test_merger_path_appends_slug_or_falls_back():
+    assert (
+        merger_path("WA-35022", "Hexagon - Waygate Technologies")
+        == "/mergers/WA-35022/hexagon-waygate-technologies"
+    )
+    # No derivable slug -> bare-id form.
+    assert merger_path("MN-10007", "!!!") == "/mergers/MN-10007"

--- a/slug-cases.json
+++ b/slug-cases.json
@@ -1,0 +1,85 @@
+{
+  "_comment": "Golden fixture pinning the slugify() algorithm across all three hand-synced implementations: merger-tracker/frontend/src/utils/slug.js (SPA links + canonical + prerender), scripts/slug.py (sitemap), and the inline copy in functions/mergers/[matter]/[[path]].js (OG handler). Exercised by merger-tracker/frontend/src/utils/__tests__/slug.test.js and scripts/tests/test_slug.py. Every {name -> slug} pair must hold in every implementation; if you change the algorithm, update all three and regenerate this file.",
+  "cases": [
+    {
+      "name": "Asahi – Warehouse site on Tilburn Rd, Deer Park (Vic)",
+      "slug": "asahi-warehouse-site-on-tilburn-rd-deer-park-vic"
+    },
+    {
+      "name": "Lawrence & Hanson - Gordon Macdonald",
+      "slug": "lawrence-hanson-gordon-macdonald"
+    },
+    {
+      "name": "Hexagon - Waygate Technologies",
+      "slug": "hexagon-waygate-technologies"
+    },
+    {
+      "name": "Macquarie Asset Management-led consortium / Qube",
+      "slug": "macquarie-asset-management-led-consortium-qube"
+    },
+    {
+      "name": "ACME Corp.",
+      "slug": "acme-corp"
+    },
+    {
+      "name": "  Leading and trailing spaces  ",
+      "slug": "leading-and-trailing-spaces"
+    },
+    {
+      "name": "Multiple---hyphens___and   spaces",
+      "slug": "multiple-hyphens-and-spaces"
+    },
+    {
+      "name": "Café Öland Ăē accents",
+      "slug": "caf-land-accents"
+    },
+    {
+      "name": "100% Pure / Co.",
+      "slug": "100-pure-co"
+    },
+    {
+      "name": "O'Brien Group",
+      "slug": "o-brien-group"
+    },
+    {
+      "name": "Foo—Bar (em dash)",
+      "slug": "foo-bar-em-dash"
+    },
+    {
+      "name": "MergerCo (2024)",
+      "slug": "mergerco-2024"
+    },
+    {
+      "name": "A very long merger name that goes well beyond the eighty character truncation limit yes indeed",
+      "slug": "a-very-long-merger-name-that-goes-well-beyond-the-eighty-character-truncation-li"
+    },
+    {
+      "name": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa extra words here",
+      "slug": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    {
+      "name": "!!!",
+      "slug": ""
+    },
+    {
+      "name": "---",
+      "slug": ""
+    },
+    {
+      "name": "",
+      "slug": ""
+    },
+    {
+      "name": "UPPERCASE NAME",
+      "slug": "uppercase-name"
+    },
+    {
+      "name": "Trailing punctuation!!!",
+      "slug": "trailing-punctuation"
+    },
+    {
+      "name": "ABC Pty Ltd & XYZ Holdings (No. 2)",
+      "slug": "abc-pty-ltd-xyz-holdings-no-2"
+    }
+  ]
+}


### PR DESCRIPTION
Merger detail pages are client-rendered: every `/mergers/{id}/{slug}` URL
served the identical `index.html`, with the per-page title, description and
`<link rel="canonical">` only injected after JS ran (react-helmet-async).
Search engines do duplicate-clustering and canonical selection on the raw,
pre-render HTML, so Google grouped unrelated mergers into one duplicate
cluster and picked an arbitrary URL as canonical (e.g. WA-35022 -> MN-10007,
WA-85032 -> WA-65004), leaving the real pages unindexed.

Add a Vite plugin that, after the bundle is written, stamps a static,
differentiated HTML file into `dist/mergers/{id}/{slug}/` for every merger
with the correct title, description, canonical, Open Graph/Twitter tags,
Article + BreadcrumbList JSON-LD and a real body summary in the raw markup.
The page still boots the SPA, so createRoot replaces the prerendered #root on
mount and users get the full interactive page — crawlers and users receive
the same HTML. Title/description mirror MergerDetail.jsx's <SEO> props and the
slug is derived via the shared slugify util so the output stays in sync with
the sitemap and client-rendered canonical.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FvvVsxDXssv2S7c8x9iRDE