### PR TITLE
Align stat card labels, values and subtitles across a row

### DIFF
--- a/merger-tracker/frontend/src/components/StatCard.jsx
+++ b/merger-tracker/frontend/src/components/StatCard.jsx
@@ -18,8 +18,12 @@ function StatCard({ title, value, subtitle, icon, href }) {
             </div>
           )}
           <div className="flex-1 min-w-0">
+            {/* The label reserves two lines so the value below it starts at the
+                same height in every card of a row, whether or not that card's
+                label wraps. Without it, a one-line label lifts its number 20px
+                above its neighbours'. */}
             <dl>
-              <dt className="text-sm font-medium text-gray-500 mb-1">
+              <dt className="text-sm font-medium text-gray-500 leading-5 min-h-10 mb-1">
                 {title}
               </dt>
               <dd>
@@ -28,7 +32,7 @@ function StatCard({ title, value, subtitle, icon, href }) {
                 </div>
               </dd>
               {subtitle && (
-                <dd className="text-sm text-gray-500 mt-1">{subtitle}</dd>
+                <dd className="text-sm text-gray-500 leading-5 mt-1">{subtitle}</dd>
               )}
             </dl>
           </div>

--- a/merger-tracker/frontend/src/pages/RefiledNotifications.jsx
+++ b/merger-tracker/frontend/src/pages/RefiledNotifications.jsx
@@ -214,11 +214,22 @@ function RefiledNotifications() {
         </header>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-          <StatCard title="Waivers re-filed" value={totalPairs} icon={<FaArrowRightArrowLeft />} />
-          <StatCard title="Awaiting a determination" value={current.length} icon={<FaHourglassHalf />} />
+          <StatCard
+            title="Waivers re-filed"
+            value={totalPairs}
+            subtitle="Waiver declined, then notified"
+            icon={<FaArrowRightArrowLeft />}
+          />
+          <StatCard
+            title="Awaiting a determination"
+            value={current.length}
+            subtitle={`${completed.length} already determined`}
+            icon={<FaHourglassHalf />}
+          />
           <StatCard
             title="Median time to re-file"
             value={medianDaysToRefile !== null ? `${medianDaysToRefile} days` : 'N/A'}
+            subtitle="From decline to re-filing"
             icon={<FaCalendarDays />}
           />
           <StatCard


### PR DESCRIPTION
The stat card grid on the refiled-notifications page rendered its four
numbers at two different heights: cards whose label fitted on one line
("Waivers re-filed", "Clearance rate") lifted their value 20px above the
cards whose label wrapped to two ("Awaiting a determination", "Median
time to re-file"). The same thing happens on the extensions page.

Reserve two lines for the label so the value always starts at the same
height, and give the three refiled cards the subtitle they were missing —
previously only the clearance-rate card had one, so it was the only card
whose content reached the bottom of the (grid-stretched) row.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01731GgcRd62kxQmUd8p6k1y