### PR TITLE
Parse questionnaire deadlines with weekday or unbracketed timezone prefixes

### DIFF
--- a/data/processed/questionnaire_data.json
+++ b/data/processed/questionnaire_data.json
@@ -803,8 +803,8 @@
   },
   "MN-01104": {
     "_sha256": "bd85e3fcb04da8d24128b00972f15324f0a658429df9493724de30c9b053a065",
-    "deadline": null,
-    "deadline_iso": null,
+    "deadline": "29 June 2026",
+    "deadline_iso": "2026-06-29",
     "file_name": "Genea - Care Fertility Greenslopes - Questionnaire.pdf",
     "file_path": "matters/MN-01104/Genea - Care Fertility Greenslopes - Questionnaire.pdf",
     "questions": [
@@ -1037,8 +1037,8 @@
   },
   "MN-05012": {
     "_sha256": "82b9a0867ee0d3f8215d23b876c325a75a45299c68cea11a5051274b6548e0f2",
-    "deadline": null,
-    "deadline_iso": null,
+    "deadline": "10 April 2026",
+    "deadline_iso": "2026-04-10",
     "file_name": "Eagers - Audi - third-party questionnaire - March 2026.pdf",
     "file_path": "matters/MN-05012/Eagers - Audi - third-party questionnaire - March 2026.pdf",
     "questions": [
@@ -1598,8 +1598,8 @@
   },
   "MN-10022": {
     "_sha256": "acd52c8f3b2d0a5ea5a6426cf0592f587ef41ed66e9e55621524ac814e878aba",
-    "deadline": null,
-    "deadline_iso": null,
+    "deadline": "7 August 2026",
+    "deadline_iso": "2026-08-07",
     "file_name": "M Resources and Golden Energy and Resources \u2013 Tahmoor Coal Mine - Questionnaire_0.pdf",
     "file_path": "matters/MN-10022/M Resources and Golden Energy and Resources \u2013 Tahmoor Coal Mine - Questionnaire_0.pdf",
     "questions": [
@@ -2374,8 +2374,8 @@
   },
   "MN-25021": {
     "_sha256": "87f49212338d5642825b019d8de5dd7f8ce59964e132763017c793f2af0bf7e1",
-    "deadline": null,
-    "deadline_iso": null,
+    "deadline": "19 May 2026",
+    "deadline_iso": "2026-05-19",
     "file_name": "Questionnaire - OpenAI - Tomoro.pdf",
     "file_path": "matters/MN-25021/Questionnaire - OpenAI - Tomoro.pdf",
     "questions": [
@@ -2593,8 +2593,68 @@
     "questions_count": 16
   },
   "MN-30003": {
-    "_sha256": "243f8d942af2661225be2f27cd0821da8a1eed7a185a158e150756894b9e453c",
+    "_sha256": "c661fc75b91b478187203e4fb1ea8e18f2c64e203b8e7253feafa078c779fcec",
     "all_questionnaires": [
+      {
+        "_sha256": "c661fc75b91b478187203e4fb1ea8e18f2c64e203b8e7253feafa078c779fcec",
+        "deadline": "1 July 2026",
+        "deadline_iso": "2026-07-01",
+        "file_name": "Microstar Konvoy - Questionnaire - Remedy offer (17 June 2026).pdf",
+        "file_path": "matters/MN-30003/Microstar Konvoy - Questionnaire - Remedy offer (17 June 2026).pdf",
+        "questions": [
+          {
+            "number": 1,
+            "section": null,
+            "text": "Provide a brief description of your business or organisation, including any commercial relationships with MicroStar, Kegstar, or Konvoy."
+          },
+          {
+            "number": 2,
+            "section": null,
+            "text": "Outline any concerns you have regarding the impact of the Acquisition on competition."
+          },
+          {
+            "number": 3,
+            "section": "The remedy offer",
+            "text": "Describe the extent to which Kegstar\u2019s remedy offer would address any concerns you have in relation to the Acquisition"
+          },
+          {
+            "number": 4,
+            "section": "The remedy offer",
+            "text": "Provide any views you have on whether a period of 3 years is an appropriate duration for the majority of obligations under Kegstar\u2019s remedy offer."
+          },
+          {
+            "number": 5,
+            "section": "The remedy offer",
+            "text": "Provide any additional information or comments you consider relevant to the ACCC\u2019s consideration of the remedy offer."
+          },
+          {
+            "number": 6,
+            "section": "Non-enforcement of exclusivity in Kegstar contracts",
+            "text": "Provide your view on whether the obligations on Kegstar to not include or enforce an exclusivity provision in agreements with customers or suppliers would address your competition concerns in relation to the Acquisition."
+          },
+          {
+            "number": 7,
+            "section": "Non-enforcement of exclusivity in Kegstar contracts",
+            "text": "Provide your views on whether a period of 3 years to not include or enforce the exclusivity provisions is appropriate."
+          },
+          {
+            "number": 8,
+            "section": "Konvoy Customer options",
+            "text": "Under the remedy offer, Kegstar must offer to enter into a contract for Kegstar services, if an existing Konvoy Customer requests a contract within 3 months from Completion \u2013 provide your view on whether this is an acceptable mechanism and timeframe. Please also provide any other views on the Konvoy Customer options."
+          },
+          {
+            "number": 9,
+            "section": "Customer option to purchase kegs",
+            "text": "Provide your view on whether you are likely to purchase kegs from Kegstar, if given the option, and if this could replace the loss of competition from Konvoy leaving the market. Please also provide any other views on the Customer option to purchase kegs."
+          },
+          {
+            "number": 10,
+            "section": "Service level commitment",
+            "text": "Provide your view on whether the inclusion of a termination right if key performance indicators are not met into Customer Contracts for Kegstar\u2019s services would address any competition concerns from the Acquisition."
+          }
+        ],
+        "questions_count": 10
+      },
       {
         "_sha256": "243f8d942af2661225be2f27cd0821da8a1eed7a185a158e150756894b9e453c",
         "deadline": "2 March 2026",
@@ -2684,77 +2744,17 @@
           }
         ],
         "questions_count": 7
-      },
-      {
-        "_sha256": "c661fc75b91b478187203e4fb1ea8e18f2c64e203b8e7253feafa078c779fcec",
-        "deadline": null,
-        "deadline_iso": null,
-        "file_name": "Microstar Konvoy - Questionnaire - Remedy offer (17 June 2026).pdf",
-        "file_path": "matters/MN-30003/Microstar Konvoy - Questionnaire - Remedy offer (17 June 2026).pdf",
-        "questions": [
-          {
-            "number": 1,
-            "section": null,
-            "text": "Provide a brief description of your business or organisation, including any commercial relationships with MicroStar, Kegstar, or Konvoy."
-          },
-          {
-            "number": 2,
-            "section": null,
-            "text": "Outline any concerns you have regarding the impact of the Acquisition on competition."
-          },
-          {
-            "number": 3,
-            "section": "The remedy offer",
-            "text": "Describe the extent to which Kegstar\u2019s remedy offer would address any concerns you have in relation to the Acquisition"
-          },
-          {
-            "number": 4,
-            "section": "The remedy offer",
-            "text": "Provide any views you have on whether a period of 3 years is an appropriate duration for the majority of obligations under Kegstar\u2019s remedy offer."
-          },
-          {
-            "number": 5,
-            "section": "The remedy offer",
-            "text": "Provide any additional information or comments you consider relevant to the ACCC\u2019s consideration of the remedy offer."
-          },
-          {
-            "number": 6,
-            "section": "Non-enforcement of exclusivity in Kegstar contracts",
-            "text": "Provide your view on whether the obligations on Kegstar to not include or enforce an exclusivity provision in agreements with customers or suppliers would address your competition concerns in relation to the Acquisition."
-          },
-          {
-            "number": 7,
-            "section": "Non-enforcement of exclusivity in Kegstar contracts",
-            "text": "Provide your views on whether a period of 3 years to not include or enforce the exclusivity provisions is appropriate."
-          },
-          {
-            "number": 8,
-            "section": "Konvoy Customer options",
-            "text": "Under the remedy offer, Kegstar must offer to enter into a contract for Kegstar services, if an existing Konvoy Customer requests a contract within 3 months from Completion \u2013 provide your view on whether this is an acceptable mechanism and timeframe. Please also provide any other views on the Konvoy Customer options."
-          },
-          {
-            "number": 9,
-            "section": "Customer option to purchase kegs",
-            "text": "Provide your view on whether you are likely to purchase kegs from Kegstar, if given the option, and if this could replace the loss of competition from Konvoy leaving the market. Please also provide any other views on the Customer option to purchase kegs."
-          },
-          {
-            "number": 10,
-            "section": "Service level commitment",
-            "text": "Provide your view on whether the inclusion of a termination right if key performance indicators are not met into Customer Contracts for Kegstar\u2019s services would address any competition concerns from the Acquisition."
-          }
-        ],
-        "questions_count": 10
       }
     ],
-    "deadline": "2 March 2026",
-    "deadline_iso": "2026-03-02",
-    "file_name": "MN-30003 - MicroStar-Konvoy - third party questionnaire - 9 Feb 2026.pdf",
-    "file_path": "matters/MN-30003/MN-30003 - MicroStar-Konvoy - third party questionnaire - 9 Feb 2026.pdf",
+    "deadline": "1 July 2026",
+    "deadline_iso": "2026-07-01",
+    "file_name": "Microstar Konvoy - Questionnaire - Remedy offer (17 June 2026).pdf",
+    "file_path": "matters/MN-30003/Microstar Konvoy - Questionnaire - Remedy offer (17 June 2026).pdf",
     "questions": [
       {
         "number": 1,
         "section": null,
-        "text": "Provide a brief description of your business or organisation, including any commercial relationships with MicroStar or Konvoy."
+        "text": "Provide a brief description of your business or organisation, including any commercial relationships with MicroStar, Kegstar, or Konvoy."
       },
       {
         "number": 2,
@@ -2763,31 +2763,46 @@
       },
       {
         "number": 3,
-        "section": "Questions for customers of MicroStar or Konvoy",
-        "text": "In the event that you were not able to access keg pooling services or the price for keg pooling services increased substantially, what impact would this have on your business? How would you respond? What options are available?"
+        "section": "The remedy offer",
+        "text": "Describe the extent to which Kegstar\u2019s remedy offer would address any concerns you have in relation to the Acquisition"
       },
       {
         "number": 4,
-        "section": "Questions for customers of MicroStar or Konvoy",
-        "text": "In the last six (6) months, have you experienced any changes (in terms of price, or quality or nature of services) to the supply of keg pooling services or keg leasing services you access from MicroStar or Konvoy? If so, please provide details on the nature of those changes."
+        "section": "The remedy offer",
+        "text": "Provide any views you have on whether a period of 3 years is an appropriate duration for the majority of obligations under Kegstar\u2019s remedy offer."
       },
       {
         "number": 5,
-        "section": "Questions for competitors or potential competitors of MicroStar or Konvoy",
-        "text": "Does your organisation compete with MicroStar or Konvoy in their supply of key pooling services? If so, describe the services you supply in competition with them. If not, is your organisation interested in providing keg pooling services, why/why not?"
+        "section": "The remedy offer",
+        "text": "Provide any additional information or comments you consider relevant to the ACCC\u2019s consideration of the remedy offer."
       },
       {
         "number": 6,
-        "section": "Questions for competitors or potential competitors of MicroStar or Konvoy",
-        "text": "Please describe what is involved in entering and expanding in the supply of keg pooling services. If known, please provide details on the assets and supporting facilities necessary to enter or expand. Do you consider that the Acquisition will change the ease or difficulty of commencing the supply of key pooling services?"
+        "section": "Non-enforcement of exclusivity in Kegstar contracts",
+        "text": "Provide your view on whether the obligations on Kegstar to not include or enforce an exclusivity provision in agreements with customers or suppliers would address your competition concerns in relation to the Acquisition."
       },
       {
         "number": 7,
-        "section": "Other issues",
-        "text": "Provide any additional information or comments that you consider relevant to the ACCC\u2019s assessment of the Acquisition."
+        "section": "Non-enforcement of exclusivity in Kegstar contracts",
+        "text": "Provide your views on whether a period of 3 years to not include or enforce the exclusivity provisions is appropriate."
+      },
+      {
+        "number": 8,
+        "section": "Konvoy Customer options",
+        "text": "Under the remedy offer, Kegstar must offer to enter into a contract for Kegstar services, if an existing Konvoy Customer requests a contract within 3 months from Completion \u2013 provide your view on whether this is an acceptable mechanism and timeframe. Please also provide any other views on the Konvoy Customer options."
+      },
+      {
+        "number": 9,
+        "section": "Customer option to purchase kegs",
+        "text": "Provide your view on whether you are likely to purchase kegs from Kegstar, if given the option, and if this could replace the loss of competition from Konvoy leaving the market. Please also provide any other views on the Customer option to purchase kegs."
+      },
+      {
+        "number": 10,
+        "section": "Service level commitment",
+        "text": "Provide your view on whether the inclusion of a termination right if key performance indicators are not met into Customer Contracts for Kegstar\u2019s services would address any competition concerns from the Acquisition."
       }
     ],
-    "questions_count": 7
+    "questions_count": 10
   },
   "MN-30005": {
     "_sha256": "cb9453ac480ed6dd506ea39bf32b8f6a702e49a897bb73d8b5d6be89583a3c98",
@@ -4173,8 +4188,8 @@
   },
   "MN-50022": {
     "_sha256": "084b0b4d2607b923de96bb3da95af2e0a5e28950a30b386497116bbc659f2af2",
-    "deadline": null,
-    "deadline_iso": null,
+    "deadline": "22 June 2026",
+    "deadline_iso": "2026-06-22",
     "file_name": "Service Stream - RiE - Acquisitions register questionnaire.pdf",
     "file_path": "matters/MN-50022/Service Stream - RiE - Acquisitions register questionnaire.pdf",
     "questions": [
@@ -4331,8 +4346,8 @@
   },
   "MN-55003": {
     "_sha256": "88f2d20ceae2b4b455410fad8ed74ee783d3fa469b5d61e9a907942648ae2ce1",
-    "deadline": null,
-    "deadline_iso": null,
+    "deadline": "11 February 2026",
+    "deadline_iso": "2026-02-11",
     "file_name": "Davison Earthmovers - third-party questionnaire - FINAL - 4 Feb 2026.pdf",
     "file_path": "matters/MN-55003/Davison Earthmovers - third-party questionnaire - FINAL - 4 Feb 2026.pdf",
     "questions": [
@@ -4538,8 +4553,8 @@
   },
   "MN-60004": {
     "_sha256": "f27d6d26a96ae134d7a9e2d4426c7bb8a5c489f025071ad482a71379b7a01411",
-    "deadline": null,
-    "deadline_iso": null,
+    "deadline": "6 March 2026",
+    "deadline_iso": "2026-03-06",
     "file_name": "Delta - third-party questionnaire - January 2026.pdf",
     "file_path": "matters/MN-60004/Delta - third-party questionnaire - January 2026.pdf",
     "questions": [
@@ -4767,8 +4782,8 @@
   },
   "MN-60015": {
     "_sha256": "8fa34067ce973701addce2e52eed8ff0b0e48e98f94eb66fe41bf8c2b71443ef",
-    "deadline": null,
-    "deadline_iso": null,
+    "deadline": "1 June 2026",
+    "deadline_iso": "2026-06-01",
     "file_name": "Stonepeak_Castrol - Third Party Questionnaire.pdf",
     "file_path": "matters/MN-60015/Stonepeak_Castrol - Third Party Questionnaire.pdf",
     "questions": [
@@ -4833,8 +4848,8 @@
   },
   "MN-60026": {
     "_sha256": "080ddc1fa19e1acd0f0dd25a3fa88821815e08cac318235d47155f14856e2387",
-    "deadline": null,
-    "deadline_iso": null,
+    "deadline": "4 August 2026",
+    "deadline_iso": "2026-08-04",
     "file_name": "Publicis - LiveRamp - third-party questionnaire.pdf",
     "file_path": "matters/MN-60026/Publicis - LiveRamp - third-party questionnaire.pdf",
     "questions": [
@@ -4908,8 +4923,49 @@
     "questions_count": 4
   },
   "MN-65005": {
-    "_sha256": "668013fc61e20b7cc6d3404a4cf05c154039a111582acb44e237a75441ae8917",
+    "_sha256": "57087a1b66b346788d5638f5bbecd79c60c914e38c8d1b1d8629e4afabc95130",
     "all_questionnaires": [
+      {
+        "_sha256": "57087a1b66b346788d5638f5bbecd79c60c914e38c8d1b1d8629e4afabc95130",
+        "deadline": "22 July 2026",
+        "deadline_iso": "2026-07-22",
+        "file_name": "IAG RACI - Questionnaire - Remedy Offer (1 July 2026)_1.pdf",
+        "file_path": "matters/MN-65005/IAG RACI - Questionnaire - Remedy Offer (1 July 2026)_1.pdf",
+        "questions": [
+          {
+            "number": 1,
+            "section": null,
+            "text": "Provide a brief description of your business or organisation (if applicable), including any relationship you or your business/organisation have with IAG, RACI, or RAC."
+          },
+          {
+            "number": 2,
+            "section": null,
+            "text": "Outline any concerns you have regarding the impact of the Acquisition on competition."
+          },
+          {
+            "bullets": [
+              "Distribution Agreement commitments",
+              "smash repair services commitment",
+              "repair service facilities commitment",
+              "supporting commitments"
+            ],
+            "number": 3,
+            "section": "The remedy offer",
+            "text": "Describe the extent to which IAG\u2019s remedy offer would address any concerns you have in relation to the Acquisition, including with respect to the:"
+          },
+          {
+            "number": 4,
+            "section": "The remedy offer",
+            "text": "Provide any views you have on whether a period of 5 years is an appropriate duration for IAG\u2019s remedy offer."
+          },
+          {
+            "number": 5,
+            "section": "The remedy offer",
+            "text": "Provide any additional information or comments you consider relevant to the ACCC\u2019s consideration of the remedy offer."
+          }
+        ],
+        "questions_count": 5
+      },
       {
         "_sha256": "668013fc61e20b7cc6d3404a4cf05c154039a111582acb44e237a75441ae8917",
         "deadline": "12 March 2026",
@@ -4979,58 +5035,17 @@
           }
         ],
         "questions_count": 12
-      },
-      {
-        "_sha256": "57087a1b66b346788d5638f5bbecd79c60c914e38c8d1b1d8629e4afabc95130",
-        "deadline": null,
-        "deadline_iso": null,
-        "file_name": "IAG RACI - Questionnaire - Remedy Offer (1 July 2026)_1.pdf",
-        "file_path": "matters/MN-65005/IAG RACI - Questionnaire - Remedy Offer (1 July 2026)_1.pdf",
-        "questions": [
-          {
-            "number": 1,
-            "section": null,
-            "text": "Provide a brief description of your business or organisation (if applicable), including any relationship you or your business/organisation have with IAG, RACI, or RAC."
-          },
-          {
-            "number": 2,
-            "section": null,
-            "text": "Outline any concerns you have regarding the impact of the Acquisition on competition."
-          },
-          {
-            "bullets": [
-              "Distribution Agreement commitments",
-              "smash repair services commitment",
-              "repair service facilities commitment",
-              "supporting commitments"
-            ],
-            "number": 3,
-            "section": "The remedy offer",
-            "text": "Describe the extent to which IAG\u2019s remedy offer would address any concerns you have in relation to the Acquisition, including with respect to the:"
-          },
-          {
-            "number": 4,
-            "section": "The remedy offer",
-            "text": "Provide any views you have on whether a period of 5 years is an appropriate duration for IAG\u2019s remedy offer."
-          },
-          {
-            "number": 5,
-            "section": "The remedy offer",
-            "text": "Provide any additional information or comments you consider relevant to the ACCC\u2019s consideration of the remedy offer."
-          }
-        ],
-        "questions_count": 5
       }
     ],
-    "deadline": "12 March 2026",
-    "deadline_iso": "2026-03-12",
-    "file_name": "Questionnaire - IAG - RACI.pdf",
-    "file_path": "matters/MN-65005/Questionnaire - IAG - RACI.pdf",
+    "deadline": "22 July 2026",
+    "deadline_iso": "2026-07-22",
+    "file_name": "IAG RACI - Questionnaire - Remedy Offer (1 July 2026)_1.pdf",
+    "file_path": "matters/MN-65005/IAG RACI - Questionnaire - Remedy Offer (1 July 2026)_1.pdf",
     "questions": [
       {
         "number": 1,
         "section": null,
-        "text": "Provide a brief description of your business or, organisation including any relationships with IAG, RAC and/or RACI."
+        "text": "Provide a brief description of your business or organisation (if applicable), including any relationship you or your business/organisation have with IAG, RACI, or RAC."
       },
       {
         "number": 2,
@@ -5038,57 +5053,28 @@
         "text": "Outline any concerns you have regarding the impact of the Acquisition on competition."
       },
       {
+        "bullets": [
+          "Distribution Agreement commitments",
+          "smash repair services commitment",
+          "repair service facilities commitment",
+          "supporting commitments"
+        ],
         "number": 3,
-        "section": "Questions about motor insurance and home and contents insurance",
-        "text": "Explain whether there are any features of the motor insurance and/or home and contents insurance markets in Western Australia and/or certain areas of Western Australia which differ compared to the rest of Australia."
+        "section": "The remedy offer",
+        "text": "Describe the extent to which IAG\u2019s remedy offer would address any concerns you have in relation to the Acquisition, including with respect to the:"
       },
       {
         "number": 4,
-        "section": "Questions about motor insurance and home and contents insurance",
-        "text": "Describe how effective a competitor RACI is in Western Australia, and on what factors it competes most strongly (e.g. price, service quality, coverage, etc). Also explain on what factors it does not compete strongly."
+        "section": "The remedy offer",
+        "text": "Provide any views you have on whether a period of 5 years is an appropriate duration for IAG\u2019s remedy offer."
       },
       {
         "number": 5,
-        "section": "Questions about motor insurance and home and contents insurance",
-        "text": "Describe how effective a competitor IAG is in Western Australia, and on what factors it competes most strongly (e.g. price, service quality, coverage, etc). Also explain on what factors it does not compete strongly."
-      },
-      {
-        "number": 6,
-        "section": "Questions about motor insurance and home and contents insurance",
-        "text": "Describe how closely IAG and RACI compete in the supply of motor insurance and/or home and contents insurance Western Australia (e.g. in terms of price, service quality, coverage, etc)."
-      },
-      {
-        "number": 7,
-        "section": "Questions about motor insurance and home and contents insurance",
-        "text": "Explain how strongly established insurers and mid-tier insurers compete in Western Australia. Explain the extent to which established insurer and mid- tier insurers would prevent the merged IAG/RACI from increasing premiums, reducing coverage, reducing its product range or diminishing the service provided in Western Australia. Please also include the level of constraint insurers with larger market shares outside of Western Australia are likely to impose."
-      },
-      {
-        "number": 8,
-        "section": "Questions about motor insurance and home and contents insurance",
-        "text": "Explain any challenges being faced by the insurance industry and the impact this could have on insurers and insurance products, including whether RACI is likely to experience heightened vulnerability to these challenges as a state- based, mutual organisation."
-      },
-      {
-        "number": 9,
-        "section": "Questions about motor insurance and home and contents insurance",
-        "text": "Identify any insurers that have entered or exited in the last 12 months or known upcoming examples of entry or exit in the supply of motor and home and contents insurance in Western Australia or Australia."
-      },
-      {
-        "number": 10,
-        "section": "Questions about repair services",
-        "text": "Explain the extent to which the merged IAG/RACI would be in an enhanced position to foreclose or frustrate competing insurers' access to each of (i) smash repair services, (ii) windscreen repair and replacement services, and (iii) building repair services."
-      },
-      {
-        "number": 11,
-        "section": "Questions about repair services",
-        "text": "Explain the extent to which the merged entity IAG/RACI would be able to reduce prices or degrade the terms on which it acquires repair services. Please explain why you consider the merged entity would (or would not) be able to do this, including whether competition from other insurers would prevent the merged entity from doing so."
-      },
-      {
-        "number": 12,
-        "section": "Other issues",
-        "text": "Provide any additional information or comments that you consider relevant to the ACCC\u2019s assessment of the Acquisition."
+        "section": "The remedy offer",
+        "text": "Provide any additional information or comments you consider relevant to the ACCC\u2019s consideration of the remedy offer."
       }
     ],
-    "questions_count": 12
+    "questions_count": 5
   },
   "MN-65007": {
     "_sha256": "34e6692edd4560633b87407fafc0cf21864736939184219f9e96d35d0aea8fa8",
@@ -7237,8 +7223,8 @@
   },
   "MN-95002": {
     "_sha256": "3ad8cd4161bfc0df998af06dffe1b21ce04a5165786c9dd64b4745f08d76198d",
-    "deadline": null,
-    "deadline_iso": null,
+    "deadline": "9 February 2026",
+    "deadline_iso": "2026-02-09",
     "file_name": "Exact Sciences - Third-party questionnaire template - January 2026_3.pdf",
     "file_path": "matters/MN-95002/Exact Sciences - Third-party questionnaire template - January 2026_3.pdf",
     "questions": [

--- a/scripts/parse_questionnaire.py
+++ b/scripts/parse_questionnaire.py
@@ -62,6 +62,29 @@ def _build_caches_from_existing(json_path: Path):
     return cache, neg_cache
 
 
+# Optional "5.00pm (AEDT) on" / "5:00pm AEST on" / "10:00am on" prefix that
+# some questionnaires put between the "Deadline to respond:" label and the
+# date. The timezone's brackets are optional because the ACCC template is
+# inconsistent about them (e.g. MN-90008 brackets it, MN-30003 does not).
+_TIME_OF_DAY = r'\d{1,2}(?:[:.]\d{2})?\s*[ap]\.?m\.?'
+_TIMEZONE = r'\(?[A-Z]{2,5}\)?'
+_DEADLINE_TIME_PREFIX = rf'(?:{_TIME_OF_DAY})\s*(?:{_TIMEZONE})?\s*on\s+'
+
+# Optional word before the date — a weekday ("Tuesday 4 August 2026",
+# "Wednesday, 6 May 2026") or a linking word ("by 4 August 2026"). The comma
+# is optional: most questionnaires omit it, and requiring it previously lost
+# the deadline for every "Deadline to respond: <Weekday> <date>" matter.
+_DEADLINE_WORD_PREFIX = r'[A-Za-z]+,?\s+'
+
+_DEADLINE_RE = re.compile(
+    r'Deadline to respond:\s*'
+    rf'(?:{_DEADLINE_TIME_PREFIX})?'
+    rf'(?:{_DEADLINE_WORD_PREFIX})?'
+    r'(\d{1,2}\s+[A-Za-z]+\s+\d{4})',
+    re.IGNORECASE | re.DOTALL,
+)
+
+
 def extract_deadline(text: str) -> Optional[str]:
     """
     Extract the consultation closing date from the questionnaire.
@@ -69,7 +92,10 @@ def extract_deadline(text: str) -> Optional[str]:
     Looks for patterns like:
     - "Deadline to respond: 25 August 2025"
     - "Deadline to respond: 3 November 2025"
+    - "Deadline to respond: Tuesday 4 August 2026"
+    - "Deadline to respond: Wednesday, 6 May 2026"
     - "Deadline to respond: 5.00pm (AEDT) on 20 October 2025"
+    - "Deadline to respond: 5:00pm AEST on 1 July 2026"
 
     Args:
         text: Full text of the questionnaire PDF
@@ -77,12 +103,7 @@ def extract_deadline(text: str) -> Optional[str]:
     Returns:
         The deadline date as a string, or None if not found
     """
-    # Look for "Deadline to respond:" followed by optional time/timezone, then a date
-    # Pattern handles both formats:
-    # 1. "Deadline to respond: 25 August 2025"
-    # 2. "Deadline to respond: 5.00pm (AEDT) on 20 October 2025"
-    pattern = r'Deadline to respond:\s*(?:[\d:.apm]+\s*\([A-Z]+\)\s+on\s+)?(?:[A-Za-z]+,\s*)?(\d{1,2}\s+[A-Za-z]+\s+\d{4})'
-    match = re.search(pattern, text, re.IGNORECASE | re.DOTALL)
+    match = _DEADLINE_RE.search(text)
 
     if match:
         # Clean up the deadline by removing extra whitespace and newlines

--- a/scripts/tests/test_pipeline.py
+++ b/scripts/tests/test_pipeline.py
@@ -814,6 +814,23 @@ class TestExtractDeadline:
         result = extract_deadline(text)
         assert result == "6 May 2026"
 
+    def test_deadline_with_day_name_without_comma(self):
+        # The ACCC template usually omits the comma (e.g. MN-60026).
+        text = "Deadline to respond: Tuesday 4 August 2026"
+        result = extract_deadline(text)
+        assert result == "4 August 2026"
+
+    def test_deadline_with_unbracketed_timezone(self):
+        # e.g. MN-30003 / MN-65005 — same template, no brackets on the zone.
+        text = "Deadline to respond: 5:00pm AEST on 1 July 2026"
+        result = extract_deadline(text)
+        assert result == "1 July 2026"
+
+    def test_deadline_with_time_but_no_timezone(self):
+        text = "Deadline to respond: 5pm on 1 July 2026"
+        result = extract_deadline(text)
+        assert result == "1 July 2026"
+
     def test_deadline_with_newline_in_date(self):
         text = "Deadline to respond: 25\nAugust 2025"
         # The regex uses DOTALL so \s+ matches newlines


### PR DESCRIPTION
MN-60026's questionnaire card showed no response deadline because
extract_deadline() failed to parse its "Deadline to respond: Tuesday 4
August 2026" line. The optional weekday prefix in the regex required a
trailing comma ("Wednesday, 6 May 2026"), but the ACCC template usually
omits it, so every "<Weekday> <date>" questionnaire lost its deadline.

A second variant was also unparsed: the time-of-day prefix required the
timezone to be bracketed, so "5:00pm AEST on 1 July 2026" (MN-30003,
MN-65005) missed too.

Rewrite the pattern to make the comma optional, accept a bracketed or
bare timezone, and allow a time of day with no timezone at all. Verified
against all 226 questionnaire PDFs in data/raw: 12 previously unparsed
deadlines now resolve, with no change to the 214 that already parsed.

Refresh data/processed/questionnaire_data.json for the affected matters.
The parse cache is keyed by PDF SHA-256, so the stale nulls would have
survived the fix indefinitely; invalidating just those entries re-parses
12 PDFs. MN-30003 and MN-65005 also promote their newer remedy-offer
questionnaires to primary, which sorts latest-deadline-first and had been
treating a null deadline as oldest.