### PR TITLE
Link related parties for mergers 61-80

### DIFF
--- a/data/processed/related_parties.json
+++ b/data/processed/related_parties.json
@@ -1502,6 +1502,14 @@
         {
           "name": "Siemens Mobility GmbH",
           "identifier": "LEI  529900LT6G2TUO3TZB94"
+        },
+        {
+          "name": "Siemens Mobility Holding B.V.",
+          "identifier": "LEI  529900JJ6XL7YX9GBM87"
+        },
+        {
+          "name": "Siemens Aktiengesellschaft",
+          "identifier": "LEI  W38RGI023J3WT1HWRP32"
         }
       ]
     },
@@ -1534,6 +1542,10 @@
         {
           "name": "ORIGIN ENERGY LIMITED",
           "identifier": "30 000 051 696"
+        },
+        {
+          "name": "ORIGIN ZERO INVESTMENTS PTY LTD",
+          "identifier": "52 079 089 231"
         }
       ]
     },
@@ -1770,6 +1782,18 @@
         {
           "name": "Wakeling South Coast Pty Ltd",
           "identifier": "636 298 970"
+        },
+        {
+          "name": "HURRIKAYNE PTY LTD",
+          "identifier": "74 118 744 915"
+        },
+        {
+          "name": "WOLLONGONG CITY MOTORS PTY LTD",
+          "identifier": "22 002 019 598"
+        },
+        {
+          "name": "Paul Burgess Nominees Pty Ltd as trustee for Paul Burgess Trust",
+          "identifier": "119 875 768"
         }
       ]
     },
@@ -2038,6 +2062,14 @@
         {
           "name": "Apollo Capital Management, L.P.",
           "identifier": "4293091"
+        },
+        {
+          "name": "AP Emerald (Luxembourg) S.à r.l.",
+          "identifier": "RCS  B307795"
+        },
+        {
+          "name": "Apollo Global Management, Inc.",
+          "identifier": "CIK 0001858681"
         }
       ]
     },
@@ -2074,6 +2106,10 @@
         {
           "name": "AUSTRALIANSUPER PTY LTD atf AustralianSuper",
           "identifier": "94 006 457 987"
+        },
+        {
+          "name": "AIRTREE VENTURES OPPORTUNITY FUND 2021 TRUSCO PTY LTD atf the Airtree Ventures AS Co-invesment Oppor",
+          "identifier": "90 652 901 043"
         }
       ]
     },
@@ -3214,6 +3250,134 @@
         {
           "name": "Ampere Holdings I B.V.",
           "identifier": "CCI number  69397775"
+        }
+      ]
+    },
+    {
+      "id": "pipe-management-australia",
+      "canonical_name": "Pipe Management Australia",
+      "members": [
+        {
+          "name": "HEADWORKS AUSTRALIA PTY LTD",
+          "identifier": "39 637 942 646"
+        },
+        {
+          "name": "UTILITY MANAGEMENT GROUP PTY LTD",
+          "identifier": "39 644 190 527"
+        }
+      ]
+    },
+    {
+      "id": "harvest-pub",
+      "canonical_name": "Harvest Pub",
+      "members": [
+        {
+          "name": "HARVEST PUB OPERATIONS 2 PTY LTD",
+          "identifier": "51 652 748 242"
+        },
+        {
+          "name": "AMAL TRUSTEES PTY LIMITED",
+          "identifier": "98 609 737 064"
+        }
+      ]
+    },
+    {
+      "id": "comms-group",
+      "canonical_name": "Comms Group",
+      "members": [
+        {
+          "name": "COMMS GROUP LTD",
+          "identifier": "64 619 196 539"
+        },
+        {
+          "name": "ON GROUP HOLDINGS PTY LTD",
+          "identifier": "68 622 185 808"
+        }
+      ]
+    },
+    {
+      "id": "aub-group",
+      "canonical_name": "AUB Group",
+      "members": [
+        {
+          "name": "AUB GROUP LIMITED",
+          "identifier": "60 000 000 715"
+        },
+        {
+          "name": "AUSTAGENCIES PTY LTD",
+          "identifier": "76 006 090 464"
+        }
+      ]
+    },
+    {
+      "id": "lava-street-veterinary-clinic-and-doggy-kinder",
+      "canonical_name": "Lava Street Veterinary Clinic and Doggy Kinder",
+      "members": [
+        {
+          "name": "DOGGY KINDER PTY LTD",
+          "identifier": "60 665 736 265"
+        },
+        {
+          "name": "The Trustee for Longyester Unit Trust",
+          "identifier": "18 762 651 022"
+        }
+      ]
+    },
+    {
+      "id": "kingston-beach-dental",
+      "canonical_name": "Kingston Beach Dental",
+      "members": [
+        {
+          "name": "KINGSTON BEACH DENTAL PROFESSIONALS PTY LTD",
+          "identifier": "62 688 443 825"
+        },
+        {
+          "name": "Kingston Beach Dental",
+          "identifier": "48 655 424 512"
+        }
+      ]
+    },
+    {
+      "id": "bayer",
+      "canonical_name": "Bayer",
+      "members": [
+        {
+          "name": "Bayer Aktiengesellschaft",
+          "identifier": "HRB  48248"
+        },
+        {
+          "name": "Bayer Global Investments B.V.",
+          "identifier": "KVK  51490986"
+        },
+        {
+          "name": "Bayer Asset Management B.V.",
+          "identifier": "KVK  42012880"
+        },
+        {
+          "name": "Bayer Nordic SE",
+          "identifier": "Finnish Patent and Registration Office  24305802"
+        },
+        {
+          "name": "Bayer Oy",
+          "identifier": "Finnish Patent and Registration Office  17037774"
+        }
+      ]
+    },
+    {
+      "id": "mermec",
+      "canonical_name": "MerMec",
+      "members": [
+        {
+          "name": "Mer Mec S.p.A.",
+          "identifier": "LEI  81560011DF7243CFC226"
+        },
+        {
+          "name": "MERMEC AUSTRALIA PTY LTD",
+          "identifier": "42 619 285 988"
+        },
+        {
+          "name": "Angelo Holding S.r.l.",
+          "identifier": "LEI  815600BFD5004E85D746"
         }
       ]
     }


### PR DESCRIPTION
- New Pipe Management Australia group (Headworks Australia + Utility
  Management Group, which merged to form PMA in 2020)
- New Harvest Pub group (Harvest Pub Operations 2 + Amal Trustees atf
  Harvest Pub Trust 2, sold together as one venue in the Laundy Woy deal)
- New Comms Group (ASX:CCG) + On Group Holdings (OnPlatinum), confirmed
  parent/subsidiary via the efex acquisition announcement
- New AUB Group (AUB Group Limited + Austagencies, confirmed wholly
  owned subsidiary)
- New Lava Street Veterinary Clinic and Doggy Kinder group (Doggy
  Kinder + Longyester atf Longyester Unit Trust, one combined practice
  sold together)
- New Kingston Beach Dental group (the two ABNs behind the same dental
  practice acquired by Impression Dental Group)
- New Bayer group (Aktiengesellschaft + Global Investments + Asset
  Management + Nordic SE + Oy, per the Apollo/Bayer Asset Management
  notice)
- New MerMec group (Mer Mec S.p.A. + MerMec Australia + Angelo Holding,
  the Pertosa-owned seller confirmed via Siemens Mobility's acquisition
  announcement)
- Hurrikayne, Wollongong City Motors and Paul Burgess Nominees added to
  Wakeling Motos (all named as part of Wakeling Automotive Group in the
  Peter Warren acquisition)
- Siemens Mobility Holding B.V. and Siemens Aktiengesellschaft added to
  the Siemens Mobility group (confirmed parent/investment vehicle)
- Origin Zero Investments added to Origin Energy Limited (confirmed
  wholly owned subsidiary)
- AP Emerald (Luxembourg) and Apollo Global Management, Inc. added to
  Apollo Capital Management (deal vehicle and ultimate parent)
- AirTree Ventures Opportunity Fund 2021 Trusco added to AustralianSuper
  (the co-investment vehicle used for the Advanced Navigation deal)

Excluded per the existing "unrelated PE parent" precedent: Quadrant
Private Equity, Advent Partners and Genesis Capital, each of which
merely owns/controls one of the operating parties without itself being
part of that operating business's identity — and, in Genesis Capital's
case, controls two otherwise-unrelated portfolio companies (Kanda
Healthcare and Impression Dental Group) that shouldn't be treated as
one group on that basis alone. IKEA Australia (Ingka) and Inter IKEA
were also left unlinked, since the notice itself describes them as
operating independently of one another.