### PR TITLE
Add Phase 2 determinations doughnut to the dashboard

### DIFF
--- a/merger-tracker/frontend/public/data/stats.json
+++ b/merger-tracker/frontend/public/data/stats.json
@@ -12,7 +12,7 @@
     "Referred to phase 2": 8
   },
   "by_phase_2_determination": {
-    "Approved": 1,
+    "Approved with conditions": 1,
     "Not approved": 2,
     "Assessment ceased": 2
   },

--- a/merger-tracker/frontend/public/data/stats.json
+++ b/merger-tracker/frontend/public/data/stats.json
@@ -11,6 +11,11 @@
     "Approved": 157,
     "Referred to phase 2": 8
   },
+  "by_phase_2_determination": {
+    "Approved": 1,
+    "Not approved": 2,
+    "Assessment ceased": 2
+  },
   "by_waiver_determination": {
     "Approved": 303,
     "Not approved": 14

--- a/merger-tracker/frontend/src/constants/chartColors.js
+++ b/merger-tracker/frontend/src/constants/chartColors.js
@@ -16,6 +16,10 @@ export const CHART_PALETTE = {
   teal: '#6b8f7f',
   tealLight: 'rgba(107, 143, 127, 0.15)',
   sage: '#8cafa0',
+  // Approvals granted subject to conditions — a lighter primary, so a
+  // conditional clearance reads as the same family as an outright one while
+  // staying its own segment.
+  primarySoft: '#5f8a76',
   // Ceased assessments — the purple the rest of the site marks them with
   // (badges, timeline dots, digest), muted to sit beside the earth tones
   // above rather than dominate the chart.
@@ -33,10 +37,12 @@ export const CHART_PALETTE_ORDER = [
 
 // merger.accc_determination -> chart colour, so "Approved" is always the
 // primary green regardless of key order in the underlying stats object.
-// Also keyed by "Assessment ceased", which the Phase 2 chart plots as an
-// outcome in its own right (a review the parties dropped out of).
+// Also keyed by the two outcomes the Phase 2 chart plots in their own right:
+// "Approved with conditions", and "Assessment ceased" (a review the parties
+// dropped out of).
 export const DETERMINATION_COLORS = {
   [MERGER_STATUS.APPROVED]: CHART_PALETTE.primary,
+  [MERGER_STATUS.APPROVED_WITH_CONDITIONS]: CHART_PALETTE.primarySoft,
   [MERGER_STATUS.NOT_APPROVED]: CHART_PALETTE.accent,
   [MERGER_STATUS.DECLINED]: CHART_PALETTE.accent,
   [MERGER_STATUS.NOT_OPPOSED]: CHART_PALETTE.teal,

--- a/merger-tracker/frontend/src/constants/chartColors.js
+++ b/merger-tracker/frontend/src/constants/chartColors.js
@@ -16,6 +16,10 @@ export const CHART_PALETTE = {
   teal: '#6b8f7f',
   tealLight: 'rgba(107, 143, 127, 0.15)',
   sage: '#8cafa0',
+  // Ceased assessments — the purple the rest of the site marks them with
+  // (badges, timeline dots, digest), muted to sit beside the earth tones
+  // above rather than dominate the chart.
+  ceased: '#7e5aa8',
 };
 
 // Fallback order for chart segments whose label has no explicit colour
@@ -29,12 +33,15 @@ export const CHART_PALETTE_ORDER = [
 
 // merger.accc_determination -> chart colour, so "Approved" is always the
 // primary green regardless of key order in the underlying stats object.
+// Also keyed by "Assessment ceased", which the Phase 2 chart plots as an
+// outcome in its own right (a review the parties dropped out of).
 export const DETERMINATION_COLORS = {
   [MERGER_STATUS.APPROVED]: CHART_PALETTE.primary,
   [MERGER_STATUS.NOT_APPROVED]: CHART_PALETTE.accent,
   [MERGER_STATUS.DECLINED]: CHART_PALETTE.accent,
   [MERGER_STATUS.NOT_OPPOSED]: CHART_PALETTE.teal,
   [MERGER_STATUS.REFERRED_TO_PHASE_2]: CHART_PALETTE.sage,
+  [MERGER_STATUS.ASSESSMENT_CEASED]: CHART_PALETTE.ceased,
 };
 
 // Hex values mirroring tailwind.config.js theme colors (primary, phase-2,

--- a/merger-tracker/frontend/src/constants/mergerStatus.js
+++ b/merger-tracker/frontend/src/constants/mergerStatus.js
@@ -24,6 +24,12 @@ export const MERGER_STATUS = {
   DECLINED: 'Declined',
   NOT_OPPOSED: 'Not opposed',
   REFERRED_TO_PHASE_2: 'Referred to phase 2',
+
+  // Display label rather than a register value — the ACCC records a
+  // conditional clearance as a plain "Approved" with merger.has_conditions set
+  // alongside. Charts that need the two to read as separate outcomes get this
+  // label from the data pipeline (see scripts/constants/merger_status.py).
+  APPROVED_WITH_CONDITIONS: 'Approved with conditions',
 };
 
 // Values that appear in merger.stage.

--- a/merger-tracker/frontend/src/pages/Dashboard.jsx
+++ b/merger-tracker/frontend/src/pages/Dashboard.jsx
@@ -35,11 +35,13 @@ ChartJS.register(
   ArcElement
 );
 
-// Fixed segment order for the Phase 2 doughnut, so the chart doesn't reshuffle
-// as determinations land. "Assessment ceased" sits last because it isn't a
-// determination at all — it's a Phase 2 review the parties withdrew from.
+// Fixed segment order for the Phase 2 doughnut, running cleared → blocked, so
+// the chart doesn't reshuffle as determinations land. "Assessment ceased" sits
+// last because it isn't a determination at all — it's a Phase 2 review the
+// parties withdrew from.
 const PHASE_2_OUTCOME_ORDER = [
   MERGER_STATUS.APPROVED,
+  MERGER_STATUS.APPROVED_WITH_CONDITIONS,
   MERGER_STATUS.NOT_OPPOSED,
   MERGER_STATUS.NOT_APPROVED,
   MERGER_STATUS.DECLINED,

--- a/merger-tracker/frontend/src/pages/Dashboard.jsx
+++ b/merger-tracker/frontend/src/pages/Dashboard.jsx
@@ -35,6 +35,17 @@ ChartJS.register(
   ArcElement
 );
 
+// Fixed segment order for the Phase 2 doughnut, so the chart doesn't reshuffle
+// as determinations land. "Assessment ceased" sits last because it isn't a
+// determination at all — it's a Phase 2 review the parties withdrew from.
+const PHASE_2_OUTCOME_ORDER = [
+  MERGER_STATUS.APPROVED,
+  MERGER_STATUS.NOT_OPPOSED,
+  MERGER_STATUS.NOT_APPROVED,
+  MERGER_STATUS.DECLINED,
+  MERGER_STATUS.ASSESSMENT_CEASED,
+];
+
 function Dashboard() {
   const { data: stats, loading, error } = useFetchData(API_ENDPOINTS.stats, {
     cacheKey: 'dashboard-stats',
@@ -76,6 +87,28 @@ function Dashboard() {
       {
         data: Object.values(stats.by_determination),
         backgroundColor: determinationLabels.map((label, i) =>
+          DETERMINATION_COLORS[label] || CHART_PALETTE_ORDER[i % CHART_PALETTE_ORDER.length]
+        ),
+        borderWidth: 0,
+        borderRadius: 4,
+      },
+    ],
+  };
+
+  // Concluded Phase 2 reviews only — matters still in Phase 2 have no outcome
+  // to chart yet. Any outcome the fixed order doesn't know about is appended
+  // rather than dropped.
+  const phase2Counts = stats.by_phase_2_determination || {};
+  const phase2Labels = [
+    ...PHASE_2_OUTCOME_ORDER.filter((label) => phase2Counts[label]),
+    ...Object.keys(phase2Counts).filter((label) => !PHASE_2_OUTCOME_ORDER.includes(label)),
+  ];
+  const phase2DeterminationData = {
+    labels: phase2Labels,
+    datasets: [
+      {
+        data: phase2Labels.map((label) => phase2Counts[label]),
+        backgroundColor: phase2Labels.map((label, i) =>
           DETERMINATION_COLORS[label] || CHART_PALETTE_ORDER[i % CHART_PALETTE_ORDER.length]
         ),
         borderWidth: 0,
@@ -214,7 +247,7 @@ function Dashboard() {
       })()}
 
       {/* Charts */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+      <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-4 gap-6">
         {/* Phase 1 Duration Table */}
         {stats.phase_duration.percentiles && (
           <div className="bg-white p-6 rounded-2xl border border-gray-100 shadow-card flex flex-col">
@@ -258,6 +291,27 @@ function Dashboard() {
               <tbody>
                 {Object.entries(stats.by_determination).map(([det, count]) => (
                   <tr key={det}><td>{det}</td><td>{count}</td></tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* Phase 2 Determination Distribution */}
+        {phase2Labels.length > 0 && (
+          <div className="bg-white p-6 rounded-2xl border border-gray-100 shadow-card">
+            <h2 id="chart-phase2-title" className="text-base font-semibold text-gray-900 mb-5">
+              Phase 2 determinations
+            </h2>
+            <div className="h-64" role="img" aria-labelledby="chart-phase2-title" aria-describedby="chart-phase2-summary">
+              <Doughnut data={phase2DeterminationData} options={chartOptions} />
+            </div>
+            <table id="chart-phase2-summary" className="sr-only">
+              <caption>Phase 2 determination breakdown, including ceased assessments</caption>
+              <thead><tr><th>Outcome</th><th>Count</th></tr></thead>
+              <tbody>
+                {phase2Labels.map((det) => (
+                  <tr key={det}><td>{det}</td><td>{phase2Counts[det]}</td></tr>
                 ))}
               </tbody>
             </table>

--- a/merger-tracker/frontend/src/pages/__tests__/Dashboard.test.jsx
+++ b/merger-tracker/frontend/src/pages/__tests__/Dashboard.test.jsx
@@ -1,0 +1,75 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router';
+import { HelmetProvider } from 'react-helmet-async';
+import Dashboard from '../Dashboard';
+import { dataCache } from '../../utils/dataCache';
+
+function ok(json) {
+  return { ok: true, status: 200, json: () => Promise.resolve(json) };
+}
+
+// chart.js can't paint in jsdom, so the doughnuts are asserted through the
+// sr-only summary tables they're described by — the same data, in the form
+// screen readers get it.
+function statsFixture(overrides = {}) {
+  return {
+    total_mergers: 10,
+    total_waivers: 4,
+    by_status: { 'Under assessment': 2 },
+    by_determination: { Approved: 6, 'Referred to phase 2': 3 },
+    by_phase_2_determination: { Approved: 1, 'Not approved': 1, 'Assessment ceased': 1 },
+    by_waiver_determination: { Approved: 4 },
+    phase_duration: { average_business_days: 20, median_business_days: 18 },
+    ...overrides,
+  };
+}
+
+function renderDashboard(stats) {
+  vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+    if (url.includes('stats.json')) return Promise.resolve(ok(stats));
+    if (url.includes('upcoming-events.json')) return Promise.resolve(ok({ events: [] }));
+    return Promise.resolve(ok({}));
+  });
+  return render(
+    <HelmetProvider>
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>
+    </HelmetProvider>
+  );
+}
+
+describe('Dashboard phase 2 determination chart', () => {
+  beforeEach(() => {
+    dataCache.clear();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    dataCache.clear();
+  });
+
+  it('charts ceased assessments alongside the phase 2 determinations', async () => {
+    renderDashboard(statsFixture());
+
+    const summary = await screen.findByRole('table', {
+      name: /Phase 2 determination breakdown/,
+    });
+    const rows = within(summary).getAllByRole('row').slice(1); // drop the header
+    expect(rows.map((row) => row.textContent)).toEqual([
+      'Approved1',
+      'Not approved1',
+      'Assessment ceased1',
+    ]);
+  });
+
+  it('omits the chart until a phase 2 review has concluded', async () => {
+    renderDashboard(statsFixture({ by_phase_2_determination: {} }));
+
+    // Wait for the page to render before asserting an absence.
+    await waitFor(() => expect(screen.getByText('Phase 1 determinations')).toBeInTheDocument());
+    expect(screen.queryByText('Phase 2 determinations')).not.toBeInTheDocument();
+  });
+});

--- a/merger-tracker/frontend/src/pages/__tests__/Dashboard.test.jsx
+++ b/merger-tracker/frontend/src/pages/__tests__/Dashboard.test.jsx
@@ -18,7 +18,11 @@ function statsFixture(overrides = {}) {
     total_waivers: 4,
     by_status: { 'Under assessment': 2 },
     by_determination: { Approved: 6, 'Referred to phase 2': 3 },
-    by_phase_2_determination: { Approved: 1, 'Not approved': 1, 'Assessment ceased': 1 },
+    by_phase_2_determination: {
+      'Assessment ceased': 1,
+      'Not approved': 1,
+      'Approved with conditions': 1,
+    },
     by_waiver_determination: { Approved: 4 },
     phase_duration: { average_business_days: 20, median_business_days: 18 },
     ...overrides,
@@ -51,15 +55,17 @@ describe('Dashboard phase 2 determination chart', () => {
     dataCache.clear();
   });
 
-  it('charts ceased assessments alongside the phase 2 determinations', async () => {
+  it('charts conditional approvals and ceased assessments as their own outcomes', async () => {
     renderDashboard(statsFixture());
 
     const summary = await screen.findByRole('table', {
       name: /Phase 2 determination breakdown/,
     });
     const rows = within(summary).getAllByRole('row').slice(1); // drop the header
+    // Fixed cleared → blocked → withdrawn order, whatever order stats.json
+    // happens to list the outcomes in.
     expect(rows.map((row) => row.textContent)).toEqual([
-      'Approved1',
+      'Approved with conditions1',
       'Not approved1',
       'Assessment ceased1',
     ]);

--- a/scripts/constants/merger_status.py
+++ b/scripts/constants/merger_status.py
@@ -31,6 +31,14 @@ REFERRED_TO_PHASE_2 = 'Referred to phase 2'
 CLEARED_DETERMINATIONS = frozenset({APPROVED, NOT_OPPOSED})
 BLOCKED_DETERMINATIONS = frozenset({NOT_APPROVED, DECLINED})
 
+# Display label, not an ACCC-published value: the register records a
+# conditional clearance as a plain "Approved" and carries the conditions
+# separately (merger['has_conditions'], set by enrichment.detect_has_conditions).
+# Used where the two need to read as distinct outcomes — currently stats.json's
+# Phase 2 outcome counts. Mirrors the "· with conditions" the frontend's
+# StatusBadge appends elsewhere.
+APPROVED_WITH_CONDITIONS = 'Approved with conditions'
+
 # Values that appear in merger['stage'].
 PHASE_1 = 'Phase 1'
 PHASE_2 = 'Phase 2'

--- a/scripts/static_data/enrichment.py
+++ b/scripts/static_data/enrichment.py
@@ -104,6 +104,23 @@ def is_phase_2_referral_event(event_title: str) -> bool:
     )
 
 
+def phase_2_outcome(merger: dict) -> tuple:
+    """Return ``(determination, date)`` for a Phase 2 review that has concluded.
+
+    A ceased assessment ends the review without a formal determination, so the
+    cessation itself is treated as the outcome (mirroring how stats.py's
+    "recent determinations" handles ceased assessments). Returns ``(None, None)``
+    while a matter is still in Phase 2. Shared by phase2.json's completed-matter
+    cards and stats.json's Phase 2 outcome counts so the two can't drift.
+    """
+    determination = merger.get('phase_2_determination')
+    determination_date = merger.get('phase_2_determination_date')
+    if not determination and merger.get('status') == merger_status.ASSESSMENT_CEASED:
+        determination = merger_status.ASSESSMENT_CEASED
+        determination_date = merger.get('ceased_date')
+    return determination, determination_date
+
+
 def strip_event_status(merger: dict) -> dict:
     """Return a copy of ``merger`` with each event's 'status' key dropped.
 

--- a/scripts/static_data/outputs/phase2.py
+++ b/scripts/static_data/outputs/phase2.py
@@ -8,7 +8,7 @@ are already computed by :func:`static_data.enrichment.enrich_merger`.
 
 from constants import merger_status
 
-from ..enrichment import is_phase_2_referral_event
+from ..enrichment import is_phase_2_referral_event, phase_2_outcome
 from ..filters import filter_notifications
 from ..loaders import FORWARD_REFILE_RELATIONSHIPS
 
@@ -37,13 +37,9 @@ def _entry(merger: dict) -> dict:
     nocc_date, nocc_issued = _nocc(merger)
 
     # A ceased assessment ends the Phase 2 review without a formal
-    # determination, so treat the cessation itself as the outcome (mirrors
-    # stats.py's "recent determinations" handling of ceased assessments).
-    determination = merger.get('phase_2_determination')
-    determination_date = merger.get('phase_2_determination_date')
-    if not determination and merger.get('status') == merger_status.ASSESSMENT_CEASED:
-        determination = merger_status.ASSESSMENT_CEASED
-        determination_date = merger.get('ceased_date')
+    # determination, so the cessation counts as the outcome — see
+    # enrichment.phase_2_outcome, shared with stats.json's outcome counts.
+    determination, determination_date = phase_2_outcome(merger)
 
     return {
         'merger_id': merger.get('merger_id'),

--- a/scripts/static_data/outputs/stats.py
+++ b/scripts/static_data/outputs/stats.py
@@ -103,14 +103,20 @@ def generate(mergers: list) -> dict:
     # have concluded — including the ones the parties withdrew from, which end
     # as a ceased assessment rather than a determination. Matters still in
     # Phase 2 are excluded, so this reconciles with the completed matters on
-    # the Phase 2 tracker (phase2.json).
+    # the Phase 2 tracker (phase2.json). Approvals split by whether conditions
+    # were imposed: at Phase 2 that distinction is the point, since a clearance
+    # bought with a s 87B undertaking or a divestiture is a different result
+    # from an unconditional one.
     by_phase_2_determination = defaultdict(int)
     for m in notification_mergers:
         if merger_status.PHASE_2 not in (m.get('stage') or ''):
             continue
         det, det_date = phase_2_outcome(m)
-        if det and det_date:
-            by_phase_2_determination[det] += 1
+        if not (det and det_date):
+            continue
+        if det == merger_status.APPROVED and m.get('has_conditions'):
+            det = merger_status.APPROVED_WITH_CONDITIONS
+        by_phase_2_determination[det] += 1
 
     # By waiver determination
     by_waiver_determination = defaultdict(int)

--- a/scripts/static_data/outputs/stats.py
+++ b/scripts/static_data/outputs/stats.py
@@ -6,7 +6,7 @@ from statistics import median
 from constants import merger_status
 
 from ..durations import collect_phase_1_durations, collect_waiver_durations
-from ..enrichment import is_phase_2_referral_event
+from ..enrichment import is_phase_2_referral_event, phase_2_outcome
 from ..filters import filter_notifications, filter_waivers
 from ..loaders import BACKWARD_REFILE_RELATIONSHIPS
 
@@ -98,6 +98,19 @@ def generate(mergers: list) -> dict:
         det = m.get('phase_1_determination')
         if det:
             by_determination[det] += 1
+
+    # By Phase 2 outcome (notifications only). Counts the Phase 2 reviews that
+    # have concluded — including the ones the parties withdrew from, which end
+    # as a ceased assessment rather than a determination. Matters still in
+    # Phase 2 are excluded, so this reconciles with the completed matters on
+    # the Phase 2 tracker (phase2.json).
+    by_phase_2_determination = defaultdict(int)
+    for m in notification_mergers:
+        if merger_status.PHASE_2 not in (m.get('stage') or ''):
+            continue
+        det, det_date = phase_2_outcome(m)
+        if det and det_date:
+            by_phase_2_determination[det] += 1
 
     # By waiver determination
     by_waiver_determination = defaultdict(int)
@@ -300,6 +313,7 @@ def generate(mergers: list) -> dict:
         "total_conditional_approvals": total_conditional_approvals,
         "by_status": dict(by_status),
         "by_determination": dict(by_determination),
+        "by_phase_2_determination": dict(by_phase_2_determination),
         "by_waiver_determination": dict(by_waiver_determination),
         "clearance_rate": clearance_rate_data,
         "phase_duration": phase_duration_data,

--- a/scripts/tests/test_static_data_outputs.py
+++ b/scripts/tests/test_static_data_outputs.py
@@ -28,6 +28,7 @@ from static_data.outputs import (
     industries,
     list as list_out,
     parties,
+    phase2,
     questionnaires,
     stats,
     theories_of_harm,
@@ -264,6 +265,98 @@ class TestStatsGenerate:
         phase_2 = next(d for d in phase_transitions if d['merger_id'] == 'MN-0005')
         assert phase_2['determination'] == merger_status.REFERRED_TO_PHASE_2
         assert phase_2['determination_date'] == '2026-04-16T12:00:00Z'
+
+
+def _phase_2_fixture():
+    """Three Phase 2 matters: one determined, one ceased, one still running."""
+    return _raw_fixture() + [
+        {
+            'merger_id': 'MN-0007',
+            'merger_name': 'Nu not approved in phase 2',
+            'status': merger_status.ASSESSMENT_COMPLETED,
+            'accc_determination': merger_status.NOT_APPROVED,
+            'stage': 'Phase 2 - detailed assessment',
+            'effective_notification_datetime': '2026-01-05T09:00:00Z',
+            'determination_publication_date': '2026-06-10T12:00:00Z',
+            'page_modified_datetime': '2026-06-10T12:30:00Z',
+            'anzsic_codes': [],
+            'acquirers': ['Nu'],
+            'targets': ['Xi'],
+            'other_parties': [],
+            'url': 'https://example.com/MN-0007',
+            'events': [
+                {'title': 'Merger notified to ACCC', 'date': '2026-01-05T09:00:00Z'},
+                {'title': 'Decision to Proceed to a Phase 2 review', 'date': '2026-03-02T12:00:00Z'},
+            ],
+        },
+        {
+            'merger_id': 'MN-0008',
+            'merger_name': 'Omicron withdrew from phase 2',
+            'status': merger_status.ASSESSMENT_CEASED,
+            'accc_determination': None,
+            'stage': 'Phase 2 - detailed assessment',
+            'effective_notification_datetime': '2026-01-20T09:00:00Z',
+            'determination_publication_date': None,
+            'page_modified_datetime': '2026-07-01T12:30:00Z',
+            'anzsic_codes': [],
+            'acquirers': ['Omicron'],
+            'targets': ['Pi'],
+            'other_parties': [],
+            'url': 'https://example.com/MN-0008',
+            'events': [
+                {'title': 'Merger notified to ACCC', 'date': '2026-01-20T09:00:00Z'},
+                {'title': 'Decision to Proceed to a Phase 2 review', 'date': '2026-03-16T12:00:00Z'},
+                {'title': 'Consideration of Notification ceased', 'date': '2026-07-01T12:00:00Z'},
+            ],
+        },
+        {
+            'merger_id': 'MN-0009',
+            'merger_name': 'Rho still in phase 2',
+            'status': merger_status.UNDER_ASSESSMENT,
+            'accc_determination': None,
+            'stage': 'Phase 2 - detailed assessment',
+            'effective_notification_datetime': '2026-04-01T09:00:00Z',
+            'determination_publication_date': None,
+            'end_of_determination_period': '2026-11-02T12:00:00Z',
+            'page_modified_datetime': '2026-06-01T12:30:00Z',
+            'anzsic_codes': [],
+            'acquirers': ['Rho'],
+            'targets': ['Sigma'],
+            'other_parties': [],
+            'url': 'https://example.com/MN-0009',
+            'events': [
+                {'title': 'Merger notified to ACCC', 'date': '2026-04-01T09:00:00Z'},
+                {'title': 'Decision to Proceed to a Phase 2 review', 'date': '2026-05-20T12:00:00Z'},
+            ],
+        },
+    ]
+
+
+class TestStatsPhase2Determinations:
+    """by_phase_2_determination: the dashboard's Phase 2 outcome doughnut."""
+
+    def test_counts_determinations_and_withdrawals(self):
+        payload = stats.generate([enrich_merger(m) for m in _phase_2_fixture()])
+        # The ceased matter is charted as its own outcome — a Phase 2 review
+        # the parties dropped out of, never determined — while MN-0009, still
+        # in Phase 2, has no outcome to count yet.
+        assert payload['by_phase_2_determination'] == {
+            merger_status.NOT_APPROVED: 1,
+            merger_status.ASSESSMENT_CEASED: 1,
+        }
+
+    def test_phase_1_determinations_stay_separate(self):
+        payload = stats.generate([enrich_merger(m) for m in _phase_2_fixture()])
+        # A Phase 2 outcome must not leak into the Phase 1 chart: all three
+        # referred matters count once there, as "Referred to phase 2".
+        assert payload['by_determination'][merger_status.REFERRED_TO_PHASE_2] == 3
+        assert merger_status.ASSESSMENT_CEASED not in payload['by_determination']
+
+    def test_reconciles_with_phase_2_tracker(self):
+        enriched = [enrich_merger(m) for m in _phase_2_fixture()]
+        payload = stats.generate(enriched)
+        tracker = phase2.generate(enriched)
+        assert sum(payload['by_phase_2_determination'].values()) == tracker['count']['completed']
 
 
 class TestStatsMedianMatchesAnalysis:

--- a/scripts/tests/test_static_data_outputs.py
+++ b/scripts/tests/test_static_data_outputs.py
@@ -268,7 +268,7 @@ class TestStatsGenerate:
 
 
 def _phase_2_fixture():
-    """Three Phase 2 matters: one determined, one ceased, one still running."""
+    """Four Phase 2 matters: two determined, one ceased, one still running."""
     return _raw_fixture() + [
         {
             'merger_id': 'MN-0007',
@@ -329,6 +329,26 @@ def _phase_2_fixture():
                 {'title': 'Decision to Proceed to a Phase 2 review', 'date': '2026-05-20T12:00:00Z'},
             ],
         },
+        {
+            'merger_id': 'MN-0010',
+            'merger_name': 'Mu approved in phase 2 on undertakings',
+            'status': merger_status.ASSESSMENT_COMPLETED,
+            'accc_determination': merger_status.APPROVED,
+            'stage': 'Phase 2 - detailed assessment',
+            'effective_notification_datetime': '2025-12-01T09:00:00Z',
+            'determination_publication_date': '2026-05-11T12:00:00Z',
+            'page_modified_datetime': '2026-05-11T12:30:00Z',
+            'anzsic_codes': [],
+            'acquirers': ['Mu'],
+            'targets': ['Tau'],
+            'other_parties': [],
+            'url': 'https://example.com/MN-0010',
+            'events': [
+                {'title': 'Merger notified to ACCC', 'date': '2025-12-01T09:00:00Z'},
+                {'title': 'Decision to Proceed to a Phase 2 review', 'date': '2026-02-02T12:00:00Z'},
+                {'title': 'ACCC accepted s 87B undertaking', 'date': '2026-05-11T12:00:00Z'},
+            ],
+        },
     ]
 
 
@@ -337,19 +357,31 @@ class TestStatsPhase2Determinations:
 
     def test_counts_determinations_and_withdrawals(self):
         payload = stats.generate([enrich_merger(m) for m in _phase_2_fixture()])
-        # The ceased matter is charted as its own outcome — a Phase 2 review
-        # the parties dropped out of, never determined — while MN-0009, still
-        # in Phase 2, has no outcome to count yet.
+        # MN-0010's approval came with a s 87B undertaking, so it counts apart
+        # from an unconditional clearance. The ceased matter is charted as its
+        # own outcome — a Phase 2 review the parties dropped out of, never
+        # determined — while MN-0009, still in Phase 2, has none to count yet.
         assert payload['by_phase_2_determination'] == {
+            merger_status.APPROVED_WITH_CONDITIONS: 1,
             merger_status.NOT_APPROVED: 1,
             merger_status.ASSESSMENT_CEASED: 1,
         }
 
+    def test_unconditional_approval_keeps_the_plain_label(self):
+        mergers = _phase_2_fixture()
+        conditional = next(m for m in mergers if m['merger_id'] == 'MN-0010')
+        conditional['events'] = [
+            e for e in conditional['events'] if '87B' not in e['title']
+        ]
+        payload = stats.generate([enrich_merger(m) for m in mergers])
+        assert payload['by_phase_2_determination'][merger_status.APPROVED] == 1
+        assert merger_status.APPROVED_WITH_CONDITIONS not in payload['by_phase_2_determination']
+
     def test_phase_1_determinations_stay_separate(self):
         payload = stats.generate([enrich_merger(m) for m in _phase_2_fixture()])
-        # A Phase 2 outcome must not leak into the Phase 1 chart: all three
+        # A Phase 2 outcome must not leak into the Phase 1 chart: all four
         # referred matters count once there, as "Referred to phase 2".
-        assert payload['by_determination'][merger_status.REFERRED_TO_PHASE_2] == 3
+        assert payload['by_determination'][merger_status.REFERRED_TO_PHASE_2] == 4
         assert merger_status.ASSESSMENT_CEASED not in payload['by_determination']
 
     def test_reconciles_with_phase_2_tracker(self):


### PR DESCRIPTION
Charts how concluded Phase 2 reviews ended, alongside the existing Phase 1
and waiver doughnuts. Ceased assessments count as an outcome of their own —
a Phase 2 review the parties withdrew from ends without a determination, so
leaving them out would understate how Phase 2 matters actually finish.

stats.json gains by_phase_2_determination, counting only Phase 2 matters
that have concluded. The "determination or cessation" rule now lives in
enrichment.phase_2_outcome, shared with phase2.json's completed-matter
cards so the dashboard count and the Phase 2 tracker can't drift.

The chart grid goes to 2x2 on lg and 4-across on xl to fit the fourth card.