### PR TITLE
Stop the dashboard's sr-only chart tables widening the page on mobile

### DIFF
--- a/merger-tracker/frontend/src/pages/Dashboard.jsx
+++ b/merger-tracker/frontend/src/pages/Dashboard.jsx
@@ -287,15 +287,22 @@ function Dashboard() {
             <div className="h-64" role="img" aria-labelledby="chart-phase1-title" aria-describedby="chart-phase1-summary">
               <Doughnut data={determinationData} options={chartOptions} />
             </div>
-            <table id="chart-phase1-summary" className="sr-only">
-              <caption>Phase 1 determination breakdown</caption>
-              <thead><tr><th>Determination</th><th>Count</th></tr></thead>
-              <tbody>
-                {Object.entries(stats.by_determination).map(([det, count]) => (
-                  <tr key={det}><td>{det}</td><td>{count}</td></tr>
-                ))}
-              </tbody>
-            </table>
+            {/* The sr-only wrapper has to be a div: `sr-only`'s width: 1px is
+                only a minimum for a table box, so a bare sr-only table lays
+                out at its full content width and — being absolutely
+                positioned against the viewport — widens the whole page on
+                mobile. The div clips it for real. */}
+            <div className="sr-only">
+              <table id="chart-phase1-summary">
+                <caption>Phase 1 determination breakdown</caption>
+                <thead><tr><th>Determination</th><th>Count</th></tr></thead>
+                <tbody>
+                  {Object.entries(stats.by_determination).map(([det, count]) => (
+                    <tr key={det}><td>{det}</td><td>{count}</td></tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </div>
         )}
 
@@ -308,15 +315,17 @@ function Dashboard() {
             <div className="h-64" role="img" aria-labelledby="chart-phase2-title" aria-describedby="chart-phase2-summary">
               <Doughnut data={phase2DeterminationData} options={chartOptions} />
             </div>
-            <table id="chart-phase2-summary" className="sr-only">
-              <caption>Phase 2 determination breakdown, including ceased assessments</caption>
-              <thead><tr><th>Outcome</th><th>Count</th></tr></thead>
-              <tbody>
-                {phase2Labels.map((det) => (
-                  <tr key={det}><td>{det}</td><td>{phase2Counts[det]}</td></tr>
-                ))}
-              </tbody>
-            </table>
+            <div className="sr-only">
+              <table id="chart-phase2-summary">
+                <caption>Phase 2 determination breakdown, including ceased assessments</caption>
+                <thead><tr><th>Outcome</th><th>Count</th></tr></thead>
+                <tbody>
+                  {phase2Labels.map((det) => (
+                    <tr key={det}><td>{det}</td><td>{phase2Counts[det]}</td></tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </div>
         )}
 
@@ -329,15 +338,17 @@ function Dashboard() {
             <div className="h-64" role="img" aria-labelledby="chart-waiver-title" aria-describedby="chart-waiver-summary">
               <Doughnut data={waiverDeterminationData} options={chartOptions} />
             </div>
-            <table id="chart-waiver-summary" className="sr-only">
-              <caption>Waiver determination breakdown</caption>
-              <thead><tr><th>Determination</th><th>Count</th></tr></thead>
-              <tbody>
-                {Object.entries(stats.by_waiver_determination).map(([det, count]) => (
-                  <tr key={det}><td>{det}</td><td>{count}</td></tr>
-                ))}
-              </tbody>
-            </table>
+            <div className="sr-only">
+              <table id="chart-waiver-summary">
+                <caption>Waiver determination breakdown</caption>
+                <thead><tr><th>Determination</th><th>Count</th></tr></thead>
+                <tbody>
+                  {Object.entries(stats.by_waiver_determination).map(([det, count]) => (
+                    <tr key={det}><td>{det}</td><td>{count}</td></tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </div>
         )}
       </div>

--- a/merger-tracker/frontend/src/pages/__tests__/Dashboard.test.jsx
+++ b/merger-tracker/frontend/src/pages/__tests__/Dashboard.test.jsx
@@ -71,6 +71,20 @@ describe('Dashboard phase 2 determination chart', () => {
     ]);
   });
 
+  // `sr-only`'s width: 1px is only a minimum for a table box, so an sr-only
+  // table lays out at its full content width and, being absolutely positioned,
+  // widens the whole page on mobile. The clipping has to happen on a div.
+  it('hides each chart summary table behind an sr-only wrapper, not on the table', async () => {
+    renderDashboard(statsFixture());
+
+    const summaries = await screen.findAllByRole('table', { hidden: true });
+    expect(summaries).toHaveLength(3);
+    for (const table of summaries) {
+      expect(table).not.toHaveClass('sr-only');
+      expect(table.parentElement).toHaveClass('sr-only');
+    }
+  });
+
   it('omits the chart until a phase 2 review has concluded', async () => {
     renderDashboard(statsFixture({ by_phase_2_determination: {} }));
 


### PR DESCRIPTION
Tailwind's sr-only sets width: 1px, but for a table box that width is only
a minimum — auto table layout expands to the content width regardless. The
three chart summary tables therefore laid out ~500px wide and, being
position: absolute with no positioned ancestor, sized against the viewport
and pushed the document's scroll width to 539px at a 390px viewport. Mobile
browsers widen the layout viewport to match, so the whole page rendered
wider than the screen — dashboard only, since it is the only page using the
pattern.

Wrapping each table in an sr-only div moves the clipping onto a block box,
which does honour width: 1px and overflow: hidden. The ids stay on the
tables so the charts' aria-describedby still resolves.