### PR TITLE
Trim the treemap's last row when it under-fills the line

### DIFF
--- a/merger-tracker/frontend/src/components/Treemap.jsx
+++ b/merger-tracker/frontend/src/components/Treemap.jsx
@@ -1,5 +1,7 @@
+import { useLayoutEffect, useRef } from 'react';
 import { Link } from 'react-router';
 import { FaArrowRightLong } from 'react-icons/fa6';
+import { tailCellsToHide } from '../utils/treemapTail';
 
 // A treemap-style heatmap: cells packed by deal volume (flex-grow
 // proportional to the merger count) and shaded by intensity. Acts as the
@@ -29,9 +31,51 @@ function Treemap({
   desktopLimit = DEFAULT_DESKTOP_LIMIT,
   mobileLimit = DEFAULT_MOBILE_LIMIT,
 }) {
+  const containerRef = useRef(null);
+
   const cells = [...items]
     .sort((a, b) => b.merger_count - a.merger_count)
     .slice(0, desktopLimit);
+  // Re-measure whenever the cells themselves change, not just their number.
+  const cellSizes = cells.map((item) => item.merger_count).join(',');
+
+  // Trimming happens in the DOM rather than in React state: the decision needs
+  // the laid-out rows, and re-rendering the full set to re-measure would flash
+  // the tail back in. Hiding a trailing row can't reflow the rows above it, so
+  // one pass per width settles it.
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    let lastWidth = null;
+    const trimTail = () => {
+      const children = Array.from(container.children);
+      for (const child of children) child.style.display = '';
+      const gap = parseFloat(getComputedStyle(container).columnGap) || 0;
+      // offsetParent is null for the cells the mobile cap has hidden.
+      const measured = children
+        .filter((child) => child.offsetParent !== null)
+        .map((child) => ({
+          el: child,
+          top: child.offsetTop,
+          basis: parseFloat(child.style.flexBasis) || child.getBoundingClientRect().width,
+        }));
+      lastWidth = container.clientWidth;
+      const hidden = tailCellsToHide(measured, lastWidth, gap);
+      for (const { el } of measured.slice(measured.length - hidden)) {
+        el.style.display = 'none';
+      }
+    };
+
+    trimTail();
+    const observer = new ResizeObserver(() => {
+      // Hiding the tail changes the container's height, which would otherwise
+      // re-enter this callback and fight itself. Only width can change the answer.
+      if (container.clientWidth !== lastWidth) trimTail();
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [cellSizes, mobileLimit]);
 
   if (cells.length === 0) return null;
 
@@ -39,7 +83,7 @@ function Treemap({
 
   return (
     <div>
-      <div className="flex flex-wrap gap-2">
+      <div ref={containerRef} className="flex flex-wrap gap-2">
         {cells.map((item, i) => {
           const intensity = item.merger_count / maxCount;
           const hideOnMobile = i >= mobileLimit;

--- a/merger-tracker/frontend/src/utils/__tests__/treemapTail.test.js
+++ b/merger-tracker/frontend/src/utils/__tests__/treemapTail.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { tailCellsToHide } from '../treemapTail';
+
+// Cells as the layout effect measures them: `top` groups them into rows and
+// `basis` is the width each asks for before flex-grow stretches the row.
+const row = (top, ...bases) => bases.map((basis) => ({ top, basis }));
+
+const GAP = 8;
+const WIDTH = 1000;
+
+describe('tailCellsToHide', () => {
+  it('hides a lone trailing cell that would stretch across the whole row', () => {
+    const cells = [
+      ...row(0, 300, 260, 240, 180),
+      ...row(100, 170, 160, 150, 140),
+      ...row(200, 130),
+    ];
+    expect(tailCellsToHide(cells, WIDTH, GAP)).toBe(1);
+  });
+
+  it('hides a short trailing row of several cells', () => {
+    const cells = [...row(0, 300, 260, 240, 180), ...row(100, 130, 130)];
+    expect(tailCellsToHide(cells, WIDTH, GAP)).toBe(2);
+  });
+
+  it('keeps a trailing row that nearly fills the line', () => {
+    const cells = [...row(0, 300, 260, 240, 180), ...row(100, 300, 260, 240)];
+    expect(tailCellsToHide(cells, WIDTH, GAP)).toBe(0);
+  });
+
+  it('keeps everything when the cells fit on a single row', () => {
+    expect(tailCellsToHide(row(0, 300, 260, 130), WIDTH, GAP)).toBe(0);
+  });
+
+  it('keeps the tail on narrow viewports where every row holds one cell', () => {
+    const cells = [...row(0, 200), ...row(100, 160), ...row(200, 130)];
+    expect(tailCellsToHide(cells, 360, GAP)).toBe(0);
+  });
+
+  it('does nothing before the container has been measured', () => {
+    const cells = [...row(0, 300, 260, 240, 180), ...row(100, 130)];
+    expect(tailCellsToHide(cells, 0, GAP)).toBe(0);
+  });
+});

--- a/merger-tracker/frontend/src/utils/treemapTail.js
+++ b/merger-tracker/frontend/src/utils/treemapTail.js
@@ -1,0 +1,48 @@
+// Row measurement for the Treemap heatmap (src/components/Treemap.jsx).
+//
+// Flexbox grows the cells on the final row to fill the line, so a short tail —
+// often a single low-volume item — is drawn as wide as the busiest cell on the
+// page, reading as the exact opposite of what its number says. The component
+// measures the wrapped rows after layout and asks here whether the last row is
+// misleading enough to drop; the full ranking is always in the table below.
+//
+// A row is "full" up to the width of whichever cell forced the wrap, so genuine
+// rows sit near 1. The tail has to be well under half a row, and well below the
+// row above it, before we take it away.
+const TAIL_MAX_FILL = 0.55;
+const TAIL_MIN_DROP = 0.25;
+
+// Cells share a row when their offsetTop matches (1px of slack for subpixel
+// layout). `cells` arrive in DOM order, so rows come out in visual order.
+function groupIntoRows(cells) {
+  const rows = [];
+  let rowTop = null;
+  for (const cell of cells) {
+    if (rowTop === null || Math.abs(cell.top - rowTop) > 1) {
+      rows.push([]);
+      rowTop = cell.top;
+    }
+    rows[rows.length - 1].push(cell);
+  }
+  return rows;
+}
+
+// How many trailing cells to hide: either the whole last row, or none. Each
+// cell is `{ top, basis }` — the basis being the width the cell asks for before
+// flex-grow stretches it.
+export function tailCellsToHide(cells, containerWidth, gap) {
+  if (!containerWidth) return 0;
+  const rows = groupIntoRows(cells);
+  if (rows.length < 2) return 0;
+
+  const fill = (row) =>
+    (row.reduce((sum, cell) => sum + cell.basis, 0) + gap * (row.length - 1)) / containerWidth;
+  const tail = rows[rows.length - 1];
+  const tailFill = fill(tail);
+  const aboveFill = fill(rows[rows.length - 2]);
+
+  // The second test keeps narrow viewports intact: there every row holds one
+  // cell and is equally underfull, so the tail isn't misleading at all.
+  if (tailFill >= TAIL_MAX_FILL || aboveFill - tailFill < TAIL_MIN_DROP) return 0;
+  return tail.length;
+}


### PR DESCRIPTION
Flexbox grows the cells on the final wrapped row to fill the line, so a
short tail — on /parties currently a single cell — renders as wide as the
busiest item on the page, reading as the opposite of what its count says.

After layout, group the cells into rows by offsetTop and drop the last row
when it asks for less than 55% of the line and is at least 25 percentage
points emptier than the row above. The second test leaves narrow viewports
alone: there every row holds one cell and is equally underfull, so the tail
isn't misleading. The complete ranking stays in the table below either way.

Hiding is applied to the DOM rather than through React state so the full
set stays measurable and the tail never flashes in on re-measure; a width
guard on the ResizeObserver keeps the height change it causes from
re-entering the callback.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TTodoU2qzG3eWCKaaTazRA