### PR TITLE
Recover register matters dropped by unstable listing pagination

### DIFF
--- a/data/raw/matters/MN-25037.html
+++ b/data/raw/matters/MN-25037.html
@@ -6,11 +6,11 @@
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="Sanad Services Group owned by One Hundred and Seven Investment RSC LTD – Sole Proprietorship L.L.C. (Sanad Services) and Ace Aéro Partenaires II S.L.P. (AAP2) (an investment fund) propose to acquire Revima Holding SAS (Revima)." />
 <link rel="shortlink" href="https://www.accc.gov.au/node/173226" />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/sanad-services-and-tikehau-capital-%E2%80%93-revima" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/acquisitions-and-mergers-registers/acquisitions-register/sanad-services-and-tikehau-capital-%E2%80%93-revima" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />
-<meta property="og:url" content="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/sanad-services-and-tikehau-capital-%E2%80%93-revima" />
+<meta property="og:url" content="https://www.accc.gov.au/public-registers/acquisitions-and-mergers-registers/acquisitions-register/sanad-services-and-tikehau-capital-%E2%80%93-revima" />
 <meta property="og:title" content="Sanad Services and Tikehau Capital – Revima" />
 <meta property="og:description" content="Sanad Services Group owned by One Hundred and Seven Investment RSC LTD – Sole Proprietorship L.L.C. (Sanad Services) and Ace Aéro Partenaires II S.L.P. (AAP2) (an investment fund) propose to acquire Revima Holding SAS (Revima)." />
 <meta property="og:image" content="https://www.accc.gov.au/sites/www.accc.gov.au/themes/acccgov_theme/images/og-image.png" />
@@ -25,7 +25,7 @@
 <meta name="dcterms.date" content="2026-07-21" />
 <meta name="dcterms.type" content="Text" />
 <meta name="dcterms.format" content="text/html" />
-<meta name="dcterms.identifier" content="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/sanad-services-and-tikehau-capital-%E2%80%93-revima" />
+<meta name="dcterms.identifier" content="https://www.accc.gov.au/public-registers/acquisitions-and-mergers-registers/acquisitions-register/sanad-services-and-tikehau-capital-%E2%80%93-revima" />
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
@@ -250,8 +250,8 @@
     <ol class="breadcrumb">
           <li class="breadcrumb-item"><a href="/">Home</a></li>
           <li class="breadcrumb-item"><a href="/public-registers">Public registers</a></li>
-          <li class="breadcrumb-item"><a href="/public-registers/mergers-and-acquisitions-registers">Mergers and acquisitions registers</a></li>
-          <li class="breadcrumb-item"><a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register">Acquisitions register</a></li>
+          <li class="breadcrumb-item"><a href="/public-registers/acquisitions-and-mergers-registers">Acquisitions and mergers registers</a></li>
+          <li class="breadcrumb-item"><a href="/public-registers/acquisitions-and-mergers-registers/acquisitions-register">Acquisitions register</a></li>
         </ol>
   </nav>
 
@@ -348,7 +348,7 @@
       <div class="modal-body">
         <p>Receive an email alert when this acquisition is updated on the register.</p><p>Before subscribing, please read our <a href="/about-us/using-our-website/privacy-policy">Privacy Policy</a> to understand how your personal information is handled.</p><p>To sign up for another acquisition, open the acquisition in the <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register">acquisitions register</a> and choose subscribe.</p>
         <div class="accc-mailchimp-subscription-form" id="mc_embed_signup">
-          <div id="acq-subscribe-status-message"></div><div id="acquisition-subscribe-modal-form-wrapper"><form class="acquisition-subscribe-form validate" data-drupal-selector="acquisition-subscribe-form" novalidate="novalidate" action="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/sanad-services-and-tikehau-capital-%E2%80%93-revima" method="post" id="acquisition-subscribe-form" accept-charset="UTF-8">
+          <div id="acq-subscribe-status-message"></div><div id="acquisition-subscribe-modal-form-wrapper"><form class="acquisition-subscribe-form validate" data-drupal-selector="acquisition-subscribe-form" novalidate="novalidate" action="/public-registers/acquisitions-and-mergers-registers/acquisitions-register/sanad-services-and-tikehau-capital-%E2%80%93-revima" method="post" id="acquisition-subscribe-form" accept-charset="UTF-8">
   <div class="form-group js-form-item form-item form-type-email js-form-type-email form-item-email js-form-item-email">
              <label for="edit-email" class="field-element-label js-form-required form-required">
     Email

--- a/data/raw/matters/MN-35029.html
+++ b/data/raw/matters/MN-35029.html
@@ -6,17 +6,17 @@
 <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "G-S5TGQHQ4G8", {"groups":"default","page_placeholder":"PLACEHOLDER_page_location","link_attribution":true});</script>
 <meta name="description" content="L&#039;Oréal S.A. and its subsidiaries (L&#039;Oréal), through its wholly-owned subsidiary L&#039;Oréal India Private Limited, proposes to acquire 65.22% of the share capital of Onesto Labs Private Limited (Innovist)." />
 <link rel="shortlink" href="https://www.accc.gov.au/node/173211" />
-<link rel="canonical" href="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/lor%C3%A9al-innovist" />
+<link rel="canonical" href="https://www.accc.gov.au/public-registers/acquisitions-and-mergers-registers/acquisitions-register/lor%C3%A9al-innovist" />
 <meta name="generator" content="Drupal 10 (https://www.drupal.org)" />
 <meta property="og:site_name" content="Australian Competition and Consumer Commission" />
 <meta property="og:type" content="article" />
-<meta property="og:url" content="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/lor%C3%A9al-innovist" />
+<meta property="og:url" content="https://www.accc.gov.au/public-registers/acquisitions-and-mergers-registers/acquisitions-register/lor%C3%A9al-innovist" />
 <meta property="og:title" content="L&#039;Oréal - Innovist" />
 <meta property="og:description" content="L&#039;Oréal S.A. and its subsidiaries (L&#039;Oréal), through its wholly-owned subsidiary L&#039;Oréal India Private Limited, proposes to acquire 65.22% of the share capital of Onesto Labs Private Limited (Innovist)." />
 <meta property="og:image" content="https://www.accc.gov.au/sites/www.accc.gov.au/themes/acccgov_theme/images/og-image.png" />
 <meta property="og:updated_time" content="2026-07-21T10:00:00+10:00" />
 <meta property="article:published_time" content="2026-07-21T10:00:00+10:00" />
-<meta property="article:modified_time" content="2026-07-29T17:06:36+10:00" />
+<meta property="article:modified_time" content="2026-08-18T12:10:19+10:00" />
 <meta name="dcterms.title" content="L&#039;Oréal - Innovist" />
 <meta name="dcterms.creator" content="Australian Competition and Consumer Commission" />
 <meta name="dcterms.description" content="L&#039;Oréal S.A. and its subsidiaries (L&#039;Oréal), through its wholly-owned subsidiary L&#039;Oréal India Private Limited, proposes to acquire 65.22% of the share capital of Onesto Labs Private Limited (Innovist)." />
@@ -25,12 +25,12 @@
 <meta name="dcterms.date" content="2026-07-21" />
 <meta name="dcterms.type" content="Text" />
 <meta name="dcterms.format" content="text/html" />
-<meta name="dcterms.identifier" content="https://www.accc.gov.au/public-registers/mergers-and-acquisitions-registers/acquisitions-register/lor%C3%A9al-innovist" />
+<meta name="dcterms.identifier" content="https://www.accc.gov.au/public-registers/acquisitions-and-mergers-registers/acquisitions-register/lor%C3%A9al-innovist" />
 <meta name="dcterms.language" content="en" />
 <meta name="dcterms.coverage" content="Australia" />
 <meta name="dcterms.rights" content="This website is the property of the Australian Competition and Consumer Commission." />
 <meta name="dcterms.created" content="2026-07-22T10:53:52+10:00" />
-<meta name="dcterms.modified" content="2026-07-29T17:06:36+10:00" />
+<meta name="dcterms.modified" content="2026-08-18T12:10:19+10:00" />
 <meta property="fb:admins" content="100009948060422" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@acccgovau" />
@@ -250,8 +250,8 @@
     <ol class="breadcrumb">
           <li class="breadcrumb-item"><a href="/">Home</a></li>
           <li class="breadcrumb-item"><a href="/public-registers">Public registers</a></li>
-          <li class="breadcrumb-item"><a href="/public-registers/mergers-and-acquisitions-registers">Mergers and acquisitions registers</a></li>
-          <li class="breadcrumb-item"><a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register">Acquisitions register</a></li>
+          <li class="breadcrumb-item"><a href="/public-registers/acquisitions-and-mergers-registers">Acquisitions and mergers registers</a></li>
+          <li class="breadcrumb-item"><a href="/public-registers/acquisitions-and-mergers-registers/acquisitions-register">Acquisitions register</a></li>
         </ol>
   </nav>
 
@@ -307,9 +307,9 @@
                     <div class="accc-field__section accc-field__section--metadata">
          
 <div  class="acquisition-summary-wrapper">
-        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline under-assessment clearfix">
+        <div class="field field--name-field-acccgov-merger-status field--type-list-string field--label-inline assessment-completed clearfix">
     <h3 class="field__label">Acquisition status</h3>
-              <div class="field__item">Under assessment</div>
+              <div class="field__item">Assessment completed</div>
           </div>
   <div class="field field--name-dynamic-token-fieldnode-acccgov-merger-id field--type-ds field--label-inline clearfix">
     <h3 class="field__label">Acquisition case number</h3>
@@ -348,7 +348,7 @@
       <div class="modal-body">
         <p>Receive an email alert when this acquisition is updated on the register.</p><p>Before subscribing, please read our <a href="/about-us/using-our-website/privacy-policy">Privacy Policy</a> to understand how your personal information is handled.</p><p>To sign up for another acquisition, open the acquisition in the <a href="/public-registers/mergers-and-acquisitions-registers/acquisitions-register">acquisitions register</a> and choose subscribe.</p>
         <div class="accc-mailchimp-subscription-form" id="mc_embed_signup">
-          <div id="acq-subscribe-status-message"></div><div id="acquisition-subscribe-modal-form-wrapper"><form class="acquisition-subscribe-form validate" data-drupal-selector="acquisition-subscribe-form" novalidate="novalidate" action="/public-registers/mergers-and-acquisitions-registers/acquisitions-register/lor%C3%A9al-innovist" method="post" id="acquisition-subscribe-form" accept-charset="UTF-8">
+          <div id="acq-subscribe-status-message"></div><div id="acquisition-subscribe-modal-form-wrapper"><form class="acquisition-subscribe-form validate" data-drupal-selector="acquisition-subscribe-form" novalidate="novalidate" action="/public-registers/acquisitions-and-mergers-registers/acquisitions-register/lor%C3%A9al-innovist" method="post" id="acquisition-subscribe-form" accept-charset="UTF-8">
   <div class="form-group js-form-item form-item form-type-email js-form-type-email form-item-email js-form-item-email">
              <label for="edit-email" class="field-element-label js-form-required form-required">
     Email
@@ -401,12 +401,17 @@
     <h3 class="field__label">Stage</h3>
               <div class="field__item">Phase 1 - initial assessment</div>
           </div>
-  <div class="field field--name-field-acccgov-end-determination field--type-datetime field--label-inline clearfix">
-    <h3 class="field__label">End of determination period</h3>
-              <div class="field__item"><time datetime="2026-08-31T12:00:00Z" class="datetime">31 Aug 2026</time>
-</div>
+  <div class="field field--name-field-acccgov-acquisition-deter field--type-list-string field--label-inline clearfix">
+    <h3 class="field__label">ACCC determination</h3>
+              <div class="field__item">Approved</div>
           </div>
 
+<div class="field field--name-field-acccgov-pub-reg-end-date field--type-datetime field--label-inline">
+  <h3 class="field__label">Determination publication date</h3>
+        <div class="field__item"><time datetime="2026-08-18T12:00:00Z" class="datetime">18 August 2026</time>
+</div>
+      </div>
+        
   </div>
 
 <div >
@@ -486,15 +491,21 @@
   </div>
 
 <div >
-    <h3 class="border-bottom">Consultation</h3>
-                  <div class="field field--name-field-acccgov-consultation-text field--type-text-long field--label-hidden clearfix text-formatted field__item">
-<div class="read-more-wrapper">
-    <div class="full-text">
-    <p dir="ltr">The period for providing submissions or information in response to the ACCC’s Phase 1 questionnaire has concluded.</p>
-
-  </div>
-  </div></div>
-      
+    <h3 class="border-bottom">Decisions and key events</h3>
+            <div class="field field--name-field-acccgov-merger-events field--type-entity-reference-revisions field--label-hidden clearfix table-responsive field__items">
+              <table class="table table-striped">
+          <tbody>
+                          <tr>
+      <td class="acccgov-timeline__date"><time datetime="2026-08-18T12:00:00Z" class="datetime">18 Aug 2026</time>
+</td>
+      <td>L&#039;Oreal - Innovist - Phase 1 determination</td>
+      <td class="acccgov-timeline__file-link"><span class="file file--mime-application-pdf file--application-pdf"><a href="/system/files/public-merger-register/documents/L%27oreal%20-%20Innovist%20-%20Phase%201%20determination.pdf" type="application/pdf" title="L&#039;oreal - Innovist - Phase 1 determination.pdf"><svg  class="fa-file-pdf" aria-hidden="true"><use href="/themes/custom/accc_bootstrap/icons/icons.svg?tSTATIC"></use></svg>
+ Attachment <span class="badge badge-info">149.18 KB</span></a></span>
+</td>
+    </tr>
+  
+                </tbody></table>    </div>
+  
   </div>
 
       </div>

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,6 +22,7 @@ scrape.sh ──► extract_mergers.py ──► generate_static_data.py ──�
 | --- | --- |
 | `scrape.sh` | Bash wrapper using `pup`/`curl` to fetch the ACCC acquisitions register and individual matter pages into `data/raw/`. |
 | `cutoff.py` | Determines which mergers are old enough to skip during scraping/extraction. Used as a module *and* as a CLI by `scrape.sh`. |
+| `scrape_targets.py` | Chooses which matter pages `scrape.sh` fetches: applies `cutoff.py`, de-duplicates the listing, and recovers matters the register listing dropped (its pagination sort is unstable). |
 
 ### Extract
 

--- a/scripts/scrape.sh
+++ b/scripts/scrape.sh
@@ -248,30 +248,22 @@ if [ -z "$relative_links" ]; then
   exit 0
 fi
 
-# 4. Filter out links for mergers past cutoff (unless --all is specified)
+# 4. Work out which matters to fetch.
+#
+# scrape_targets.py drops matters past cutoff (unless --all), de-duplicates the
+# listing, and — importantly — adds back any matter we already know about that
+# this crawl's listing failed to mention. The register paginates over an
+# unstable sort, so a matter can silently drop out of the listing and then
+# never be re-scraped again; see scripts/scrape_targets.py for detail.
 if [ "$SCRAPE_ALL" = true ]; then
   echo "Scraping all mergers (--all flag specified)"
-  links_to_fetch="$relative_links"
+  select_args=(--all)
 else
-  # Get list of URL paths to skip from cutoff.py
-  skip_paths_file=$(mktemp)
-  trap 'rm -f "$skip_paths_file"' EXIT
-
-  if [ -f "$MERGERS_JSON" ]; then
-    python3 "$SCRIPT_DIR/cutoff.py" --paths "$MERGERS_JSON" > "$skip_paths_file" 2>/dev/null || true
-  fi
-
-  skip_count=$(wc -l < "$skip_paths_file" | tr -d ' ')
-  if [ "$skip_count" -gt 0 ]; then
-    echo "Skipping $skip_count merger(s) past cutoff date (use --all to scrape all)"
-
-    # Filter out links that exactly match a skip path. Single grep call vs.
-    # spawning one per link.
-    links_to_fetch=$(grep -vxFf "$skip_paths_file" <<< "$relative_links" || true)
-  else
-    links_to_fetch="$relative_links"
-  fi
+  select_args=()
 fi
+
+links_to_fetch=$(printf '%s\n' "$relative_links" \
+  | python3 "$SCRIPT_DIR/scrape_targets.py" "${select_args[@]}" "$MERGERS_JSON")
 
 link_count=$(echo "$links_to_fetch" | grep -c . || true)
 if [ "$link_count" -eq 0 ]; then

--- a/scripts/scrape_targets.py
+++ b/scripts/scrape_targets.py
@@ -1,0 +1,186 @@
+"""Decide which register matter pages the scraper should fetch.
+
+The ACCC register listing is paginated at 50 rows per page over a sort that
+is not stable across requests: scrape.sh fetches each page as its own HTTP
+request, and rows that tie on the sort key can move between those requests.
+The result is that one crawl serves the same matter on two adjacent pages
+and silently drops another. Observed live on a 12-page crawl: 554 rows
+served, 550 distinct, 4 matters missing from the listing entirely even
+though their pages were still online.
+
+A matter that falls out of the listing is never re-fetched, so its saved
+HTML in data/raw/matters/ — and every field extract_mergers.py derives from
+it — stays frozen at whatever the last successful crawl happened to see.
+That is invisible in the output: the record simply keeps reporting a stale
+status forever.
+
+To close the gap, the listing links are unioned with the URL paths of
+matters already recorded in mergers.json that are still active under the
+cutoff rules. A matter the listing drops is then recovered from what we
+already know about it, and only genuinely new matters depend on the listing.
+
+Comparisons are made on a normalised key rather than the raw path, because
+the same matter is reachable under two spellings of the register segment
+(``mergers-and-acquisitions-registers`` and the newer
+``acquisitions-and-mergers-registers``, which 301s between them). The ACCC
+is mid-migration and serves a mix of both, so raw-string matching would
+both re-fetch matters that are past cutoff and queue duplicates of matters
+already covered by the listing.
+"""
+
+import json
+import os
+import sys
+from urllib.parse import unquote, urlparse
+
+from cutoff import CUTOFF_WEEKS, should_skip_merger
+
+
+def normalize_target(path: str) -> str:
+    """Return a comparison key identifying the matter a path points at.
+
+    Keys off the final path segment (the matter slug) with percent-escapes
+    decoded and case folded, so the two register-segment spellings and any
+    difference in escape casing collapse to the same value.
+    """
+    if not path:
+        return ''
+    segment = urlparse(path).path.rstrip('/').rsplit('/', 1)[-1]
+    return unquote(segment).casefold()
+
+
+def select_targets(listing_paths, mergers, cutoff_weeks: int = CUTOFF_WEEKS,
+                   scrape_all: bool = False):
+    """Choose the matter paths to fetch.
+
+    Args:
+        listing_paths: Relative paths scraped from the register listing pages.
+        mergers: Records already in mergers.json.
+        cutoff_weeks: Weeks after determination at which a matter goes cold.
+        scrape_all: Ignore cutoff dates — fetch every matter we know of.
+
+    Returns:
+        (paths, stats) where paths preserves listing order (listing links
+        first, then recovered ones) and stats reports what happened.
+    """
+    skip_keys = set()
+    known_paths = []
+    for merger in mergers:
+        url = merger.get('url', '')
+        if not url:
+            continue
+        path = urlparse(url).path
+        if not path:
+            continue
+        if not scrape_all and should_skip_merger(merger, cutoff_weeks=cutoff_weeks):
+            skip_keys.add(normalize_target(path))
+        else:
+            known_paths.append(path)
+
+    paths = []
+    seen = set()
+    stats = {
+        'listing': 0,
+        'duplicates': 0,
+        'skipped': 0,
+        'recovered': 0,
+        'recovered_paths': [],
+    }
+
+    for path in listing_paths:
+        path = path.strip()
+        if not path:
+            continue
+        stats['listing'] += 1
+        key = normalize_target(path)
+        if key in skip_keys:
+            stats['skipped'] += 1
+            continue
+        if key in seen:
+            stats['duplicates'] += 1
+            continue
+        seen.add(key)
+        paths.append(path)
+
+    # Recover matters the listing dropped. Without this a matter that ties on
+    # the listing's sort key can vanish for an unbounded number of runs.
+    for path in known_paths:
+        key = normalize_target(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        paths.append(path)
+        stats['recovered'] += 1
+        stats['recovered_paths'].append(path)
+
+    return paths, stats
+
+
+def load_mergers(mergers_json_path: str):
+    """Read mergers.json, treating a missing or unreadable file as empty."""
+    if not os.path.exists(mergers_json_path):
+        return []
+    try:
+        with open(mergers_json_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return []
+    return data if isinstance(data, list) else []
+
+
+def main():
+    """Read listing paths on stdin, write the paths to fetch on stdout.
+
+    Usage:
+        pup ... | python3 scrape_targets.py [--all] [mergers.json]
+
+    Progress detail goes to stderr so stdout stays a clean path list.
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description='Select register matter paths for the scraper to fetch.'
+    )
+    parser.add_argument(
+        'mergers_json',
+        nargs='?',
+        default='data/processed/mergers.json',
+        help='Path to mergers.json (default: data/processed/mergers.json)'
+    )
+    parser.add_argument(
+        '--all',
+        action='store_true',
+        help='Ignore cutoff dates and fetch every known matter'
+    )
+    parser.add_argument(
+        '--cutoff-weeks',
+        type=int,
+        default=CUTOFF_WEEKS,
+        help=f'Weeks after determination to cut off (default: {CUTOFF_WEEKS})'
+    )
+    args = parser.parse_args()
+
+    listing_paths = [line.strip() for line in sys.stdin if line.strip()]
+    mergers = load_mergers(args.mergers_json)
+    paths, stats = select_targets(
+        listing_paths,
+        mergers,
+        cutoff_weeks=args.cutoff_weeks,
+        scrape_all=args.all,
+    )
+
+    if stats['duplicates']:
+        print(f"    Listing served {stats['duplicates']} duplicate link(s)", file=sys.stderr)
+    if stats['skipped']:
+        print(f"    Skipping {stats['skipped']} merger(s) past cutoff", file=sys.stderr)
+    if stats['recovered']:
+        print(f"    Recovered {stats['recovered']} merger(s) missing from the listing:", file=sys.stderr)
+        for path in stats['recovered_paths']:
+            print(f"    - {path}", file=sys.stderr)
+
+    for path in paths:
+        print(path)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tests/README.md
+++ b/scripts/tests/README.md
@@ -16,6 +16,7 @@ without network or PDF tooling installed.
 | --- | --- |
 | `test_pipeline.py` | End-to-end extraction behaviour against fixture HTML. |
 | `test_cutoff_io.py` | `cutoff.py` skip logic and CLI output. |
+| `test_scrape_targets.py` | Fetch-list selection in `scrape_targets.py`: cutoff skipping, de-duplication, and recovery of matters the register listing drops. |
 | `test_embed.py` | `embed.py` chunking and metadata serialisation. |
 | `test_generate_weekly_digest.py` | Bucketing + dedup vs. the prior week's digest. |
 | `test_merger_filters.py` | Canonical loaders and predicates in `merger_filters.py`. |

--- a/scripts/tests/test_scrape_targets.py
+++ b/scripts/tests/test_scrape_targets.py
@@ -1,0 +1,172 @@
+"""Tests for scrape_targets.py — the scraper's fetch-list selection.
+
+The behaviour that matters here is recovery: the ACCC register paginates over
+an unstable sort, so a crawl can serve one matter twice and drop another
+entirely. A dropped matter must still be fetched from what mergers.json
+already knows, or its saved HTML never refreshes again.
+"""
+
+import json
+import os
+import sys
+import unittest.mock
+from datetime import datetime, timedelta
+
+# Add scripts directory to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+sys.modules.setdefault('pdfplumber', unittest.mock.MagicMock())
+sys.modules.setdefault('markdownify', unittest.mock.MagicMock())
+sys.modules.setdefault('requests', unittest.mock.MagicMock())
+
+from scrape_targets import load_mergers, normalize_target, select_targets
+
+REGISTER = '/public-registers/acquisitions-and-mergers-registers/acquisitions-register'
+OLD_REGISTER = '/public-registers/mergers-and-acquisitions-registers/acquisitions-register'
+
+
+def _url(slug, register=REGISTER):
+    return f'https://www.accc.gov.au{register}/{slug}'
+
+
+def _active(merger_id, slug, register=REGISTER):
+    """A matter with no determination — always active."""
+    return {'merger_id': merger_id, 'stage': 'Phase 1 - initial assessment',
+            'url': _url(slug, register)}
+
+
+def _completed(merger_id, slug, weeks_ago=10, register=REGISTER):
+    """An approved matter old enough to be past cutoff."""
+    published = (datetime.now() - timedelta(weeks=weeks_ago)).strftime('%Y-%m-%dT12:00:00Z')
+    return {'merger_id': merger_id, 'stage': 'Phase 1 - initial assessment',
+            'accc_determination': 'Approved', 'determination_publication_date': published,
+            'url': _url(slug, register)}
+
+
+class TestNormalizeTarget:
+    def test_ignores_register_segment_word_order(self):
+        # The ACCC serves both spellings and 301s between them.
+        assert normalize_target(f'{REGISTER}/acme-widgets') == \
+            normalize_target(f'{OLD_REGISTER}/acme-widgets')
+
+    def test_decodes_percent_escapes(self):
+        assert normalize_target(f'{REGISTER}/lor%C3%A9al-innovist') == \
+            normalize_target(f'{REGISTER}/loréal-innovist')
+
+    def test_ignores_escape_case(self):
+        assert normalize_target(f'{REGISTER}/a-%e2%80%93-b') == \
+            normalize_target(f'{REGISTER}/a-%E2%80%93-b')
+
+    def test_accepts_absolute_urls(self):
+        assert normalize_target(_url('acme-widgets')) == \
+            normalize_target(f'{REGISTER}/acme-widgets')
+
+    def test_empty_path(self):
+        assert normalize_target('') == ''
+
+
+class TestSelectTargets:
+    def test_recovers_matter_missing_from_listing(self):
+        mergers = [_active('MN-1', 'acme-widgets'), _active('MN-2', 'lor%C3%A9al-innovist')]
+        listing = [f'{REGISTER}/acme-widgets']
+
+        paths, stats = select_targets(listing, mergers)
+
+        assert stats['recovered'] == 1
+        assert f'{REGISTER}/lor%C3%A9al-innovist' in paths
+
+    def test_recovery_matches_across_register_spellings(self):
+        # The stored URL and the listing link disagree on word order; that must
+        # not queue the same matter twice.
+        mergers = [_active('MN-1', 'acme-widgets', register=OLD_REGISTER)]
+        listing = [f'{REGISTER}/acme-widgets']
+
+        paths, stats = select_targets(listing, mergers)
+
+        assert stats['recovered'] == 0
+        assert paths == [f'{REGISTER}/acme-widgets']
+
+    def test_drops_duplicate_listing_links(self):
+        listing = [f'{REGISTER}/acme-widgets', f'{OLD_REGISTER}/acme-widgets']
+
+        paths, stats = select_targets(listing, [])
+
+        assert paths == [f'{REGISTER}/acme-widgets']
+        assert stats['duplicates'] == 1
+
+    def test_skips_matters_past_cutoff(self):
+        mergers = [_completed('MN-1', 'old-deal')]
+        listing = [f'{REGISTER}/old-deal', f'{REGISTER}/new-deal']
+
+        paths, stats = select_targets(listing, mergers)
+
+        assert paths == [f'{REGISTER}/new-deal']
+        assert stats['skipped'] == 1
+
+    def test_past_cutoff_matters_are_not_recovered(self):
+        # Recovery must not resurrect matters the cutoff deliberately retires.
+        mergers = [_completed('MN-1', 'old-deal')]
+
+        paths, stats = select_targets([], mergers)
+
+        assert paths == []
+        assert stats['recovered'] == 0
+
+    def test_cutoff_skip_matches_across_register_spellings(self):
+        mergers = [_completed('MN-1', 'old-deal', register=OLD_REGISTER)]
+        listing = [f'{REGISTER}/old-deal']
+
+        paths, stats = select_targets(listing, mergers)
+
+        assert paths == []
+        assert stats['skipped'] == 1
+
+    def test_all_ignores_cutoff_and_recovers_everything(self):
+        mergers = [_completed('MN-1', 'old-deal'), _active('MN-2', 'live-deal')]
+
+        paths, stats = select_targets([], mergers, scrape_all=True)
+
+        assert sorted(paths) == sorted([f'{REGISTER}/old-deal', f'{REGISTER}/live-deal'])
+        assert stats['skipped'] == 0
+        assert stats['recovered'] == 2
+
+    def test_listing_order_is_preserved_with_recoveries_last(self):
+        mergers = [_active('MN-3', 'dropped-deal')]
+        listing = [f'{REGISTER}/first', f'{REGISTER}/second']
+
+        paths, _ = select_targets(listing, mergers)
+
+        assert paths == [f'{REGISTER}/first', f'{REGISTER}/second',
+                         f'{REGISTER}/dropped-deal']
+
+    def test_ignores_records_without_a_url(self):
+        paths, stats = select_targets([], [{'merger_id': 'MN-1'}, {'merger_id': 'MN-2', 'url': ''}])
+
+        assert paths == []
+        assert stats['recovered'] == 0
+
+    def test_blank_listing_lines_are_ignored(self):
+        paths, stats = select_targets(['', '  ', f'{REGISTER}/acme-widgets'], [])
+
+        assert paths == [f'{REGISTER}/acme-widgets']
+        assert stats['listing'] == 1
+
+
+class TestLoadMergers:
+    def test_missing_file(self, tmp_path):
+        assert load_mergers(str(tmp_path / 'nope.json')) == []
+
+    def test_malformed_json(self, tmp_path):
+        path = tmp_path / 'mergers.json'
+        path.write_text('{not json')
+        assert load_mergers(str(path)) == []
+
+    def test_non_list_payload(self, tmp_path):
+        path = tmp_path / 'mergers.json'
+        path.write_text(json.dumps({'merger_id': 'MN-1'}))
+        assert load_mergers(str(path)) == []
+
+    def test_reads_records(self, tmp_path):
+        path = tmp_path / 'mergers.json'
+        path.write_text(json.dumps([_active('MN-1', 'acme-widgets')]))
+        assert len(load_mergers(str(path))) == 1


### PR DESCRIPTION
The ACCC acquisitions register paginates at 50 rows per page and scrape.sh
fetches each page as a separate HTTP request. The listing's sort is not
stable across those requests, so rows that tie on the sort key can move
between pages mid-crawl: one matter gets served on two adjacent pages while
another is never served at all.

The register's own facet counts report 554 matters (226 notifications + 328
waivers). A crawl right now serves 554 rows across 12 pages but only 550
distinct ones, with 4 duplicated at page boundaries and 4 missing entirely.

A matter that falls out of the listing is never re-fetched, so its saved HTML
in data/raw/matters/ — and every field extract_mergers.py derives from it —
silently stays frozen at whatever the last successful crawl saw. MN-35029
(L'Oréal - Innovist) had its Phase 1 determination published today and is
currently absent from the listing, so no scheduled run would have picked the
determination up.

scrape_targets.py now builds the fetch list by unioning the listing links
with the URL paths of matters already in mergers.json that are still active
under the cutoff rules, so only genuinely new matters depend on the listing
being complete. Comparisons use a normalised key (matter slug, percent-escapes
decoded, case folded) because the ACCC is mid-migration between two spellings
of the register path segment and serves a mix of both — raw string matching
was already failing to skip 32 past-cutoff matters and would have queued
duplicate fetches for the rest.

Also refreshes the two matter pages missing from the current listing so the
next extraction picks up their real status.