### PR TITLE
Fold Accenture Venture Holdings, LLC into the Accenture group

### DIFF
--- a/data/processed/related_parties.json
+++ b/data/processed/related_parties.json
@@ -504,6 +504,14 @@
         {
           "name": "Accenture Venture Holdings B.V.",
           "identifier": "KVK  42007173"
+        },
+        {
+          "name": "Accenture Venture Holdings, LLC",
+          "identifier": "Delaware registered number  10429510"
+        },
+        {
+          "name": "Accenture Venture Holdings, LLC",
+          "identifier": "Delaware file number  10429510"
         }
       ]
     },
@@ -1966,20 +1974,6 @@
         {
           "name": "Apollo Capital Management, L.P.",
           "identifier": "4293091"
-        }
-      ]
-    },
-    {
-      "id": "accenture-venture-holdings-llc",
-      "canonical_name": "Accenture Venture Holdings, LLC",
-      "members": [
-        {
-          "name": "Accenture Venture Holdings, LLC",
-          "identifier": "Delaware registered number  10429510"
-        },
-        {
-          "name": "Accenture Venture Holdings, LLC",
-          "identifier": "Delaware file number  10429510"
         }
       ]
     },


### PR DESCRIPTION
The daily related-party detector created a separate canonical group for
the two "Accenture Venture Holdings, LLC" records (Delaware file number /
registered number 10429510) on MN-50032 and MN-60031. It is the same
real-world entity as the rest of the Accenture group, which already holds
Accenture plc, Accenture Inc., Accenture International B.V., Accenture
Venture Holdings B.V. and the Australian subsidiaries.

Merge the two groups so all Accenture parties link to one canonical
party page.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014kzZEunjPY3EhRF815pok4