### PR TITLE
Flag conditional approvals on recent determination cards

### DIFF
--- a/merger-tracker/frontend/public/data/phase2.json
+++ b/merger-tracker/frontend/public/data/phase2.json
@@ -9,6 +9,7 @@
       "end_of_determination_period": "2026-09-23T12:00:00Z",
       "determination": null,
       "determination_date": null,
+      "has_conditions": false,
       "phase_2_inferred": false,
       "under_appeal": false,
       "is_refiled": false
@@ -22,6 +23,7 @@
       "end_of_determination_period": "2026-11-10T12:00:00Z",
       "determination": null,
       "determination_date": null,
+      "has_conditions": false,
       "phase_2_inferred": false,
       "under_appeal": false,
       "is_refiled": false
@@ -35,6 +37,7 @@
       "end_of_determination_period": "2026-11-27T12:00:00Z",
       "determination": null,
       "determination_date": null,
+      "has_conditions": false,
       "phase_2_inferred": false,
       "under_appeal": false,
       "is_refiled": false
@@ -50,6 +53,7 @@
       "end_of_determination_period": "2026-08-17T12:00:00Z",
       "determination": "Not approved",
       "determination_date": "2026-08-07T12:00:00Z",
+      "has_conditions": false,
       "phase_2_inferred": false,
       "under_appeal": false,
       "is_refiled": false
@@ -63,6 +67,7 @@
       "end_of_determination_period": "2026-11-06T12:00:00Z",
       "determination": "Assessment ceased",
       "determination_date": "2026-07-10T12:00:00Z",
+      "has_conditions": false,
       "phase_2_inferred": false,
       "under_appeal": false,
       "is_refiled": false
@@ -76,6 +81,7 @@
       "end_of_determination_period": "2026-07-02T12:00:00Z",
       "determination": "Not approved",
       "determination_date": "2026-07-01T12:00:00Z",
+      "has_conditions": false,
       "phase_2_inferred": false,
       "under_appeal": true,
       "is_refiled": false
@@ -89,6 +95,7 @@
       "end_of_determination_period": "2026-10-08T12:00:00Z",
       "determination": "Assessment ceased",
       "determination_date": "2026-06-15T12:00:00Z",
+      "has_conditions": false,
       "phase_2_inferred": false,
       "under_appeal": false,
       "is_refiled": true
@@ -102,6 +109,7 @@
       "end_of_determination_period": "2026-06-05T12:00:00Z",
       "determination": "Approved",
       "determination_date": "2026-06-02T12:00:00Z",
+      "has_conditions": true,
       "phase_2_inferred": false,
       "under_appeal": false,
       "is_refiled": false

--- a/merger-tracker/frontend/public/data/stats.json
+++ b/merger-tracker/frontend/public/data/stats.json
@@ -225,7 +225,8 @@
       "page_modified_datetime": "2026-08-12T09:46:14+10:00",
       "determination_type": "final",
       "is_waiver": false,
-      "stage": "Phase 1 - initial assessment"
+      "stage": "Phase 1 - initial assessment",
+      "has_conditions": true
     },
     {
       "merger_id": "MN-75029",
@@ -235,7 +236,8 @@
       "page_modified_datetime": "2026-08-12T08:22:52+10:00",
       "determination_type": "final",
       "is_waiver": false,
-      "stage": "Phase 1 - initial assessment"
+      "stage": "Phase 1 - initial assessment",
+      "has_conditions": false
     },
     {
       "merger_id": "WA-50033",
@@ -245,7 +247,8 @@
       "page_modified_datetime": "2026-08-11T18:18:10+10:00",
       "determination_type": "final",
       "is_waiver": true,
-      "stage": "Waiver application"
+      "stage": "Waiver application",
+      "has_conditions": false
     },
     {
       "merger_id": "WA-10024",
@@ -255,7 +258,8 @@
       "page_modified_datetime": "2026-08-11T16:56:13+10:00",
       "determination_type": "final",
       "is_waiver": true,
-      "stage": "Waiver application"
+      "stage": "Waiver application",
+      "has_conditions": false
     },
     {
       "merger_id": "MN-60025",
@@ -265,7 +269,8 @@
       "page_modified_datetime": "2026-08-10T16:40:55+10:00",
       "determination_type": "final",
       "is_waiver": false,
-      "stage": "Phase 1 - initial assessment"
+      "stage": "Phase 1 - initial assessment",
+      "has_conditions": false
     },
     {
       "merger_id": "WA-70029",
@@ -275,7 +280,8 @@
       "page_modified_datetime": "2026-08-10T16:34:12+10:00",
       "determination_type": "final",
       "is_waiver": true,
-      "stage": "Waiver application"
+      "stage": "Waiver application",
+      "has_conditions": false
     },
     {
       "merger_id": "MN-15027",
@@ -285,7 +291,8 @@
       "page_modified_datetime": "2026-08-10T09:20:51+10:00",
       "determination_type": "final",
       "is_waiver": false,
-      "stage": "Phase 1 - initial assessment"
+      "stage": "Phase 1 - initial assessment",
+      "has_conditions": false
     },
     {
       "merger_id": "MN-30003",
@@ -295,7 +302,8 @@
       "page_modified_datetime": "2026-08-10T18:23:56+10:00",
       "determination_type": "final",
       "is_waiver": false,
-      "stage": "Phase 2 - detailed assessment"
+      "stage": "Phase 2 - detailed assessment",
+      "has_conditions": false
     },
     {
       "merger_id": "WA-05035",
@@ -305,7 +313,8 @@
       "page_modified_datetime": "2026-08-07T16:41:43+10:00",
       "determination_type": "final",
       "is_waiver": true,
-      "stage": "Waiver application"
+      "stage": "Waiver application",
+      "has_conditions": false
     },
     {
       "merger_id": "MN-70026",
@@ -315,7 +324,8 @@
       "page_modified_datetime": "2026-08-06T17:14:51+10:00",
       "determination_type": "final",
       "is_waiver": false,
-      "stage": "Phase 1 - initial assessment"
+      "stage": "Phase 1 - initial assessment",
+      "has_conditions": false
     },
     {
       "merger_id": "WA-05037",
@@ -325,7 +335,8 @@
       "page_modified_datetime": "2026-08-05T16:44:06+10:00",
       "determination_type": "final",
       "is_waiver": true,
-      "stage": "Waiver application"
+      "stage": "Waiver application",
+      "has_conditions": false
     },
     {
       "merger_id": "MN-65023",
@@ -335,7 +346,8 @@
       "page_modified_datetime": "2026-08-05T12:51:47+10:00",
       "determination_type": "final",
       "is_waiver": false,
-      "stage": "Phase 1 - initial assessment"
+      "stage": "Phase 1 - initial assessment",
+      "has_conditions": false
     }
   ]
 }

--- a/merger-tracker/frontend/src/components/Phase2CompletedCards.jsx
+++ b/merger-tracker/frontend/src/components/Phase2CompletedCards.jsx
@@ -1,5 +1,5 @@
 import { calculateDuration } from '../utils/dates';
-import { DETERMINATION_LABELS } from '../constants/mergerStatus';
+import { DETERMINATION_LABELS, isConditionalApproval } from '../constants/mergerStatus';
 import { getCardStyle } from '../constants/cardStyles';
 import CardCollapseGrid from './CardCollapseGrid';
 import MergerCardBody, { CHIP_BASE_CLASS } from './MergerCardBody';
@@ -28,6 +28,11 @@ function Phase2CompletedCards({ matters }) {
                 <span aria-hidden="true">·</span>
                 <span className="tabular-nums">{duration} days in Phase 2</span>
               </>
+            )}
+            {isConditionalApproval(item) && (
+              <span className={`${CHIP_BASE_CLASS} font-medium ${style.chip}`}>
+                With conditions
+              </span>
             )}
             {item.is_refiled && (
               <span className={`${CHIP_BASE_CLASS} font-medium ${style.chip}`}>

--- a/merger-tracker/frontend/src/components/RecentDeterminationsCards.jsx
+++ b/merger-tracker/frontend/src/components/RecentDeterminationsCards.jsx
@@ -1,6 +1,6 @@
 import { formatDate } from '../utils/dates';
 import { isNewItem } from '../utils/lastVisit';
-import { DETERMINATION_LABELS, MERGER_STATUS } from '../constants/mergerStatus';
+import { DETERMINATION_LABELS, isConditionalApproval } from '../constants/mergerStatus';
 import { getCardStyle, NEW_ITEM_BORDER } from '../constants/cardStyles';
 import CardCollapseGrid from './CardCollapseGrid';
 import MergerCardBody, { CHIP_BASE_CLASS } from './MergerCardBody';
@@ -11,13 +11,6 @@ function getDeterminationCardStyle(item) {
   // Highlight recent determinations the visitor hasn't seen yet (those that
   // also show a "New" badge) with a blue ring so they stand out.
   return isNewItem(item.merger_id) ? { ...base, border: NEW_ITEM_BORDER } : base;
-}
-
-// The register publishes a conditional clearance as a plain "Approved" with
-// has_conditions set alongside (see mergerStatus.js), so the card spells the
-// difference out rather than letting it read as an unconditional approval.
-function hasConditionalApproval(item) {
-  return Boolean(item.has_conditions) && item.determination === MERGER_STATUS.APPROVED;
 }
 
 function RecentDeterminationsCards({ determinations }) {
@@ -52,7 +45,7 @@ function RecentDeterminationsCards({ determinations }) {
             <span>{item.merger_id}</span>
             <span aria-hidden="true">·</span>
             <span>{formatDate(item.determination_date)}</span>
-            {hasConditionalApproval(item) && (
+            {isConditionalApproval(item) && (
               <span className={`${CHIP_BASE_CLASS} font-medium ${style.chip}`}>
                 With conditions
               </span>

--- a/merger-tracker/frontend/src/components/RecentDeterminationsCards.jsx
+++ b/merger-tracker/frontend/src/components/RecentDeterminationsCards.jsx
@@ -1,6 +1,6 @@
 import { formatDate } from '../utils/dates';
 import { isNewItem } from '../utils/lastVisit';
-import { DETERMINATION_LABELS } from '../constants/mergerStatus';
+import { DETERMINATION_LABELS, MERGER_STATUS } from '../constants/mergerStatus';
 import { getCardStyle, NEW_ITEM_BORDER } from '../constants/cardStyles';
 import CardCollapseGrid from './CardCollapseGrid';
 import MergerCardBody, { CHIP_BASE_CLASS } from './MergerCardBody';
@@ -11,6 +11,13 @@ function getDeterminationCardStyle(item) {
   // Highlight recent determinations the visitor hasn't seen yet (those that
   // also show a "New" badge) with a blue ring so they stand out.
   return isNewItem(item.merger_id) ? { ...base, border: NEW_ITEM_BORDER } : base;
+}
+
+// The register publishes a conditional clearance as a plain "Approved" with
+// has_conditions set alongside (see mergerStatus.js), so the card spells the
+// difference out rather than letting it read as an unconditional approval.
+function hasConditionalApproval(item) {
+  return Boolean(item.has_conditions) && item.determination === MERGER_STATUS.APPROVED;
 }
 
 function RecentDeterminationsCards({ determinations }) {
@@ -45,6 +52,11 @@ function RecentDeterminationsCards({ determinations }) {
             <span>{item.merger_id}</span>
             <span aria-hidden="true">·</span>
             <span>{formatDate(item.determination_date)}</span>
+            {hasConditionalApproval(item) && (
+              <span className={`${CHIP_BASE_CLASS} font-medium ${style.chip}`}>
+                With conditions
+              </span>
+            )}
             {item.is_waiver && (
               <span className={`${CHIP_BASE_CLASS} font-medium ${style.chip}`}>
                 Waiver

--- a/merger-tracker/frontend/src/components/__tests__/Phase2CompletedCards.test.jsx
+++ b/merger-tracker/frontend/src/components/__tests__/Phase2CompletedCards.test.jsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it } from 'vitest';
+import Phase2CompletedCards from '../Phase2CompletedCards';
+
+function renderCards(matters) {
+  return render(
+    <MemoryRouter>
+      <Phase2CompletedCards matters={matters} />
+    </MemoryRouter>
+  );
+}
+
+const matter = {
+  merger_id: 'MN-0001',
+  merger_name: 'Alpha acquires Beta',
+  determination: 'Approved',
+  determination_date: '2026-08-01T12:00:00Z',
+  referral_date: '2026-03-10T09:00:00Z',
+  is_refiled: false,
+  under_appeal: false,
+  has_conditions: false,
+};
+
+describe('Phase2CompletedCards', () => {
+  it('flags a conditional approval', () => {
+    renderCards([{ ...matter, has_conditions: true }]);
+    expect(screen.getByText('Approved')).toBeInTheDocument();
+    expect(screen.getByText('With conditions')).toBeInTheDocument();
+  });
+
+  it('leaves an unconditional approval unflagged', () => {
+    renderCards([matter]);
+    expect(screen.getByText('Approved')).toBeInTheDocument();
+    expect(screen.queryByText('With conditions')).not.toBeInTheDocument();
+  });
+
+  it('does not flag conditions on a determination that is not an approval', () => {
+    // has_conditions is only meaningful alongside "Approved"; a stale flag on
+    // any other outcome must not surface.
+    renderCards([{ ...matter, determination: 'Not approved', has_conditions: true }]);
+    expect(screen.queryByText('With conditions')).not.toBeInTheDocument();
+  });
+
+  it('shows the conditions chip alongside the other card chips', () => {
+    renderCards([{ ...matter, has_conditions: true, is_refiled: true, under_appeal: true }]);
+    expect(screen.getByText('With conditions')).toBeInTheDocument();
+    expect(screen.getByText('Refiled')).toBeInTheDocument();
+    expect(screen.getByText('Under appeal')).toBeInTheDocument();
+  });
+});

--- a/merger-tracker/frontend/src/components/__tests__/RecentDeterminationsCards.test.jsx
+++ b/merger-tracker/frontend/src/components/__tests__/RecentDeterminationsCards.test.jsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it } from 'vitest';
+import RecentDeterminationsCards from '../RecentDeterminationsCards';
+
+function renderCards(determinations) {
+  return render(
+    <MemoryRouter>
+      <RecentDeterminationsCards determinations={determinations} />
+    </MemoryRouter>
+  );
+}
+
+const approval = {
+  merger_id: 'MN-0001',
+  merger_name: 'Alpha acquires Beta',
+  determination: 'Approved',
+  determination_date: '2026-08-11T12:00:00Z',
+  determination_type: 'final',
+  is_waiver: false,
+  has_conditions: false,
+};
+
+describe('RecentDeterminationsCards', () => {
+  it('flags a conditional approval', () => {
+    renderCards([{ ...approval, has_conditions: true }]);
+    expect(screen.getByText('Approved')).toBeInTheDocument();
+    expect(screen.getByText('With conditions')).toBeInTheDocument();
+  });
+
+  it('leaves an unconditional approval unflagged', () => {
+    renderCards([approval]);
+    expect(screen.getByText('Approved')).toBeInTheDocument();
+    expect(screen.queryByText('With conditions')).not.toBeInTheDocument();
+  });
+
+  it('does not flag conditions on a determination that is not an approval', () => {
+    // has_conditions is only meaningful alongside "Approved"; a stale flag on
+    // any other outcome must not surface.
+    renderCards([{ ...approval, determination: 'Not approved', has_conditions: true }]);
+    expect(screen.queryByText('With conditions')).not.toBeInTheDocument();
+  });
+
+  it('still shows the waiver chip alongside the conditions chip', () => {
+    renderCards([{ ...approval, is_waiver: true, has_conditions: true }]);
+    expect(screen.getByText('Waiver')).toBeInTheDocument();
+    expect(screen.getByText('With conditions')).toBeInTheDocument();
+  });
+});

--- a/merger-tracker/frontend/src/constants/mergerStatus.js
+++ b/merger-tracker/frontend/src/constants/mergerStatus.js
@@ -46,6 +46,15 @@ export const DETERMINATION_LABELS = {
   [MERGER_STATUS.ASSESSMENT_CEASED]: 'Ceased',
 };
 
+// True when a card entry records a clearance granted subject to conditions.
+// The register publishes those as a plain "Approved" with has_conditions set
+// alongside, so the card grids spell the difference out rather than letting a
+// conditional clearance read as an unconditional one. The determination check
+// keeps a stale flag from surfacing on any other outcome (mirrors StatusBadge).
+export function isConditionalApproval(item) {
+  return Boolean(item?.has_conditions) && item?.determination === MERGER_STATUS.APPROVED;
+}
+
 // Fallback Tailwind classes for StatusBadge when no specific status matches.
 export const DEFAULT_STATUS_STYLE = 'bg-gray-50 text-gray-600 border-gray-200/60';
 

--- a/scripts/static_data/outputs/phase2.py
+++ b/scripts/static_data/outputs/phase2.py
@@ -50,6 +50,9 @@ def _entry(merger: dict) -> dict:
         'end_of_determination_period': merger.get('end_of_determination_period'),
         'determination': determination,
         'determination_date': determination_date,
+        # The register records a conditional clearance as a plain "Approved";
+        # the completed-matter card flags the difference.
+        'has_conditions': bool(merger.get('has_conditions', False)),
         'phase_2_inferred': bool(merger.get('phase_2_inferred')),
         # Whether the matter is under review at the Australian Competition
         # Tribunal — surfaces an "Under appeal" chip on the completed card.

--- a/scripts/static_data/outputs/stats.py
+++ b/scripts/static_data/outputs/stats.py
@@ -252,6 +252,9 @@ def generate(mergers: list) -> dict:
                 "determination_type": "final",
                 "is_waiver": is_waiver,
                 "stage": m.get('stage'),
+                # The register records a conditional clearance as a plain
+                # "Approved"; the dashboard cards flag the difference.
+                "has_conditions": bool(m.get('has_conditions', False)),
             })
 
         # Check for Phase 2 referrals (stage transitions)

--- a/scripts/tests/test_phase2.py
+++ b/scripts/tests/test_phase2.py
@@ -108,7 +108,7 @@ class TestReturnsValidShape:
         assert set(entry.keys()) == {
             'merger_id', 'merger_name', 'referral_date', 'nocc_date', 'nocc_issued',
             'end_of_determination_period', 'determination', 'determination_date',
-            'phase_2_inferred', 'is_refiled', 'under_appeal',
+            'phase_2_inferred', 'is_refiled', 'under_appeal', 'has_conditions',
         }
 
 
@@ -135,6 +135,18 @@ class TestCurrentVsCompleted:
         entry = payload['completed'][0]
         assert entry['determination'] == 'Approved'
         assert entry['determination_date'] == '2025-08-01T12:00:00Z'
+
+    def test_completed_conditional_approval_is_flagged(self):
+        # A conditional clearance is published as a plain "Approved"; the
+        # completed-matter card needs has_conditions to tell the two apart.
+        conditional = _completed_phase2('MN-0004')
+        conditional['accc_determination_raw'] = 'Approved subject to conditions'
+        mergers = [enrich_merger(conditional), enrich_merger(_completed_phase2('MN-0005'))]
+        payload = phase2.generate(mergers)
+        by_id = {e['merger_id']: e for e in payload['completed']}
+        assert by_id['MN-0004']['determination'] == 'Approved'
+        assert by_id['MN-0004']['has_conditions'] is True
+        assert by_id['MN-0005']['has_conditions'] is False
 
     def test_waivers_excluded(self):
         mergers = [enrich_merger(_waiver())]

--- a/scripts/tests/test_static_data_outputs.py
+++ b/scripts/tests/test_static_data_outputs.py
@@ -200,6 +200,22 @@ class TestStatsGenerate:
         order = [m['merger_id'] for m in payload['recent_mergers']]
         assert order.index('MN-0002') < order.index('MN-0001')
 
+    def test_recent_determinations_flag_conditional_approvals(self):
+        # A conditional clearance is published as a plain "Approved"; the card
+        # grid needs has_conditions to tell the two apart.
+        mergers = _raw_fixture()
+        conditional = next(m for m in mergers if m['merger_id'] == 'MN-0001')
+        conditional['accc_determination_raw'] = 'Approved subject to conditions'
+        enriched = [enrich_merger(m) for m in mergers]
+        payload = stats.generate(enriched)
+        by_id = {
+            d['merger_id']: d for d in payload['recent_determinations']
+            if d['determination_type'] == 'final'
+        }
+        assert by_id['MN-0001']['determination'] == merger_status.APPROVED
+        assert by_id['MN-0001']['has_conditions'] is True
+        assert by_id['WA-0003']['has_conditions'] is False
+
     def test_recent_determinations_includes_ceased_assessments(self):
         mergers = _raw_fixture()
         mergers.append({


### PR DESCRIPTION
The register publishes a conditional clearance as a plain "Approved" with
has_conditions alongside, so the dashboard's recent-determination cards read
the same as an unconditional approval. Carry has_conditions through the
recent_determinations payload and show a "With conditions" chip next to the
existing waiver chip.