### PR TITLE
Rank dashboard appeal cards by when the appeal was filed

### DIFF
--- a/merger-tracker/frontend/public/data/stats.json
+++ b/merger-tracker/frontend/public/data/stats.json
@@ -111,21 +111,6 @@
       "is_refiled": false
     },
     {
-      "merger_id": "MN-01068",
-      "merger_name": "Coles \u2013 supermarket and liquor site in Kalgoorlie, WA",
-      "status": "Assessment completed",
-      "accc_determination": "Not approved",
-      "effective_notification_datetime": "2026-07-28T12:00:00Z",
-      "page_modified_datetime": "2026-07-01T18:32:20+10:00",
-      "is_appeal": true,
-      "under_appeal": true,
-      "appeal_type": "party_denial",
-      "appeal_status": "current",
-      "effective_determination": null,
-      "tribunal_number": "ACT 1 of 2026",
-      "appeal_date": "2026-07-15T12:00:00Z"
-    },
-    {
       "merger_id": "MN-90027",
       "merger_name": "AbbVie - Apogee",
       "status": "Under assessment",
@@ -212,6 +197,16 @@
       "accc_determination": null,
       "effective_notification_datetime": "2026-07-21T12:00:00Z",
       "page_modified_datetime": "2026-07-22T14:47:16+10:00",
+      "is_waiver": false,
+      "is_refiled": false
+    },
+    {
+      "merger_id": "MN-05036",
+      "merger_name": "Vertex \u2013 Crinetics",
+      "status": "Under assessment",
+      "accc_determination": null,
+      "effective_notification_datetime": "2026-07-21T12:00:00Z",
+      "page_modified_datetime": "2026-07-22T11:26:33+10:00",
       "is_waiver": false,
       "is_refiled": false
     }

--- a/scripts/static_data/outputs/stats.py
+++ b/scripts/static_data/outputs/stats.py
@@ -22,25 +22,15 @@ def _as_event_datetime(value: str | None) -> str | None:
     return value
 
 
-def _appeal_activity_date(appeal: dict) -> str | None:
-    """Most recent dated activity on a tribunal appeal.
-
-    The latest document date, falling back to the application's filing date, so
-    the appeal stays "recent" on the dashboard as new filings land. This is a
-    sort key only — the card displays the filing date (see ``_appeal_filed_date``).
-    """
-    doc_dates = [d.get('date') for d in appeal.get('documents', []) if d.get('date')]
-    activity = max(doc_dates) if doc_dates else appeal.get('filed_date')
-    return _as_event_datetime(activity)
-
-
 def _appeal_filed_date(appeal: dict) -> str | None:
     """When the appeal was lodged with the tribunal.
 
-    This is what the card labels "Appeal filed", so it must be the application's
-    own filing date rather than the latest activity — a document filed weeks
-    later must not move the stated filing date. Falls back to the earliest
-    document date when the overlay records no ``filed_date``.
+    Both what the card labels "Appeal filed" and how it ranks among the recent
+    cards, so it must be the application's own filing date rather than its
+    latest activity — a document filed weeks later must neither move the stated
+    filing date nor refloat a stale appeal to the top of the dashboard. Falls
+    back to the earliest document date when the overlay records no
+    ``filed_date``.
     """
     filed = appeal.get('filed_date')
     if not filed:
@@ -59,17 +49,18 @@ def _appeal_card(merger: dict) -> dict | None:
     appeal = merger.get('appeal')
     if not appeal:
         return None
-    activity_date = _appeal_activity_date(appeal)
-    if not activity_date:
+    filed_date = _appeal_filed_date(appeal)
+    if not filed_date:
         return None
     return {
         "merger_id": merger['merger_id'],
         "merger_name": merger['merger_name'],
         "status": merger.get('status'),
         "accc_determination": merger.get('accc_determination'),
-        # Latest appeal activity, used only as the sort key so the appeal
-        # interleaves with notification cards and resurfaces as filings land.
-        "effective_notification_datetime": activity_date,
+        # The lodgement date doubles as the sort key so the appeal interleaves
+        # with notification cards by when it was filed, then ages off the
+        # dashboard like any other card.
+        "effective_notification_datetime": filed_date,
         # Same same-day tie-break as notification cards (see _merger_sort_key).
         "page_modified_datetime": merger.get('page_modified_datetime', ''),
         "is_appeal": True,
@@ -78,9 +69,8 @@ def _appeal_card(merger: dict) -> dict | None:
         "appeal_status": appeal.get('status'),
         "effective_determination": appeal.get('effective_determination'),
         "tribunal_number": appeal.get('tribunal_number'),
-        # Displayed on the card as "Appeal filed", so it tracks the lodgement
-        # date and stays put as later documents arrive.
-        "appeal_date": _appeal_filed_date(appeal) or activity_date,
+        # Displayed on the card as "Appeal filed".
+        "appeal_date": filed_date,
     }
 
 
@@ -187,8 +177,8 @@ def generate(mergers: list) -> dict:
 
     # Recent mergers (include all but mark waivers). Tribunal appeals are folded
     # in as their own activity cards (see _appeal_card) so a freshly-lodged appeal
-    # surfaces on the dashboard alongside recent notifications, ranked by the same
-    # date. A card slice of 12 is taken after merging the two streams.
+    # surfaces on the dashboard alongside recent notifications, ranked by its
+    # filing date. A card slice of 12 is taken after merging the two streams.
     # Notification datetimes are stored at a nominal midday, so same-day
     # notifications all tie on effective_notification_datetime. Break the tie by
     # page_modified_datetime — the real register timestamp — so a merger that

--- a/scripts/tests/test_tribunal_appeals.py
+++ b/scripts/tests/test_tribunal_appeals.py
@@ -261,8 +261,9 @@ class TestDashboardRecentActivity:
         assert card['appeal_date'] == '2026-07-15T12:00:00Z'
 
     def test_appeal_date_stays_the_filing_date(self):
-        # Later documents keep the card "recent" (they drive the sort key) but
-        # must not shift the "Appeal filed" date shown on the card.
+        # Later documents must not shift the "Appeal filed" date shown on the
+        # card, nor refloat the card to the top of the dashboard: the card is
+        # ranked by when the appeal was lodged, so it ages off like any other.
         appeal = _appeal()
         appeal['MN-0001']['documents'].append({
             'date': '2026-07-28',
@@ -275,7 +276,7 @@ class TestDashboardRecentActivity:
         link_tribunal_appeals(mergers, appeal)
         card = [c for c in stats.generate(mergers)['recent_mergers'] if c.get('is_appeal')][0]
         assert card['appeal_date'] == '2026-07-15T12:00:00Z'
-        assert card['effective_notification_datetime'] == '2026-07-28T12:00:00Z'
+        assert card['effective_notification_datetime'] == '2026-07-15T12:00:00Z'
 
     def test_appeal_date_falls_back_to_earliest_document(self):
         # No recorded filing date → the first document stands in for it.


### PR DESCRIPTION
The appeal card's sort key was the latest tribunal document date, so the
Coles appeal (lodged 15 July) kept jumping back to the top of "Recently
notified mergers" every time a new document landed — reading as brand new
next to a card that says "Appeal filed 15 July".

Use the filing date for both the displayed date and the sort key, so an
appeal surfaces when it is lodged and then ages off the dashboard like any
other card. Regenerated stats.json: the Coles appeal drops out of the
twelve-card slice and Vertex - Crinetics takes the last place.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017XQnRWbZkkDTa6SpzzF2dH