### PR TITLE
Split "Approved with conditions" out of the Phase 1 determination chart

### DIFF
--- a/merger-tracker/frontend/public/data/stats.json
+++ b/merger-tracker/frontend/public/data/stats.json
@@ -8,8 +8,9 @@
     "Assessment ceased": 3
   },
   "by_determination": {
-    "Approved": 165,
-    "Referred to phase 2": 8
+    "Approved": 163,
+    "Referred to phase 2": 8,
+    "Approved with conditions": 2
   },
   "by_phase_2_determination": {
     "Approved with conditions": 1,

--- a/scripts/static_data/outputs/stats.py
+++ b/scripts/static_data/outputs/stats.py
@@ -92,12 +92,18 @@ def generate(mergers: list) -> dict:
         by_status[status] += 1
 
     # By Phase 1 determination (notifications only)
-    # Use pre-enriched phase_1_determination which correctly identifies "Referred to phase 2"
+    # Use pre-enriched phase_1_determination which correctly identifies "Referred to phase 2".
+    # Approvals split by whether conditions were imposed, mirroring the Phase 2
+    # breakdown below — a clearance bought with a s 87B undertaking is a
+    # different result from an unconditional one.
     by_determination = defaultdict(int)
     for m in notification_mergers:
         det = m.get('phase_1_determination')
-        if det:
-            by_determination[det] += 1
+        if not det:
+            continue
+        if det == merger_status.APPROVED and m.get('has_conditions'):
+            det = merger_status.APPROVED_WITH_CONDITIONS
+        by_determination[det] += 1
 
     # By Phase 2 outcome (notifications only). Counts the Phase 2 reviews that
     # have concluded — including the ones the parties withdrew from, which end

--- a/scripts/tests/test_static_data_outputs.py
+++ b/scripts/tests/test_static_data_outputs.py
@@ -216,6 +216,20 @@ class TestStatsGenerate:
         assert by_id['MN-0001']['has_conditions'] is True
         assert by_id['WA-0003']['has_conditions'] is False
 
+    def test_by_determination_splits_conditional_phase_1_approvals(self):
+        # Mirrors the Phase 2 chart: a Phase 1 clearance granted subject to
+        # conditions counts apart from an unconditional "Approved", instead of
+        # being folded into the same doughnut segment.
+        mergers = _raw_fixture()
+        conditional = next(m for m in mergers if m['merger_id'] == 'MN-0001')
+        conditional['accc_determination_raw'] = 'Approved subject to conditions'
+        enriched = [enrich_merger(m) for m in mergers]
+        payload = stats.generate(enriched)
+        assert payload['by_determination'][merger_status.APPROVED_WITH_CONDITIONS] == 1
+        assert merger_status.APPROVED_WITH_CONDITIONS not in payload.get(
+            'by_phase_2_determination', {}
+        )
+
     def test_recent_determinations_includes_ceased_assessments(self):
         mergers = _raw_fixture()
         mergers.append({


### PR DESCRIPTION
by_determination previously folded conditional Phase 1 clearances into the
plain "Approved" bucket. Mirror the split already done for
by_phase_2_determination so the dashboard's Phase 1 doughnut shows
conditional approvals as their own segment (frontend already had the color
and rendering support for this label).