### PR TITLE
Keep PDFs over the 25 MiB Pages limit out of the deployment

### DIFF
--- a/.github/workflows/check-deploy-assets.yml
+++ b/.github/workflows/check-deploy-assets.yml
@@ -1,0 +1,102 @@
+name: Check Deploy Assets
+
+# Cloudflare Pages won't deploy an asset over 25 MiB. scripts/build.sh leaves
+# those out so the rest of the site still ships and the Pages Function redirects
+# them to their source URL — which means an oversized file no longer announces
+# itself as a failed build. It just quietly stops being hosted. This workflow is
+# the notification for that: it opens a tracking issue, updates it as the set of
+# offending files changes, and closes it once they're gone.
+#
+# It runs on push to main rather than inside the scrape workflows so it catches
+# files arriving by any route — the pipeline, the tribunal scraper, a manual
+# workflow run, or a direct commit. scripts/compress_pdfs.py has already had its
+# go by this point, so anything reported here is something compression couldn't
+# fix or never saw.
+
+on:
+  push:
+    branches:
+      - main
+    # Mirrors DEPLOY_SOURCES in scripts/check_deploy_assets.py — the only trees
+    # that end up in the deployment. Keep the two in step.
+    paths:
+      - 'data/raw/matters/**'
+      - 'merger-tracker/frontend/public/**'
+      - 'scripts/check_deploy_assets.py'
+      - '.github/workflows/check-deploy-assets.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: check-deploy-assets
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      # Writes the findings and a ready-to-post issue body to the runner's temp
+      # dir. Exits 0 either way — an oversized file is reported as an issue, not
+      # as a red workflow run, since the site itself is still fine.
+      - name: Find oversized deployable files
+        run: |
+          python scripts/check_deploy_assets.py --json "$RUNNER_TEMP/oversized.json"
+
+      - name: Open, update or close the tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          FILE="$RUNNER_TEMP/oversized.json"
+          COUNT=$(jq '.count' "$FILE")
+
+          gh label create "oversized-asset" \
+            --description "File too large for Cloudflare Pages to deploy" \
+            --color "d93f0b" \
+            --force
+
+          # At most one issue is ever open for this — it lists every offending
+          # file, so a second file doesn't warrant a second issue.
+          NUMBER=$(gh issue list \
+            --label "oversized-asset" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ "$COUNT" -eq 0 ]; then
+            if [ -n "$NUMBER" ]; then
+              gh issue comment "$NUMBER" \
+                --body "Nothing is over the Pages asset limit any more — closing automatically."
+              gh issue close "$NUMBER"
+              echo "Closed #$NUMBER"
+            else
+              echo "Nothing over the limit, no open issue"
+            fi
+            exit 0
+          fi
+
+          jq -r '.body' "$FILE" > issue_body.md
+          TITLE=$(jq -r '.title' "$FILE")
+
+          if [ -n "$NUMBER" ]; then
+            # Refresh the existing issue so it always reflects the current set
+            # rather than whatever was true when it was first opened.
+            gh issue edit "$NUMBER" --title "$TITLE" --body-file issue_body.md
+            echo "Updated #$NUMBER ($COUNT file(s) over the limit)"
+          else
+            gh issue create \
+              --label "oversized-asset" \
+              --title "$TITLE" \
+              --body-file issue_body.md
+            echo "Opened a tracking issue ($COUNT file(s) over the limit)"
+          fi

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -222,6 +222,25 @@ jobs:
           ./scripts/generate-cli-data.sh
           python scripts/generate_rss_feed.py
 
+      # Cloudflare Pages rejects an entire deployment if any single asset is
+      # over 25 MiB, so a scanned exhibit that lands over it takes the site
+      # build down until it's shrunk. Do that before the files are committed.
+      # Ghostscript is only installed when there's something to compress, which
+      # is rare — the same pattern as the Tesseract step above.
+      - name: Compress oversized PDFs
+        if: |
+          steps.scrape-changes.outputs.changed == 'true'
+          || steps.find-docx.outputs.has_unconverted == 'true'
+          || github.event_name != 'schedule'
+        run: |
+          if find data/raw/matters -type f -name '*.pdf' -size +25M | grep -q .; then
+            sudo apt-get update
+            sudo apt-get install -y ghostscript --no-install-recommends
+            python scripts/compress_pdfs.py
+          else
+            echo "No PDFs over the 25 MiB Pages asset limit"
+          fi
+
       - name: Stage extracted data
         if: |
           steps.scrape-changes.outputs.changed == 'true'

--- a/.github/workflows/scrape-tribunal.yml
+++ b/.github/workflows/scrape-tribunal.yml
@@ -63,6 +63,27 @@ jobs:
       run: |
         xvfb-run -a python scripts/scrape_tribunal.py ${{ github.event.inputs.merger_ids }}
 
+    - name: Compress oversized PDFs
+      # Cloudflare Pages rejects an entire deployment if any single asset is
+      # over 25 MiB, and tribunal exhibits are the documents most likely to
+      # exceed it — scanned affidavits run to tens of megabytes. Shrink them
+      # before they're committed, or the next site build fails. Runs on the same
+      # always() basis as the commit below, so a partial scrape still gets it.
+      if: always()
+      run: |
+        if find data/raw/matters -type f -name '*.pdf' -size +25M | grep -q .; then
+          sudo apt-get update
+          sudo apt-get install -y ghostscript --no-install-recommends
+          # requirements-tribunal.txt is deliberately lean and has no PDF
+          # library; compress_pdfs.py validates its output with pdfplumber, so
+          # pull the main pipeline's pinned set in on the rare run that needs it
+          # rather than pinning pdfplumber a second time in its own file.
+          pip install -r scripts/requirements.txt
+          python scripts/compress_pdfs.py
+        else
+          echo "No PDFs over the 25 MiB Pages asset limit"
+        fi
+
     - name: Commit and push changes
       # Always run so any matters that did scrape are committed even if others
       # failed to clear the challenge (the run step exits non-zero in that case).

--- a/functions/mergers/[matter]/[[path]].js
+++ b/functions/mergers/[matter]/[[path]].js
@@ -96,6 +96,80 @@ async function serveOgPage(matterId, origin, env) {
   });
 }
 
+function safeDecode(str) {
+  try {
+    return decodeURIComponent(str);
+  } catch {
+    return str;
+  }
+}
+
+// Normalise the matter ID to uppercase: the static data files and SPA routes
+// are uppercase, so a hand-typed lowercase URL would otherwise produce a viewer
+// whose PDF fetch and back-link 404.
+function canonicalisePath(path) {
+  const match = path.match(/^\/mergers\/((MN|WA)-\d+)\//i);
+  if (!match) return path;
+  return path.replace(/^\/mergers\/(?:MN|WA)-\d+\//i, `/mergers/${match[1].toUpperCase()}/`);
+}
+
+// The source URL on the ACCC/Tribunal site that this document was scraped from,
+// or null if we don't have one. Each event in the matter's JSON carries both the
+// upstream `url` and the `url_gh` path we serve it under.
+async function sourceUrlForDocument(path, origin, env) {
+  const match = path.match(/^\/mergers\/((MN|WA)-\d+)\//i);
+  if (!match) return null;
+  const matterId = match[1].toUpperCase();
+
+  let merger;
+  try {
+    const dataUrl = new URL(`/data/mergers/${matterId}.json`, origin);
+    const resp = await env.ASSETS.fetch(new Request(dataUrl.toString()));
+    if (!resp.ok) return null;
+    merger = await resp.json();
+  } catch {
+    return null;
+  }
+
+  // url_gh is stored unencoded ("/mergers/MN-01068/NOCC - March 2026.pdf") while
+  // the request path arrives percent-encoded, so compare both sides decoded.
+  const wanted = safeDecode(canonicalisePath(path));
+  const event = (merger.events || []).find(
+    (e) => e.url_gh && e.url && safeDecode(canonicalisePath(e.url_gh)) === wanted,
+  );
+  if (!event) return null;
+
+  // Only ever bounce to http(s) — the events are scraped from accc.gov.au and
+  // competitiontribunal.gov.au, but this is a redirect built from data, so it
+  // shouldn't be able to emit anything but a web URL.
+  try {
+    const parsed = new URL(event.url);
+    return parsed.protocol === 'https:' || parsed.protocol === 'http:' ? parsed.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
+// Serve the PDF itself from the deployment's static assets.
+//
+// Documents over Cloudflare Pages' 25 MiB per-asset limit are left out of the
+// deployment by scripts/build.sh (the whole deploy is rejected otherwise), so
+// for those the asset lookup misses and Pages answers with the SPA shell rather
+// than a 404. Treat "didn't come back as a PDF" as the miss and redirect to the
+// document's source URL, so the link still resolves for the reader.
+async function serveRawPdf(path, origin, env) {
+  const assetUrl = new URL(path, origin);
+  const response = await env.ASSETS.fetch(new Request(assetUrl.toString()));
+
+  const contentType = response.headers.get('Content-Type') || '';
+  if (response.ok && contentType.toLowerCase().includes('application/pdf')) {
+    return response;
+  }
+
+  const sourceUrl = await sourceUrlForDocument(path, origin, env);
+  return sourceUrl ? Response.redirect(sourceUrl, 302) : response;
+}
+
 export async function onRequest(context) {
   const { request, env } = context;
   const url = new URL(request.url);
@@ -123,16 +197,14 @@ export async function onRequest(context) {
   // If ?raw param is present, serve the actual PDF from static assets
   // (used by the embedded viewer and direct download links)
   if (url.searchParams.has('raw')) {
-    const assetUrl = new URL(path, url.origin);
-    return env.ASSETS.fetch(new Request(assetUrl.toString()));
+    return serveRawPdf(path, url.origin, env);
   }
 
   // Mobile browsers (Android, iPhone, iPod) don't support inline PDF rendering
   // via <object> tags — serve the raw PDF directly instead of the viewer wrapper
   const ua = request.headers.get('User-Agent') || '';
   if (/Android|iPhone|iPod/i.test(ua)) {
-    const assetUrl = new URL(path, url.origin);
-    return env.ASSETS.fetch(new Request(assetUrl.toString()));
+    return serveRawPdf(path, url.origin, env);
   }
 
   // Extract matter ID from the path: /mergers/{MN,WA}-XXXXX/filename.pdf
@@ -141,12 +213,9 @@ export async function onRequest(context) {
     return context.next();
   }
 
-  // Normalise the matter ID to uppercase (as the OG branch above does): the
-  // static data files and SPA routes are uppercase, so a hand-typed lowercase
-  // URL would otherwise produce a viewer whose PDF fetch and back-link 404.
   const matterId = match[1].toUpperCase();
-  const canonicalPath = path.replace(/^\/mergers\/(?:MN|WA)-\d+\//i, `/mergers/${matterId}/`);
-  const displayName = decodeURIComponent(path.split('/').pop()).replace(/\.pdf$/i, '');
+  const canonicalPath = canonicalisePath(path);
+  const displayName = safeDecode(path.split('/').pop()).replace(/\.pdf$/i, '');
 
   const html = renderViewer({
     matterId,

--- a/merger-tracker/frontend/src/utils/__tests__/pdfViewerFunction.test.js
+++ b/merger-tracker/frontend/src/utils/__tests__/pdfViewerFunction.test.js
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+
+// The Pages Function that serves /mergers/{MN,WA}-XXXXX/<file>.pdf. Cloudflare
+// only invokes onRequest, so exercising it here means faking the two pieces of
+// the runtime it touches: the ASSETS binding and context.next().
+import { onRequest } from '../../../../../functions/mergers/[matter]/[[path]].js';
+
+const PDF_PATH = '/mergers/MN-01068/Affidavit of Benjamin James Welk.pdf';
+const SOURCE_URL =
+  'https://www.competitiontribunal.gov.au/__data/assets/pdf_file/0004/602167/Affidavit-of-Benjamin-James-Welk.pdf';
+
+const MERGER_JSON = {
+  merger_name: 'Woolworths / Coles Kalgoorlie',
+  events: [
+    {
+      title: 'Affidavit of Benjamin James Welk',
+      url: SOURCE_URL,
+      url_gh: PDF_PATH,
+    },
+  ],
+};
+
+// Stands in for env.ASSETS: `assets` maps a pathname to the Response the
+// deployment would return. Anything not listed is a miss, which Pages answers
+// with the SPA shell (HTML, 200) rather than a 404 — the case the fallback in
+// the Function has to recognise.
+function makeEnv(assets) {
+  return {
+    ASSETS: {
+      fetch: async (request) => {
+        // Pathnames arrive percent-encoded; the asset map is keyed by the real
+        // filename, as the deployment's file tree is.
+        const pathname = decodeURIComponent(new URL(request.url).pathname);
+        if (pathname in assets) return assets[pathname];
+        return new Response('<!doctype html><title>Australian Merger Tracker</title>', {
+          headers: { 'Content-Type': 'text/html; charset=utf-8' },
+        });
+      },
+    },
+  };
+}
+
+function pdfResponse() {
+  return new Response('%PDF-1.7 ...', { headers: { 'Content-Type': 'application/pdf' } });
+}
+
+function jsonResponse(body) {
+  return new Response(JSON.stringify(body), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function makeContext({ url, env, userAgent = 'Mozilla/5.0 (Macintosh)' }) {
+  return {
+    request: new Request(url, { headers: { 'User-Agent': userAgent } }),
+    env,
+    next: async () => new Response('passed through', { status: 599 }),
+  };
+}
+
+const rawUrl = `https://mergers.fyi${encodeURI(PDF_PATH)}?raw=1`;
+const dataPath = '/data/mergers/MN-01068.json';
+
+describe('PDF asset serving', () => {
+  it('serves the deployed PDF when it is present', async () => {
+    const env = makeEnv({ [PDF_PATH]: pdfResponse() });
+    const response = await onRequest(makeContext({ url: rawUrl, env }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('application/pdf');
+  });
+
+  it('redirects to the source URL when the PDF is too big to deploy', async () => {
+    // No PDF asset — scripts/build.sh leaves files over 25 MiB out of dist/.
+    const env = makeEnv({ [dataPath]: jsonResponse(MERGER_JSON) });
+    const response = await onRequest(makeContext({ url: rawUrl, env }));
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe(SOURCE_URL);
+  });
+
+  it('redirects on mobile too, where the viewer wrapper is skipped', async () => {
+    const env = makeEnv({ [dataPath]: jsonResponse(MERGER_JSON) });
+    const response = await onRequest(
+      makeContext({
+        url: `https://mergers.fyi${encodeURI(PDF_PATH)}`,
+        env,
+        userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)',
+      }),
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe(SOURCE_URL);
+  });
+
+  it('matches the event by url_gh even when the request path is lowercase', async () => {
+    const env = makeEnv({ [dataPath]: jsonResponse(MERGER_JSON) });
+    const response = await onRequest(
+      makeContext({
+        url: `https://mergers.fyi${encodeURI(PDF_PATH.replace('MN-01068', 'mn-01068'))}?raw=1`,
+        env,
+      }),
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe(SOURCE_URL);
+  });
+
+  it('falls back to the asset response when no source URL is known', async () => {
+    const env = makeEnv({
+      [dataPath]: jsonResponse({ ...MERGER_JSON, events: [{ title: 'No link' }] }),
+    });
+    const response = await onRequest(makeContext({ url: rawUrl, env }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toContain('text/html');
+  });
+
+  it('refuses to redirect to a non-http(s) source URL', async () => {
+    const env = makeEnv({
+      [dataPath]: jsonResponse({
+        events: [{ url: 'javascript:alert(1)', url_gh: PDF_PATH }],
+      }),
+    });
+    const response = await onRequest(makeContext({ url: rawUrl, env }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toContain('text/html');
+  });
+
+  it('still renders the viewer wrapper for a desktop request', async () => {
+    const env = makeEnv({ [PDF_PATH]: pdfResponse() });
+    const response = await onRequest(
+      makeContext({ url: `https://mergers.fyi${encodeURI(PDF_PATH)}`, env }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toContain('text/html');
+    await expect(response.text()).resolves.toContain('?raw=1');
+  });
+});

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -30,6 +30,16 @@ npm run build
 # The destination is shared with the prerendered merger pages
 # (dist/mergers/<id>/<slug>/index.html), so this step must only ever add files
 # to dist/mergers — never clear it.
+#
+# Pages refuses to deploy at all if *any* single asset is over 25 MiB, so PDFs
+# above that are left out of dist/ (the occasional scanned tribunal affidavit
+# runs to ~30 MB). They stay in the repo — only the deployment skips them, and
+# the Pages Function serving /mergers/**/*.pdf redirects to the document's
+# source URL when the asset isn't there. `find -size +25M` rounds each file up
+# to whole 25 MiB units, so it matches strictly-larger-than files only, which
+# is exactly the limit Pages enforces.
+MAX_ASSET_SIZE="25M"
+
 data_root="$(cd "../../$DATA_DIR" 2>/dev/null && pwd -P)" || data_root=""
 if [ -n "$data_root" ]; then
   dest="$PWD/dist/mergers"
@@ -46,8 +56,16 @@ if [ -n "$data_root" ]; then
 
   # `cp --parents` recreates each file's path relative to the current
   # directory, so run it from the data dir to get <matter-path>/<file>.pdf.
-  (cd "$data_root" && find . -type f -name "*.pdf" -exec cp "${cp_opts[@]}" -t "$dest" {} +)
+  (cd "$data_root" && find . -type f -name "*.pdf" ! -size "+$MAX_ASSET_SIZE" \
+    -exec cp "${cp_opts[@]}" -t "$dest" {} +)
   echo "Copied PDFs from $DATA_DIR into dist/mergers/"
+
+  oversized="$(cd "$data_root" && find . -type f -name "*.pdf" -size "+$MAX_ASSET_SIZE" \
+    -printf '  %P (%s bytes)\n' | sort)"
+  if [ -n "$oversized" ]; then
+    echo "Skipped $(printf '%s\n' "$oversized" | wc -l) PDF(s) over the ${MAX_ASSET_SIZE}iB Pages asset limit:"
+    printf '%s\n' "$oversized"
+  fi
 else
   echo "Warning: $DATA_DIR not found, skipping PDF copy"
 fi

--- a/scripts/check_deploy_assets.py
+++ b/scripts/check_deploy_assets.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Report files that are too big for Cloudflare Pages to deploy.
+
+This is the safety net behind scripts/compress_pdfs.py. Compression runs in the
+scrape workflows before anything is committed and handles the ordinary case (a
+scanned exhibit stored as lossless bitmaps), but it can't help every file — a
+PDF that's genuinely 200 MB of imagery won't come under the limit at any
+quality, and files can reach the repo by routes that never run compression at
+all (a manual workflow, a direct commit).
+
+Whatever it can't fix used to surface as a hard Pages build failure. It doesn't
+any more: scripts/build.sh leaves oversized files out of the deployment so the
+rest of the site still ships, and the Pages Function redirects them to their
+source URL. That's the right trade for availability, but it means an oversized
+file is now *silent* — the site builds green while quietly not hosting the
+document. Hence this check, which runs on every push to main and opens a GitHub
+issue so it's visible.
+
+What counts as deployable is whatever ends up in dist/, which is exactly two
+source trees: the PDFs scripts/build.sh copies out of data/raw/matters, and
+Vite's publicDir, copied verbatim. Keep DEPLOY_SOURCES in step with those.
+(Vite's own build output — JS/CSS chunks — is orders of magnitude below the
+limit and doesn't exist until build time, so it isn't checked here.)
+
+Usage:
+    python scripts/check_deploy_assets.py             # report; exit 0
+    python scripts/check_deploy_assets.py --fail      # exit 1 if anything is over
+    python scripts/check_deploy_assets.py --json out.json   # payload for CI
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from compress_pdfs import PAGES_ASSET_LIMIT, format_size  # noqa: E402
+
+# (directory, glob) pairs that feed the deployment. See the module docstring.
+DEPLOY_SOURCES = (
+    ("data/raw/matters", "*.pdf"),
+    ("merger-tracker/frontend/public", "*"),
+)
+
+ISSUE_LABEL = "oversized-asset"
+ISSUE_TITLE = "Files too large to deploy to Cloudflare Pages"
+
+
+def find_oversized(root=Path("."), limit=PAGES_ASSET_LIMIT, sources=DEPLOY_SOURCES):
+    """Deployable files over ``limit``, as ``(relative_path, size)``, largest first."""
+    root = Path(root)
+    found = {}
+    for directory, pattern in sources:
+        base = root / directory
+        if not base.exists():
+            continue
+        for path in base.rglob(pattern):
+            if not path.is_file():
+                continue
+            size = path.stat().st_size
+            if size > limit:
+                found[str(path.relative_to(root))] = size
+    return sorted(found.items(), key=lambda kv: (-kv[1], kv[0]))
+
+
+def build_issue_body(oversized, limit=PAGES_ASSET_LIMIT):
+    """Markdown for the tracking issue."""
+    lines = [
+        f"{len(oversized)} file(s) in the deployment sources are over Cloudflare "
+        f"Pages' {format_size(limit)} per-asset limit.",
+        "",
+        "These are **left out of the deployed site** by `scripts/build.sh` — the "
+        "build stays green and the rest of the site ships normally, but the "
+        "documents themselves aren't hosted. Requests for them are redirected to "
+        "their source URL on the ACCC/Tribunal site by the Pages Function, so "
+        "links still resolve; the copy under our control is just missing.",
+        "",
+        "| File | Size |",
+        "| --- | ---: |",
+    ]
+    for path, size in oversized:
+        # ACCC filenames are free-form and occasionally carry characters that
+        # would break out of a markdown table cell or a code span.
+        cell = path.replace("|", "\\|").replace("`", "'")
+        lines.append(f"| `{cell}` | {format_size(size)} |")
+
+    lines += [
+        "",
+        "### What to do",
+        "",
+        "Try compression first — it fixes most cases, and it's what the scrape "
+        "workflows already run automatically:",
+        "",
+        "```",
+        "python scripts/compress_pdfs.py",
+        "```",
+        "",
+        "If that reports it can't get the file under the limit, it's a file "
+        "whose content genuinely needs the bytes. Options are to accept the "
+        "redirect-to-source behaviour (nothing to do — close this issue), or to "
+        "split the document. Lowering `--target` trades quality for size if the "
+        "file is close.",
+        "",
+        "This issue closes itself once nothing is over the limit.",
+    ]
+    return "\n".join(lines)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--root", type=Path, default=Path("."))
+    parser.add_argument(
+        "--limit", type=int, default=PAGES_ASSET_LIMIT,
+        help="per-asset size limit in bytes (default: Cloudflare Pages' 25 MiB)",
+    )
+    parser.add_argument(
+        "--json", type=Path, metavar="PATH",
+        help="write the findings and a ready-to-post issue body to PATH",
+    )
+    parser.add_argument(
+        "--fail", action="store_true",
+        help="exit non-zero when a file is over the limit",
+    )
+    args = parser.parse_args(argv)
+
+    oversized = find_oversized(args.root, args.limit)
+
+    if args.json:
+        payload = {
+            "count": len(oversized),
+            "files": [{"path": p, "size": s} for p, s in oversized],
+            "title": ISSUE_TITLE,
+            "body": build_issue_body(oversized, args.limit) if oversized else "",
+        }
+        args.json.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    if not oversized:
+        print(f"No deployable files over {format_size(args.limit)}")
+        return 0
+
+    print(
+        f"{len(oversized)} file(s) over {format_size(args.limit)} — these will be "
+        f"left out of the deployment:",
+        file=sys.stderr,
+    )
+    for path, size in oversized:
+        print(f"  {path} ({format_size(size)})", file=sys.stderr)
+    print("Run `python scripts/compress_pdfs.py` to try to shrink them.", file=sys.stderr)
+
+    return 1 if args.fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/compress_pdfs.py
+++ b/scripts/compress_pdfs.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Shrink PDFs that are too big for Cloudflare Pages to deploy.
+
+Pages rejects an *entire* deployment if any single asset is over 25 MiB, so one
+outsized attachment takes the whole site build down. Scanned exhibits from the
+Competition Tribunal are the usual culprit: MN-01068's 30.8 MB affidavit is 69
+page scans stored as lossless Flate RGB bitmaps, which is a very expensive way
+to hold what is really a fax-quality scan of a typed document.
+
+Ghostscript re-encodes those page images as JPEG. At the presets used here it
+leaves the page count, the text layer and the image pixel dimensions alone — the
+30.8 MB affidavit comes out at 20.6 MB with no visible difference at reading
+zoom — so this is a storage-format change, not a resampling of the document.
+
+The file is rewritten in place under data/raw/matters. Both scrapers skip a
+document whose local path already exists (see ``download_attachment`` in
+extract_mergers.py and ``_resolve_download_target`` in scrape_tribunal.py), so a
+compressed file stays compressed rather than being re-fetched at full size on
+the next run. The originals remain in git history.
+
+Compression is best-effort: anything that can't be brought under the limit, or
+that fails validation, is left exactly as it was. scripts/build.sh still leaves
+oversized files out of the deployment, and the Pages Function still redirects
+those to the document's source URL, so a failure here degrades rather than
+breaks.
+
+Usage:
+    python scripts/compress_pdfs.py                  # all of data/raw/matters
+    python scripts/compress_pdfs.py path/to/file.pdf # specific files
+    python scripts/compress_pdfs.py --dry-run        # report, change nothing
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from collections import namedtuple
+from pathlib import Path
+
+MATTERS_DIR = Path("data/raw/matters")
+
+# The hard limit Cloudflare Pages enforces per asset. Must stay in sync with
+# MAX_ASSET_SIZE in scripts/build.sh.
+PAGES_ASSET_LIMIT = 25 * 1024 * 1024
+
+# What we actually aim for. Sitting just under the hard limit is a bad place to
+# be — it leaves no room for a document to be re-scanned slightly larger — and
+# the reader downloads whatever we deploy, so the headroom is worth having.
+DEFAULT_TARGET_SIZE = 20 * 1024 * 1024
+
+# Ghostscript presets, best quality first. The first one that gets the file
+# under the target wins, so a document only loses as much fidelity as it has to.
+# None of these upsample, and none downsample images already below their dpi
+# threshold, which covers every scan we've seen (144 ppi).
+QUALITY_PRESETS = ("prepress", "printer", "ebook", "screen")
+
+# A compressed file has to keep every page and effectively all of its text layer
+# — Ghostscript preserves both, so a shortfall means the rewrite went wrong and
+# the original should be kept.
+MIN_TEXT_RATIO = 0.95
+TEXT_CHECK_THRESHOLD = 200  # chars; below this the text layer is too small to judge
+
+Result = namedtuple("Result", "path original_size new_size preset status detail")
+
+
+def iter_oversized(root, limit=PAGES_ASSET_LIMIT):
+    """PDFs under ``root`` that exceed ``limit``, in a stable order."""
+    root = Path(root)
+    if not root.exists():
+        return []
+    oversized = [
+        p for p in root.rglob("*.pdf")
+        if p.is_file() and p.stat().st_size > limit
+    ]
+    return sorted(oversized)
+
+
+def pdf_stats(path):
+    """``(page_count, text_length)`` for a PDF, or None if it can't be read.
+
+    A file we can't parse is one we can't validate, so callers treat None as a
+    reason to leave the original alone.
+    """
+    try:
+        import pdfplumber
+    except ImportError:  # pragma: no cover - pdfplumber is in requirements.txt
+        print("Warning: pdfplumber not installed, skipping validation", file=sys.stderr)
+        return None
+
+    try:
+        with pdfplumber.open(str(path)) as pdf:
+            pages = len(pdf.pages)
+            text = "".join(page.extract_text() or "" for page in pdf.pages)
+        return pages, len(text)
+    except Exception as e:
+        print(f"Warning: could not read {path}: {e}", file=sys.stderr)
+        return None
+
+
+def ghostscript_compress(src, dst, preset):
+    """Re-encode ``src`` into ``dst`` at ``preset``. True if Ghostscript succeeded."""
+    cmd = [
+        "gs",
+        "-sDEVICE=pdfwrite",
+        "-dCompatibilityLevel=1.7",
+        f"-dPDFSETTINGS=/{preset}",
+        # Scanned filings repeat the same letterhead and watermark on every
+        # page; storing those once is free size on documents that have them.
+        "-dDetectDuplicateImages=true",
+        "-dCompressFonts=true",
+        "-dNOPAUSE",
+        "-dBATCH",
+        "-dQUIET",
+        "-dSAFER",
+        f"-sOutputFile={dst}",
+        str(src),
+    ]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=900)
+    except FileNotFoundError:
+        print("Error: ghostscript (gs) is not installed", file=sys.stderr)
+        return False
+    except subprocess.TimeoutExpired:
+        print(f"Warning: ghostscript timed out on {src}", file=sys.stderr)
+        return False
+
+    if proc.returncode != 0:
+        detail = (proc.stderr or "").strip().splitlines()
+        tail = detail[-1] if detail else f"exit {proc.returncode}"
+        print(f"Warning: ghostscript failed on {src}: {tail}", file=sys.stderr)
+        return False
+    return True
+
+
+def rejection_reason(original_stats, candidate, original_size):
+    """Why ``candidate`` shouldn't replace the original, or None if it's good."""
+    if not candidate.exists() or candidate.stat().st_size == 0:
+        return "produced no output"
+
+    if candidate.stat().st_size >= original_size:
+        return "no smaller than the original"
+
+    if original_stats is None:
+        # We couldn't read the original, so there's nothing to compare against.
+        return "original could not be validated"
+
+    candidate_stats = pdf_stats(candidate)
+    if candidate_stats is None:
+        return "compressed file could not be read back"
+
+    original_pages, original_text = original_stats
+    new_pages, new_text = candidate_stats
+
+    if new_pages != original_pages:
+        return f"page count changed ({original_pages} -> {new_pages})"
+
+    if original_text >= TEXT_CHECK_THRESHOLD and new_text < original_text * MIN_TEXT_RATIO:
+        return f"text layer shrank ({original_text} -> {new_text} chars)"
+
+    return None
+
+
+def compress_file(
+    path,
+    target=DEFAULT_TARGET_SIZE,
+    limit=PAGES_ASSET_LIMIT,
+    presets=QUALITY_PRESETS,
+    dry_run=False,
+    runner=ghostscript_compress,
+):
+    """Rewrite ``path`` at the highest-quality preset that gets it under ``target``.
+
+    Falls back to accepting anything under the hard ``limit`` if no preset
+    reaches the target — deploying a barely-small-enough file still beats not
+    deploying it at all.
+    """
+    path = Path(path)
+    original_size = path.stat().st_size
+    original_stats = pdf_stats(path)
+
+    tmp_dir = path.parent
+    # Highest-quality candidate that cleared the hard limit but missed the
+    # target, kept in case no preset reaches the target. Presets run best-first,
+    # so the first one to fit is the one worth holding.
+    held = None
+    held_size = None
+    held_preset = None
+
+    try:
+        for preset in presets:
+            tmp = tmp_dir / f".{path.name}.{preset}.tmp"
+            try:
+                if not runner(path, tmp, preset):
+                    continue
+
+                reason = rejection_reason(original_stats, tmp, original_size)
+                if reason is not None:
+                    print(f"  {preset}: rejected — {reason}", file=sys.stderr)
+                    continue
+
+                size = tmp.stat().st_size
+                if size <= target:
+                    if dry_run:
+                        return Result(path, original_size, size, preset, "would-compress", None)
+                    os.replace(tmp, path)
+                    tmp = None  # consumed by the replace
+                    return Result(path, original_size, size, preset, "compressed", None)
+
+                if size <= limit and held is None:
+                    held = tmp_dir / f".{path.name}.best.tmp"
+                    os.replace(tmp, held)
+                    tmp = None
+                    held_size, held_preset = size, preset
+            finally:
+                if tmp is not None:
+                    tmp.unlink(missing_ok=True)
+
+        if held is not None:
+            if dry_run:
+                return Result(
+                    path, original_size, held_size, held_preset, "would-compress", None
+                )
+            os.replace(held, path)
+            held = None  # consumed by the replace
+            return Result(
+                path, original_size, held_size, held_preset, "compressed", None
+            )
+
+        return Result(
+            path, original_size, original_size, None, "failed",
+            f"no preset got it under {limit} bytes",
+        )
+    finally:
+        if held is not None:
+            held.unlink(missing_ok=True)
+
+
+def format_size(n):
+    return f"{n / (1024 * 1024):.1f} MiB"
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "paths", nargs="*", type=Path,
+        help="specific PDFs to compress (default: every oversized PDF under --root)",
+    )
+    parser.add_argument("--root", type=Path, default=MATTERS_DIR)
+    parser.add_argument(
+        "--limit", type=int, default=PAGES_ASSET_LIMIT,
+        help="hard per-asset size limit in bytes (default: Cloudflare Pages' 25 MiB)",
+    )
+    parser.add_argument(
+        "--target", type=int, default=DEFAULT_TARGET_SIZE,
+        help="size to aim for in bytes; lower means more aggressive compression",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="report without rewriting")
+    args = parser.parse_args(argv)
+
+    if args.paths:
+        targets = [p for p in args.paths if p.is_file()]
+        missing = [p for p in args.paths if not p.is_file()]
+        for p in missing:
+            print(f"Warning: not a file: {p}", file=sys.stderr)
+    else:
+        targets = iter_oversized(args.root, args.limit)
+
+    if not targets:
+        print(f"No PDFs over {format_size(args.limit)} under {args.root}")
+        return 0
+
+    if shutil.which("gs") is None:
+        print("Error: ghostscript (gs) is not installed", file=sys.stderr)
+        return 1
+
+    failures = 0
+    for path in targets:
+        print(f"{path} ({format_size(path.stat().st_size)})")
+        result = compress_file(
+            path, target=args.target, limit=args.limit, dry_run=args.dry_run,
+        )
+        if result.status == "failed":
+            print(f"  could not compress: {result.detail}", file=sys.stderr)
+            failures += 1
+            continue
+        verb = "would compress" if result.status == "would-compress" else "compressed"
+        saved = 100 * (1 - result.new_size / result.original_size)
+        print(
+            f"  {verb} to {format_size(result.new_size)} "
+            f"(-{saved:.0f}%, /{result.preset})"
+        )
+
+    # Anything still oversized is left for build.sh to skip and the Pages
+    # Function to redirect, so this stays a warning rather than a hard failure.
+    if failures:
+        print(
+            f"{failures} file(s) still over the limit — the deployment will skip "
+            "them and redirect to the source URL",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_deploy_assets.py
+++ b/scripts/tests/test_check_deploy_assets.py
@@ -1,0 +1,181 @@
+"""Tests for scripts/check_deploy_assets.py — the safety net that notices a file
+too big for Cloudflare Pages to deploy and feeds the tracking issue."""
+
+import json
+import os
+import re
+import sys
+import unittest.mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+sys.modules.setdefault('pdfplumber', unittest.mock.MagicMock())
+
+from check_deploy_assets import (  # noqa: E402
+    DEPLOY_SOURCES,
+    build_issue_body,
+    find_oversized,
+    main,
+)
+from compress_pdfs import PAGES_ASSET_LIMIT  # noqa: E402
+
+MIB = 1024 * 1024
+
+
+def write(path, size):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"\0" * size)
+    return path
+
+
+def make_tree(root):
+    """A repo-shaped tree with both deployment sources present."""
+    (root / "data/raw/matters/MN-1").mkdir(parents=True)
+    (root / "merger-tracker/frontend/public").mkdir(parents=True)
+    return root
+
+
+class TestFindOversized:
+    def test_finds_an_oversized_matter_pdf(self, tmp_path):
+        make_tree(tmp_path)
+        write(tmp_path / "data/raw/matters/MN-1/big.pdf", 30 * MIB)
+        write(tmp_path / "data/raw/matters/MN-1/small.pdf", 1 * MIB)
+
+        assert find_oversized(tmp_path) == [("data/raw/matters/MN-1/big.pdf", 30 * MIB)]
+
+    def test_finds_an_oversized_file_in_the_public_dir(self, tmp_path):
+        # Vite copies publicDir into dist verbatim, so anything oversized in
+        # there breaks the deploy just as a PDF would.
+        make_tree(tmp_path)
+        write(tmp_path / "merger-tracker/frontend/public/huge.png", 26 * MIB)
+
+        assert find_oversized(tmp_path) == [
+            ("merger-tracker/frontend/public/huge.png", 26 * MIB)
+        ]
+
+    def test_ignores_non_pdfs_under_the_matters_dir(self, tmp_path):
+        # build.sh only copies *.pdf out of data/raw/matters, so a big DOCX
+        # there never reaches the deployment and isn't a problem.
+        make_tree(tmp_path)
+        write(tmp_path / "data/raw/matters/MN-1/big.docx", 30 * MIB)
+
+        assert find_oversized(tmp_path) == []
+
+    def test_ignores_files_outside_the_deployment_sources(self, tmp_path):
+        make_tree(tmp_path)
+        write(tmp_path / "data/processed/huge.json", 30 * MIB)
+
+        assert find_oversized(tmp_path) == []
+
+    def test_a_file_exactly_at_the_limit_is_fine(self, tmp_path):
+        # Must agree with build.sh's copy filter and compress_pdfs.py's boundary.
+        make_tree(tmp_path)
+        write(tmp_path / "data/raw/matters/MN-1/exact.pdf", PAGES_ASSET_LIMIT)
+
+        assert find_oversized(tmp_path) == []
+
+    def test_reports_largest_first(self, tmp_path):
+        make_tree(tmp_path)
+        write(tmp_path / "data/raw/matters/MN-1/medium.pdf", 30 * MIB)
+        write(tmp_path / "data/raw/matters/MN-1/biggest.pdf", 60 * MIB)
+
+        assert [p for p, _ in find_oversized(tmp_path)] == [
+            "data/raw/matters/MN-1/biggest.pdf",
+            "data/raw/matters/MN-1/medium.pdf",
+        ]
+
+    def test_missing_source_directories_are_not_an_error(self, tmp_path):
+        assert find_oversized(tmp_path) == []
+
+    def test_sources_match_what_build_sh_deploys(self):
+        # A reminder to update this list if the build ever copies something new
+        # into dist — the check and the workflow's paths filter both depend on it.
+        assert DEPLOY_SOURCES == (
+            ("data/raw/matters", "*.pdf"),
+            ("merger-tracker/frontend/public", "*"),
+        )
+
+
+class TestIssueBody:
+    def test_lists_every_offending_file_with_its_size(self):
+        body = build_issue_body([
+            ("data/raw/matters/MN-1/big.pdf", 30 * MIB),
+            ("data/raw/matters/MN-2/bigger.pdf", 60 * MIB),
+        ])
+
+        assert "`data/raw/matters/MN-1/big.pdf` | 30.0 MiB" in body
+        assert "`data/raw/matters/MN-2/bigger.pdf` | 60.0 MiB" in body
+        assert "2 file(s)" in body
+
+    def test_says_the_site_still_builds(self):
+        # The whole point of the issue is that this no longer breaks the build,
+        # so the body has to explain what actually happens.
+        body = build_issue_body([("a.pdf", 30 * MIB)])
+
+        assert "left out of the deployed site" in body
+        assert "redirected to" in body
+
+    def test_points_at_the_compression_script(self):
+        body = build_issue_body([("a.pdf", 30 * MIB)])
+
+        assert "python scripts/compress_pdfs.py" in body
+
+    def test_escapes_characters_that_would_break_the_table(self):
+        # ACCC filenames are free-form; a pipe would otherwise split the row
+        # into extra cells and a backtick would close the code span early.
+        body = build_issue_body([("data/raw/matters/MN-1/a|b`c.pdf", 30 * MIB)])
+        row = [ln for ln in body.splitlines() if "a\\|b" in ln]
+
+        assert len(row) == 1
+        # Three unescaped pipes: the row's opening, middle and closing delimiters.
+        assert len(re.findall(r"(?<!\\)\|", row[0])) == 3
+        # And the filename's backtick no longer closes the code span early.
+        assert row[0].count("`") == 2
+
+
+class TestMain:
+    def test_exit_code_is_zero_by_default(self, tmp_path, capsys):
+        make_tree(tmp_path)
+        write(tmp_path / "data/raw/matters/MN-1/big.pdf", 30 * MIB)
+
+        assert main(["--root", str(tmp_path)]) == 0
+
+    def test_fail_flag_makes_it_exit_non_zero(self, tmp_path):
+        make_tree(tmp_path)
+        write(tmp_path / "data/raw/matters/MN-1/big.pdf", 30 * MIB)
+
+        assert main(["--root", str(tmp_path), "--fail"]) == 1
+
+    def test_fail_flag_still_exits_zero_when_clean(self, tmp_path):
+        make_tree(tmp_path)
+        write(tmp_path / "data/raw/matters/MN-1/small.pdf", 1 * MIB)
+
+        assert main(["--root", str(tmp_path), "--fail"]) == 0
+
+    def test_json_payload_drives_the_workflow(self, tmp_path):
+        make_tree(tmp_path)
+        write(tmp_path / "data/raw/matters/MN-1/big.pdf", 30 * MIB)
+        out = tmp_path / "oversized.json"
+
+        main(["--root", str(tmp_path), "--json", str(out)])
+        payload = json.loads(out.read_text())
+
+        assert payload["count"] == 1
+        assert payload["files"] == [
+            {"path": "data/raw/matters/MN-1/big.pdf", "size": 30 * MIB}
+        ]
+        assert payload["title"]
+        assert "big.pdf" in payload["body"]
+
+    def test_json_payload_is_written_even_when_clean(self, tmp_path):
+        # The workflow reads count unconditionally, and uses count == 0 as its
+        # cue to close an open issue — so the file has to exist either way.
+        make_tree(tmp_path)
+        out = tmp_path / "oversized.json"
+
+        main(["--root", str(tmp_path), "--json", str(out)])
+        payload = json.loads(out.read_text())
+
+        assert payload["count"] == 0
+        assert payload["files"] == []
+        assert payload["body"] == ""

--- a/scripts/tests/test_compress_pdfs.py
+++ b/scripts/tests/test_compress_pdfs.py
@@ -1,0 +1,257 @@
+"""Tests for scripts/compress_pdfs.py — the preset-selection policy and the
+validation that decides whether a compressed file is safe to keep.
+
+Ghostscript isn't invoked here: compress_file() takes the compressor as a
+parameter, so these tests substitute a fake that writes a file of whatever size
+the scenario needs.
+"""
+
+import os
+import sys
+import unittest.mock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+sys.modules.setdefault('pdfplumber', unittest.mock.MagicMock())
+
+from compress_pdfs import (  # noqa: E402
+    PAGES_ASSET_LIMIT,
+    QUALITY_PRESETS,
+    compress_file,
+    iter_oversized,
+    rejection_reason,
+)
+
+MIB = 1024 * 1024
+
+
+def write_pdf(path, size):
+    """A file of exactly ``size`` bytes at ``path``."""
+    path.write_bytes(b"%PDF-1.7\n" + b"\0" * (size - 9))
+    return path
+
+
+def fake_compressor(sizes):
+    """A stand-in for ghostscript_compress that writes ``sizes[preset]`` bytes.
+
+    A preset mapped to None fails outright, the way ghostscript does on a
+    document it can't process.
+    """
+    def run(src, dst, preset):
+        size = sizes.get(preset)
+        if size is None:
+            return False
+        write_pdf(dst, size)
+        return True
+    return run
+
+
+@pytest.fixture
+def stats(monkeypatch):
+    """Make every PDF look like a valid 10-page document with a text layer, so
+    validation passes unless a test says otherwise."""
+    monkeypatch.setattr('compress_pdfs.pdf_stats', lambda path: (10, 5000))
+
+
+class TestPresetSelection:
+    def test_picks_the_highest_quality_preset_that_meets_the_target(self, tmp_path, stats):
+        src = write_pdf(tmp_path / "big.pdf", 30 * MIB)
+        result = compress_file(
+            src,
+            target=20 * MIB,
+            runner=fake_compressor({
+                'prepress': 28 * MIB,   # over target
+                'printer': 19 * MIB,    # first to fit — should win
+                'ebook': 14 * MIB,      # would fit too, but lower quality
+            }),
+        )
+
+        assert result.status == "compressed"
+        assert result.preset == "printer"
+        assert src.stat().st_size == 19 * MIB
+
+    def test_walks_down_the_ladder_until_the_target_is_met(self, tmp_path, stats):
+        src = write_pdf(tmp_path / "big.pdf", 60 * MIB)
+        result = compress_file(
+            src,
+            target=15 * MIB,
+            runner=fake_compressor({
+                'prepress': 55 * MIB,
+                'printer': 40 * MIB,
+                'ebook': 22 * MIB,
+                'screen': 12 * MIB,
+            }),
+        )
+
+        assert result.preset == "screen"
+        assert src.stat().st_size == 12 * MIB
+
+    def test_falls_back_to_the_best_preset_under_the_hard_limit(self, tmp_path, stats):
+        # Nothing reaches the target, but /printer clears the limit Pages
+        # actually enforces — deploying that beats not deploying at all, and it
+        # should be preferred over the lower-quality preset that also clears it.
+        src = write_pdf(tmp_path / "big.pdf", 40 * MIB)
+        result = compress_file(
+            src,
+            target=10 * MIB,
+            limit=25 * MIB,
+            runner=fake_compressor({
+                'prepress': 30 * MIB,
+                'printer': 24 * MIB,
+                'ebook': 22 * MIB,
+                'screen': 20 * MIB,
+            }),
+        )
+
+        assert result.status == "compressed"
+        assert result.preset == "printer"
+        assert src.stat().st_size == 24 * MIB
+
+    def test_leaves_the_file_alone_when_nothing_gets_under_the_limit(self, tmp_path, stats):
+        src = write_pdf(tmp_path / "huge.pdf", 200 * MIB)
+        result = compress_file(
+            src,
+            target=20 * MIB,
+            limit=25 * MIB,
+            runner=fake_compressor({p: 100 * MIB for p in QUALITY_PRESETS}),
+        )
+
+        assert result.status == "failed"
+        assert src.stat().st_size == 200 * MIB
+
+    def test_skips_presets_ghostscript_fails_on(self, tmp_path, stats):
+        src = write_pdf(tmp_path / "big.pdf", 30 * MIB)
+        result = compress_file(
+            src,
+            target=20 * MIB,
+            runner=fake_compressor({'prepress': None, 'printer': None, 'ebook': 14 * MIB}),
+        )
+
+        assert result.preset == "ebook"
+
+    def test_dry_run_reports_without_touching_the_file(self, tmp_path, stats):
+        src = write_pdf(tmp_path / "big.pdf", 30 * MIB)
+        result = compress_file(
+            src, target=20 * MIB, dry_run=True,
+            runner=fake_compressor({'prepress': 28 * MIB, 'printer': 19 * MIB}),
+        )
+
+        assert result.status == "would-compress"
+        assert result.preset == "printer"
+        assert src.stat().st_size == 30 * MIB
+
+    def test_leaves_no_temp_files_behind(self, tmp_path, stats):
+        src = write_pdf(tmp_path / "big.pdf", 40 * MIB)
+        compress_file(
+            src, target=10 * MIB, limit=25 * MIB,
+            runner=fake_compressor({
+                'prepress': 30 * MIB, 'printer': 24 * MIB,
+                'ebook': 22 * MIB, 'screen': 20 * MIB,
+            }),
+        )
+
+        assert [p.name for p in tmp_path.iterdir()] == ["big.pdf"]
+
+
+class TestValidation:
+    def test_rejects_a_compressed_file_that_lost_pages(self, tmp_path, monkeypatch):
+        src = write_pdf(tmp_path / "big.pdf", 30 * MIB)
+        # The original has 10 pages; anything ghostscript writes claims 9.
+        monkeypatch.setattr(
+            'compress_pdfs.pdf_stats',
+            lambda path: (10, 5000) if path == src else (9, 5000),
+        )
+        result = compress_file(
+            src, target=20 * MIB,
+            runner=fake_compressor({p: 14 * MIB for p in QUALITY_PRESETS}),
+        )
+
+        assert result.status == "failed"
+        assert src.stat().st_size == 30 * MIB
+
+    def test_rejects_a_compressed_file_that_lost_its_text_layer(self, tmp_path, monkeypatch):
+        src = write_pdf(tmp_path / "big.pdf", 30 * MIB)
+        monkeypatch.setattr(
+            'compress_pdfs.pdf_stats',
+            lambda path: (10, 5000) if path == src else (10, 100),
+        )
+        result = compress_file(
+            src, target=20 * MIB,
+            runner=fake_compressor({p: 14 * MIB for p in QUALITY_PRESETS}),
+        )
+
+        assert result.status == "failed"
+
+    def test_tolerates_a_small_text_difference(self, tmp_path, monkeypatch):
+        # Ghostscript's rewrite shifts the extracted text by a character or two;
+        # that's normal and must not block compression.
+        src = write_pdf(tmp_path / "big.pdf", 30 * MIB)
+        monkeypatch.setattr(
+            'compress_pdfs.pdf_stats',
+            lambda path: (10, 5000) if path == src else (10, 4999),
+        )
+        result = compress_file(
+            src, target=20 * MIB,
+            runner=fake_compressor({p: 14 * MIB for p in QUALITY_PRESETS}),
+        )
+
+        assert result.status == "compressed"
+
+    def test_ignores_the_text_check_for_a_scan_with_no_text_layer(self, tmp_path, monkeypatch):
+        # A pure image scan has no text to compare, so the check shouldn't
+        # veto compressing it.
+        src = write_pdf(tmp_path / "scan.pdf", 30 * MIB)
+        monkeypatch.setattr('compress_pdfs.pdf_stats', lambda path: (10, 0))
+        result = compress_file(
+            src, target=20 * MIB,
+            runner=fake_compressor({p: 14 * MIB for p in QUALITY_PRESETS}),
+        )
+
+        assert result.status == "compressed"
+
+    def test_rejects_output_that_is_not_smaller(self, tmp_path):
+        src = write_pdf(tmp_path / "a.pdf", 30 * MIB)
+        candidate = write_pdf(tmp_path / "b.pdf", 30 * MIB)
+
+        assert rejection_reason((10, 5000), candidate, 30 * MIB) == "no smaller than the original"
+
+    def test_rejects_an_empty_output(self, tmp_path):
+        candidate = tmp_path / "b.pdf"
+        candidate.write_bytes(b"")
+
+        assert rejection_reason((10, 5000), candidate, 30 * MIB) == "produced no output"
+
+    def test_rejects_when_the_original_could_not_be_read(self, tmp_path):
+        candidate = write_pdf(tmp_path / "b.pdf", 10 * MIB)
+
+        reason = rejection_reason(None, candidate, 30 * MIB)
+        assert reason == "original could not be validated"
+
+
+class TestFindingOversizedFiles:
+    def test_finds_only_files_over_the_limit(self, tmp_path):
+        (tmp_path / "MN-1").mkdir()
+        (tmp_path / "MN-2").mkdir()
+        write_pdf(tmp_path / "MN-1" / "big.pdf", 30 * MIB)
+        write_pdf(tmp_path / "MN-1" / "small.pdf", 1 * MIB)
+        write_pdf(tmp_path / "MN-2" / "also-big.pdf", 26 * MIB)
+
+        found = [p.name for p in iter_oversized(tmp_path, PAGES_ASSET_LIMIT)]
+        assert sorted(found) == ["also-big.pdf", "big.pdf"]
+
+    def test_a_file_exactly_at_the_limit_is_not_oversized(self, tmp_path):
+        # Pages allows files "up to 25 MiB", and scripts/build.sh copies them,
+        # so this must agree with that boundary.
+        write_pdf(tmp_path / "exact.pdf", PAGES_ASSET_LIMIT)
+
+        assert iter_oversized(tmp_path, PAGES_ASSET_LIMIT) == []
+
+    def test_ignores_non_pdf_files(self, tmp_path):
+        (tmp_path / "big.docx").write_bytes(b"\0" * (30 * MIB))
+
+        assert iter_oversized(tmp_path, PAGES_ASSET_LIMIT) == []
+
+    def test_missing_directory_is_not_an_error(self, tmp_path):
+        assert iter_oversized(tmp_path / "nope", PAGES_ASSET_LIMIT) == []


### PR DESCRIPTION
Cloudflare Pages rejects an entire deployment if any single asset exceeds
25 MiB, so the build has been failing at the asset-validation step since a
30.8 MB scanned tribunal affidavit landed in MN-01068:

  Error: Pages only supports files up to 25 MiB in size
  mergers/MN-01068/Affidavit-of-Benjamin-James-Welk.pdf is 29.4 MiB in size

Exclude oversized PDFs from the copy into dist/ and list what was skipped in
the build log. They stay in the repo, so the CLI and the data pipeline are
unaffected — only the deployment leaves them out.

To keep those documents reachable, the Pages Function that serves
/mergers/**/*.pdf now falls back to the document's source URL on the
ACCC/Tribunal site when the asset isn't in the deployment. A miss doesn't 404
there (Pages answers with the SPA shell), so the miss is detected by the
response not being a PDF, and the upstream URL comes from the matching event's
`url` in the matter JSON. Redirects are restricted to http(s) since the target
is built from scraped data.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011BeK1CNV38LnRZtipZzQXE