### PR TITLE
Unfreeze MN-35034 questionnaire event

### DIFF
--- a/data/frozen_events_mergers.json
+++ b/data/frozen_events_mergers.json
@@ -1,9 +1,3 @@
 {
-  "_comment": "Override data for specific mergers. An entry with an empty dict or 'freeze_events: true' preserves the ENTIRE existing events array rather than overwriting from the scraped page (use this when the ACCC events table is incorrect). To freeze only some events, set 'freeze_events' to a list of event titles (e.g. \"freeze_events\": [\"Questionnaire - IAG - RACI\"]) \u2014 only those events are preserved verbatim while the rest are still updated from the page. Any other keys are treated as field overrides \u2014 the scraper will use these values instead of whatever it finds on the page.",
-  "MN-35034": {
-    "_comment": "Event date(s) missing from ACCC page (The Independents Group \u2013 acquisition of entities within the Smuggler Group - Questionnaire (10 Aug 2026)); freezing these specific events to preserve the automatically set date(s) while other events still update from the page.",
-    "freeze_events": [
-      "The Independents Group \u2013 acquisition of entities within the Smuggler Group - Questionnaire"
-    ]
-  }
+  "_comment": "Override data for specific mergers. An entry with an empty dict or 'freeze_events: true' preserves the ENTIRE existing events array rather than overwriting from the scraped page (use this when the ACCC events table is incorrect). To freeze only some events, set 'freeze_events' to a list of event titles (e.g. \"freeze_events\": [\"Questionnaire - IAG - RACI\"]) \u2014 only those events are preserved verbatim while the rest are still updated from the page. Any other keys are treated as field overrides \u2014 the scraper will use these values instead of whatever it finds on the page."
 }


### PR DESCRIPTION
The event's timeline table has been removed from the ACCC page
entirely (confirmed against today's scrape of the matter HTML), so
there's nothing left to preserve — freezing is no longer needed.