### PR TITLE
Show the real filing date on dashboard appeal cards

### DIFF
--- a/merger-tracker/frontend/public/data/stats.json
+++ b/merger-tracker/frontend/public/data/stats.json
@@ -123,7 +123,7 @@
       "appeal_status": "current",
       "effective_determination": null,
       "tribunal_number": "ACT 1 of 2026",
-      "appeal_date": "2026-07-28T12:00:00Z"
+      "appeal_date": "2026-07-15T12:00:00Z"
     },
     {
       "merger_id": "MN-90027",

--- a/scripts/static_data/outputs/stats.py
+++ b/scripts/static_data/outputs/stats.py
@@ -11,19 +11,42 @@ from ..filters import filter_notifications, filter_waivers
 from ..loaders import BACKWARD_REFILE_RELATIONSHIPS
 
 
+def _as_event_datetime(value: str | None) -> str | None:
+    """Promote a bare ``YYYY-MM-DD`` to the event datetime format.
+
+    Tribunal dates are recorded as plain dates; padding them to midday UTC lets
+    them sort cleanly against the ISO notification datetimes.
+    """
+    if value and len(value) == 10 and value[4] == '-' and value[7] == '-':
+        return f"{value}T12:00:00Z"
+    return value
+
+
 def _appeal_activity_date(appeal: dict) -> str | None:
     """Most recent dated activity on a tribunal appeal.
 
     The latest document date, falling back to the application's filing date, so
-    the appeal stays "recent" on the dashboard as new filings land. A bare
-    ``YYYY-MM-DD`` is promoted to the event datetime format so it sorts cleanly
-    against the ISO notification datetimes.
+    the appeal stays "recent" on the dashboard as new filings land. This is a
+    sort key only — the card displays the filing date (see ``_appeal_filed_date``).
     """
     doc_dates = [d.get('date') for d in appeal.get('documents', []) if d.get('date')]
     activity = max(doc_dates) if doc_dates else appeal.get('filed_date')
-    if activity and len(activity) == 10 and activity[4] == '-' and activity[7] == '-':
-        return f"{activity}T12:00:00Z"
-    return activity
+    return _as_event_datetime(activity)
+
+
+def _appeal_filed_date(appeal: dict) -> str | None:
+    """When the appeal was lodged with the tribunal.
+
+    This is what the card labels "Appeal filed", so it must be the application's
+    own filing date rather than the latest activity — a document filed weeks
+    later must not move the stated filing date. Falls back to the earliest
+    document date when the overlay records no ``filed_date``.
+    """
+    filed = appeal.get('filed_date')
+    if not filed:
+        doc_dates = [d.get('date') for d in appeal.get('documents', []) if d.get('date')]
+        filed = min(doc_dates) if doc_dates else None
+    return _as_event_datetime(filed)
 
 
 def _appeal_card(merger: dict) -> dict | None:
@@ -44,8 +67,8 @@ def _appeal_card(merger: dict) -> dict | None:
         "merger_name": merger['merger_name'],
         "status": merger.get('status'),
         "accc_determination": merger.get('accc_determination'),
-        # Reused as the sort key so the appeal interleaves with notifications;
-        # the frontend shows it as the "Appeal filed" date, not a notification.
+        # Latest appeal activity, used only as the sort key so the appeal
+        # interleaves with notification cards and resurfaces as filings land.
         "effective_notification_datetime": activity_date,
         # Same same-day tie-break as notification cards (see _merger_sort_key).
         "page_modified_datetime": merger.get('page_modified_datetime', ''),
@@ -55,7 +78,9 @@ def _appeal_card(merger: dict) -> dict | None:
         "appeal_status": appeal.get('status'),
         "effective_determination": appeal.get('effective_determination'),
         "tribunal_number": appeal.get('tribunal_number'),
-        "appeal_date": activity_date,
+        # Displayed on the card as "Appeal filed", so it tracks the lodgement
+        # date and stays put as later documents arrive.
+        "appeal_date": _appeal_filed_date(appeal) or activity_date,
     }
 
 

--- a/scripts/tests/test_tribunal_appeals.py
+++ b/scripts/tests/test_tribunal_appeals.py
@@ -260,6 +260,39 @@ class TestDashboardRecentActivity:
         # A bare filing date is promoted so it sorts against ISO datetimes.
         assert card['appeal_date'] == '2026-07-15T12:00:00Z'
 
+    def test_appeal_date_stays_the_filing_date(self):
+        # Later documents keep the card "recent" (they drive the sort key) but
+        # must not shift the "Appeal filed" date shown on the card.
+        appeal = _appeal()
+        appeal['MN-0001']['documents'].append({
+            'date': '2026-07-28',
+            'filed_by': 'Australian Competition and Consumer Commission',
+            'description': 'Documentary Index',
+            'confidentiality': 'Non-confidential',
+            'url': 'https://www.competitiontribunal.gov.au/x/Documentary-Index.pdf',
+        })
+        mergers = [enrich_merger(_phase2_not_approved())]
+        link_tribunal_appeals(mergers, appeal)
+        card = [c for c in stats.generate(mergers)['recent_mergers'] if c.get('is_appeal')][0]
+        assert card['appeal_date'] == '2026-07-15T12:00:00Z'
+        assert card['effective_notification_datetime'] == '2026-07-28T12:00:00Z'
+
+    def test_appeal_date_falls_back_to_earliest_document(self):
+        # No recorded filing date → the first document stands in for it.
+        appeal = _appeal()
+        del appeal['MN-0001']['filed_date']
+        appeal['MN-0001']['documents'].append({
+            'date': '2026-07-28',
+            'filed_by': 'Australian Competition and Consumer Commission',
+            'description': 'Documentary Index',
+            'confidentiality': 'Non-confidential',
+            'url': 'https://www.competitiontribunal.gov.au/x/Documentary-Index.pdf',
+        })
+        mergers = [enrich_merger(_phase2_not_approved())]
+        link_tribunal_appeals(mergers, appeal)
+        card = [c for c in stats.generate(mergers)['recent_mergers'] if c.get('is_appeal')][0]
+        assert card['appeal_date'] == '2026-07-15T12:00:00Z'
+
     def test_no_appeal_means_no_appeal_card(self):
         mergers = [enrich_merger(_phase2_not_approved())]
         payload = stats.generate(mergers)


### PR DESCRIPTION
The "Appeal filed" line on the recently-notified cards was rendering the
appeal's latest activity date — the most recent tribunal document — so the
Coles appeal (ACT 1 of 2026, lodged 15 July) read as filed 28 July, the date
of the ACCC's documentary index.

Split the two dates: the latest activity date stays the card's sort key so an
appeal resurfaces as new filings land, while appeal_date now carries the
application's own filed_date (falling back to the earliest document date when
the overlay records none).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MWdLJzEab7WtCUadC6SpFv