### PR TITLE
Default tribunal event "filed by" to "Tribunal" when blank

### DIFF
--- a/scripts/static_data/enrichment.py
+++ b/scripts/static_data/enrichment.py
@@ -388,6 +388,21 @@ def _normalise_appeal_date(value: str | None) -> str | None:
     return value
 
 
+def _normalise_appeal_filed_by(value: str | None) -> str:
+    """Resolve a tribunal document's "filed by" to a display value.
+
+    Tribunal matter pages leave the "filed by" column blank — or fill it with a
+    placeholder dash — for documents the Tribunal itself issues (orders,
+    directions, reasons). Those show up scraped as ``None``, an empty string or
+    a lone dash. Treat any such value as filed by the Tribunal so the event
+    timeline never shows a bare "–".
+    """
+    text = (value or '').strip()
+    if not text or text.strip('-–—') == '':
+        return 'Tribunal'
+    return text
+
+
 def _appeal_event(doc: dict, appeal: dict) -> dict:
     """Turn a tribunal appeal document into a merger timeline event."""
     description = doc.get('description') or 'Tribunal document'
@@ -400,7 +415,7 @@ def _appeal_event(doc: dict, appeal: dict) -> dict:
         # Flags the event as originating from the tribunal appeal rather than
         # the ACCC register, so the frontend can style/label it distinctly.
         'is_appeal': True,
-        'appeal_filed_by': doc.get('filed_by'),
+        'appeal_filed_by': _normalise_appeal_filed_by(doc.get('filed_by')),
         'appeal_confidentiality': doc.get('confidentiality'),
         'tribunal_number': appeal.get('tribunal_number'),
         'phase': None,

--- a/scripts/tests/test_tribunal_appeals.py
+++ b/scripts/tests/test_tribunal_appeals.py
@@ -164,6 +164,26 @@ class TestLinkTribunalAppeals:
         assert ev['tribunal_number'] == 'ACT 1 of 2026'
         assert 'Application for Review' in ev['display_title']
 
+    def test_blank_filed_by_defaults_to_tribunal(self):
+        # A tribunal-issued document (order/direction/reasons) has no filing
+        # party; the matter page leaves the column blank or shows a lone dash.
+        # Each such value should surface as "Tribunal" in the event timeline.
+        for placeholder in (None, '', '  ', '-', '–', '—', ' - '):
+            appeal = _appeal()
+            appeal['MN-0001']['documents'][0]['filed_by'] = placeholder
+            mergers = [enrich_merger(_phase2_not_approved())]
+            link_tribunal_appeals(mergers, appeal)
+            ev = next(e for e in mergers[0]['events'] if e.get('is_appeal'))
+            assert ev['appeal_filed_by'] == 'Tribunal', repr(placeholder)
+
+    def test_real_filed_by_preserved(self):
+        appeal = _appeal()
+        appeal['MN-0001']['documents'][0]['filed_by'] = '  Coles  '
+        mergers = [enrich_merger(_phase2_not_approved())]
+        link_tribunal_appeals(mergers, appeal)
+        ev = next(e for e in mergers[0]['events'] if e.get('is_appeal'))
+        assert ev['appeal_filed_by'] == 'Coles'
+
     def test_no_appeal_leaves_merger_untouched(self):
         mergers = [enrich_merger(_phase2_not_approved('MN-9999'))]
         original_event_count = len(mergers[0]['events'])


### PR DESCRIPTION
Tribunal matter pages leave the "filed by" column blank, or fill it with
a placeholder dash, for documents the Tribunal itself issues (orders,
directions, reasons). These surfaced in the merger event timeline as a
bare "–" or nothing at all.

Normalise blank / dash-only "filed by" values to "Tribunal" when folding
tribunal documents into the event timeline, so those events attribute to
the Tribunal instead of showing an empty placeholder.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0137bSbXti4RYiGxt57hvDTN