### PR TITLE
Add canonical party groups

### DIFF
--- a/data/processed/related_parties.json
+++ b/data/processed/related_parties.json
@@ -190,6 +190,10 @@
         {
           "name": "Blackstone Alternative Credit Advisors LP",
           "identifier": "CRD  137519"
+        },
+        {
+          "name": "Dynamo Bidco, Inc.",
+          "identifier": ""
         }
       ]
     },
@@ -218,6 +222,10 @@
         {
           "name": "Eli Lilly and Company",
           "identifier": "350470950 (IRS Employer Identification Number)"
+        },
+        {
+          "name": "Albali Acquisition Corporation",
+          "identifier": "10665981(Delaware File Number)"
         }
       ]
     },
@@ -2370,6 +2378,14 @@
         {
           "name": "Conduent Business Services, LLC",
           "identifier": ""
+        },
+        {
+          "name": "CONDUENT VICTORIA TICKETING SYSTEM PTY LTD",
+          "identifier": "87 667 867 950"
+        },
+        {
+          "name": "CONDUENT BUSINESS SOLUTIONS (FRANCE) SAS",
+          "identifier": "20 251 484 486"
         }
       ]
     },
@@ -2384,6 +2400,22 @@
         {
           "name": "Modaxo Group, Inc",
           "identifier": ""
+        },
+        {
+          "name": "Modaxo USA Holdings, Inc",
+          "identifier": ""
+        },
+        {
+          "name": "Modaxo France Holdings SAS",
+          "identifier": ""
+        },
+        {
+          "name": "TRAPEZE GROUP ASIA PACIFIC PTY LTD",
+          "identifier": "16 010 832 318"
+        },
+        {
+          "name": "TRAPEZE MANAGEMENT HOLDINGS PTY LTD",
+          "identifier": "97 120 264 913"
         }
       ]
     },
@@ -2398,6 +2430,10 @@
         {
           "name": "Wesfarmers Limited",
           "identifier": "28 008 984 049"
+        },
+        {
+          "name": "Wesfarmers Built Pty Ltd",
+          "identifier": "698 309 509"
         }
       ]
     },
@@ -2658,6 +2694,82 @@
         {
           "name": "MML HOLDINGS LIMITED",
           "identifier": "55 084 402 380"
+        }
+      ]
+    },
+    {
+      "id": "built-group",
+      "canonical_name": "Built Group",
+      "members": [
+        {
+          "name": "Built Group Holdings Pty Limited",
+          "identifier": "88 163 462 637"
+        },
+        {
+          "name": "Built Living (Built Investor) Pty Limited",
+          "identifier": "71 698 095 831"
+        }
+      ]
+    },
+    {
+      "id": "danone",
+      "canonical_name": "Danone",
+      "members": [
+        {
+          "name": "Danone S.A.",
+          "identifier": "SIREN 552 032 534"
+        },
+        {
+          "name": "DANONE SAPUTO DAIRY AUSTRALIA PTY LTD",
+          "identifier": "32 143 172 258"
+        },
+        {
+          "name": "NUTRICIA AUSTRALIA PTY LIMITED",
+          "identifier": "99 076 246 752"
+        },
+        {
+          "name": "Compagnie Gervais Danone",
+          "identifier": "SIREN 552 067 092"
+        },
+        {
+          "name": "Société Anonyme des Eaux Minérales d’Évian S.A.",
+          "identifier": "SIREN 797 080 850"
+        },
+        {
+          "name": "Minogue BidCo",
+          "identifier": ""
+        },
+        {
+          "name": "Minogue HoldCo",
+          "identifier": ""
+        }
+      ]
+    },
+    {
+      "id": "johns-lyng-group",
+      "canonical_name": "Johns Lyng Group",
+      "members": [
+        {
+          "name": "JOHNS LYNG GROUP LIMITED",
+          "identifier": "86 620 466 248"
+        },
+        {
+          "name": "Johns Lyng Group (Nominee) Pty Ltd as trustee for the Johns Lyng Unit Trust",
+          "identifier": "57 246 253 025"
+        }
+      ]
+    },
+    {
+      "id": "c-m-build-group",
+      "canonical_name": "C&M Build Group",
+      "members": [
+        {
+          "name": "C&M Central Pty Ltd",
+          "identifier": "649 711 053"
+        },
+        {
+          "name": "C&M Central Unit Trust",
+          "identifier": "47 351 736 164"
         }
       ]
     }

--- a/data/processed/related_parties.json
+++ b/data/processed/related_parties.json
@@ -2470,6 +2470,50 @@
           "identifier": "registered number 02830397"
         }
       ]
+    },
+    {
+      "id": "the-independents-group",
+      "canonical_name": "The Independents Group",
+      "members": [
+        {
+          "name": "The Independents Creative Collective UK Ltd.",
+          "identifier": "Identifying number  04243407"
+        },
+        {
+          "name": "The Independents Group Inc.",
+          "identifier": "Identifying number  3414791"
+        },
+        {
+          "name": "K10 Holding SA",
+          "identifier": "Identifying number  B214433"
+        }
+      ]
+    },
+    {
+      "id": "smuggler-group",
+      "canonical_name": "Smuggler Group",
+      "members": [
+        {
+          "name": "Smuggler LLC",
+          "identifier": "Identifying number  6877804"
+        },
+        {
+          "name": "Smuggler London Ltd",
+          "identifier": "Identifying number  06806477"
+        },
+        {
+          "name": "Sidepiece LLC",
+          "identifier": "Identifying number  5134914"
+        },
+        {
+          "name": "Division 7 LLC",
+          "identifier": "Identifying number  7088711"
+        },
+        {
+          "name": "Smuggler Experience LLC (including shell subsidiary Lux a Deo LLC)",
+          "identifier": "Identifying number  202462414150"
+        }
+      ]
     }
   ]
 }

--- a/data/processed/related_parties.json
+++ b/data/processed/related_parties.json
@@ -282,6 +282,10 @@
         {
           "name": "Bain Capital Investors, LLC",
           "identifier": "IRS EIN  812878769"
+        },
+        {
+          "name": "BCPE Blitz Cayman, L.P.",
+          "identifier": ""
         }
       ]
     },
@@ -374,6 +378,14 @@
         {
           "name": "EQT Fund Management S.\u00e0 r.l.",
           "identifier": "Luxembourg Company Registration Number  B167972"
+        },
+        {
+          "name": "Ruby BidCo GmbH",
+          "identifier": "679581i"
+        },
+        {
+          "name": "Seal US Holdings Inc.",
+          "identifier": "10678816"
         }
       ]
     },
@@ -2336,6 +2348,10 @@
         {
           "name": "BP plc",
           "identifier": "UK company number: 00102498"
+        },
+        {
+          "name": "BP Australia Investments Pty Ltd",
+          "identifier": "66 102 991 551"
         }
       ]
     },
@@ -2481,7 +2497,7 @@
     },
     {
       "id": "time-design-international-pte-ltd",
-      "canonical_name": "Time Design International Pte Ltd",
+      "canonical_name": "Kakaku.com",
       "members": [
         {
           "name": "Time Design International Pte Ltd",
@@ -2490,6 +2506,10 @@
         {
           "name": "Time Design International Pte Ltd",
           "identifier": "UEN  201736394D"
+        },
+        {
+          "name": "Kakaku.com, Inc.",
+          "identifier": "Japan Corporate Number  011001065997"
         }
       ]
     },
@@ -2770,6 +2790,112 @@
         {
           "name": "C&M Central Unit Trust",
           "identifier": "47 351 736 164"
+        }
+      ]
+    },
+    {
+      "id": "merivale-group",
+      "canonical_name": "Merivale Group",
+      "members": [
+        {
+          "name": "HEMMES TRADING PTY LIMITED",
+          "identifier": "29 105 332 652"
+        },
+        {
+          "name": "JH 7 PROPERTIES PTY LTD",
+          "identifier": "41 621 226 140"
+        },
+        {
+          "name": "HEMMES PROPERTY PTY LIMITED",
+          "identifier": "87 105 332 518"
+        }
+      ]
+    },
+    {
+      "id": "hammondcare",
+      "canonical_name": "HammondCare",
+      "members": [
+        {
+          "name": "HAMMONDCARE",
+          "identifier": "48 000 026 219"
+        },
+        {
+          "name": "HAMMONDCARE HEALTH AND HOSPITALS LIMITED",
+          "identifier": "72 074 354 028"
+        }
+      ]
+    },
+    {
+      "id": "corza-biosurgery",
+      "canonical_name": "Corza Biosurgery",
+      "members": [
+        {
+          "name": "Corza Medical sp z.o.o.",
+          "identifier": "0000856259"
+        },
+        {
+          "name": "Corza Medical S.A.S",
+          "identifier": "891 013 914"
+        },
+        {
+          "name": "GTCR (Topaz) AcquisitionCo AS",
+          "identifier": ""
+        },
+        {
+          "name": "Corza Medical GmbH (Switzerland)",
+          "identifier": "CHE466.030.519"
+        },
+        {
+          "name": "Corza Medical B.V.",
+          "identifier": "0759493073"
+        },
+        {
+          "name": "Seal US Holdco LLC",
+          "identifier": "10680341"
+        },
+        {
+          "name": "Topaz Investment AS",
+          "identifier": ""
+        },
+        {
+          "name": "Corza Medical GmbH (Germany)",
+          "identifier": "HRB 97422"
+        },
+        {
+          "name": "Corza Medical S.r.l.",
+          "identifier": "2605047"
+        },
+        {
+          "name": "Corza Medical S.L.U.",
+          "identifier": "B42998195"
+        }
+      ]
+    },
+    {
+      "id": "tahmoor-colliery",
+      "canonical_name": "Tahmoor Colliery",
+      "members": [
+        {
+          "name": "Tahmoor Coal Pty Ltd (In Liquidation)",
+          "identifier": "97 076 663 968"
+        },
+        {
+          "name": "Bargo Collieries Pty Ltd (In Liquidation)",
+          "identifier": "34 000 970 276"
+        }
+      ]
+    },
+    {
+      "id": "qatar-investment-authority",
+      "canonical_name": "Qatar Investment Authority",
+      "members": [
+        {
+          "name": "QIA Infrastructure Holding LLC",
+          "identifier": "Qatar Financial Centre no. 01821"
+        },
+        {
+          "name": "Qatar Holding LLC",
+          "identifier": "CIK: 0001539025, Qatar Financial Centre no. 00004"
         }
       ]
     }

--- a/data/processed/related_parties.json
+++ b/data/processed/related_parties.json
@@ -2590,6 +2590,76 @@
           "identifier": "20 088 038 340"
         }
       ]
+    },
+    {
+      "id": "oeconnection",
+      "canonical_name": "OEConnection",
+      "members": [
+        {
+          "name": "OEConnection, LLC",
+          "identifier": "1196674"
+        },
+        {
+          "name": "OEC Bidco Limited",
+          "identifier": "17225784"
+        }
+      ]
+    },
+    {
+      "id": "lockheed-martin",
+      "canonical_name": "Lockheed Martin",
+      "members": [
+        {
+          "name": "Lockheed Martin Corporation",
+          "identifier": "US Department ID  D03964756"
+        },
+        {
+          "name": "RLM SYSTEMS PTY LIMITED",
+          "identifier": "67 050 753 403"
+        }
+      ]
+    },
+    {
+      "id": "opal-healthcare",
+      "canonical_name": "Opal HealthCare",
+      "members": [
+        {
+          "name": "DPG SERVICES PTY LTD",
+          "identifier": "38 090 007 999"
+        },
+        {
+          "name": "OHCA PROPERTY HOLDINGS PTY LTD",
+          "identifier": "70 675 807 477"
+        }
+      ]
+    },
+    {
+      "id": "keyton",
+      "canonical_name": "Keyton",
+      "members": [
+        {
+          "name": "Keyton Trust",
+          "identifier": "44 349 706 307"
+        },
+        {
+          "name": "KEYTON HOLDING PTY LIMITED",
+          "identifier": "72 613 131 187"
+        }
+      ]
+    },
+    {
+      "id": "metal-manufactures",
+      "canonical_name": "Metal Manufactures",
+      "members": [
+        {
+          "name": "METAL MANUFACTURES PTY LIMITED",
+          "identifier": "13 003 762 641"
+        },
+        {
+          "name": "MML HOLDINGS LIMITED",
+          "identifier": "55 084 402 380"
+        }
+      ]
     }
   ]
 }

--- a/data/processed/related_parties.json
+++ b/data/processed/related_parties.json
@@ -2514,6 +2514,82 @@
           "identifier": "Identifying number  202462414150"
         }
       ]
+    },
+    {
+      "id": "kanadevia-corporation",
+      "canonical_name": "Kanadevia Corporation",
+      "members": [
+        {
+          "name": "Kanadevia Corporation",
+          "identifier": ""
+        },
+        {
+          "name": "OSMOFLO WATER MANAGEMENT PTY LTD",
+          "identifier": "62 608 078 459"
+        },
+        {
+          "name": "OSMOFLO PTY LTD",
+          "identifier": "39 050 952 175"
+        }
+      ]
+    },
+    {
+      "id": "lendlease",
+      "canonical_name": "Lendlease",
+      "members": [
+        {
+          "name": "LENDLEASE CORPORATION LIMITED",
+          "identifier": "32 000 226 228"
+        },
+        {
+          "name": "LENDLEASE CAPITAL SERVICES PTY LTD",
+          "identifier": "67 000 001 114"
+        },
+        {
+          "name": "LENDLEASE CAPITAL SERVICES RL LTD",
+          "identifier": "47 615 893 288"
+        },
+        {
+          "name": "The Trustee for Lendlease Victoria Cross Trust",
+          "identifier": "26 397 448 085"
+        }
+      ]
+    },
+    {
+      "id": "nippon-sanso-corporation",
+      "canonical_name": "Nippon Sanso Corporation",
+      "members": [
+        {
+          "name": "Nippon Sanso Holdings Corporation",
+          "identifier": "LEI  353800F1K6653B4VPY57"
+        },
+        {
+          "name": "Supagas Pty Limited",
+          "identifier": "50 074 008 496"
+        },
+        {
+          "name": "Coregas Pty Ltd",
+          "identifier": "32 001 255 312"
+        },
+        {
+          "name": "NSC (Australia) Pty Ltd",
+          "identifier": "71 607 111 268"
+        }
+      ]
+    },
+    {
+      "id": "heeson-medical",
+      "canonical_name": "Heeson Medical",
+      "members": [
+        {
+          "name": "Heeson Medical Pty Ltd",
+          "identifier": "14 088 038 313"
+        },
+        {
+          "name": "Jacobba Pty Ltd",
+          "identifier": "20 088 038 340"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
The Independents Group covers both acquirer entities plus K10 Holding SA
(recorded as an "other party" on MN-35034). Smuggler Group covers the five
target entities.