### PR TITLE
Report the merger IDs each scrape run touched

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -78,6 +78,8 @@ jobs:
       # --- Scrape ---
 
       - name: Run scraper
+        env:
+          SCRAPE_REPORT_DIR: ${{ runner.temp }}/scrape-report
         run: |
           chmod +x ./scripts/scrape.sh
           if [ "${{ inputs.all_mergers }}" = "true" ]; then
@@ -85,6 +87,36 @@ jobs:
           else
             ./scripts/scrape.sh
           fi
+
+      # Record which merger IDs this run actually fetched, which of their
+      # pages changed, and which matters were skipped past cutoff, so a run
+      # can be spot checked against an ACCC register notification email.
+      # Runs even when the scraper failed, to summarise what it got through.
+      - name: Summarise scraped mergers
+        if: ${{ !cancelled() }}
+        env:
+          SCRAPE_REPORT_DIR: ${{ runner.temp }}/scrape-report
+          # Passed through env, never interpolated into the script: the
+          # subject is attacker-influencable content from an inbound email.
+          TRIGGER_EVENT: ${{ github.event_name }}
+          EMAIL_SUBJECT: ${{ github.event.client_payload.email_subject }}
+        run: |
+          {
+            echo "### Scrape trigger"
+            echo ""
+            printf -- '- Event: `%s`\n' "$TRIGGER_EVENT"
+            if [ -n "$EMAIL_SUBJECT" ]; then
+              printf -- '- ACCC register email: %s\n' "$EMAIL_SUBJECT"
+            fi
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          git status --porcelain -- data/raw/matters/ \
+            | awk '{print $NF}' > "${RUNNER_TEMP}/scrape-changed.txt"
+          python scripts/scrape_summary.py \
+            --report-dir "$SCRAPE_REPORT_DIR" \
+            --changed-paths "${RUNNER_TEMP}/scrape-changed.txt" \
+            | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Verify HTML cleaning
         run: |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,6 +23,7 @@ scrape.sh ──► extract_mergers.py ──► generate_static_data.py ──�
 | `scrape.sh` | Bash wrapper using `pup`/`curl` to fetch the ACCC acquisitions register and individual matter pages into `data/raw/`. |
 | `cutoff.py` | Determines which mergers are old enough to skip during scraping/extraction. Used as a module *and* as a CLI by `scrape.sh`. |
 | `scrape_targets.py` | Chooses which matter pages `scrape.sh` fetches: applies `cutoff.py`, de-duplicates the listing, and recovers matters the register listing dropped (its pagination sort is unstable). |
+| `scrape_summary.py` | Renders the Markdown run summary for a scrape (merger IDs fetched, which pages changed, what was skipped past cutoff) from the report `scrape.sh` writes when `SCRAPE_REPORT_DIR` is set. |
 
 ### Extract
 
@@ -83,4 +84,15 @@ pip install -r scripts/requirements.txt
 python scripts/extract_mergers.py         # → data/processed/mergers.json
 python scripts/generate_static_data.py    # → frontend public/data/
 python -m pytest scripts/tests/           # tests
+```
+
+To see which merger IDs a scrape touched — the same summary the pipeline
+writes to its GitHub Actions run summary — point the scraper at a report
+directory:
+
+```bash
+SCRAPE_REPORT_DIR=/tmp/scrape-report ./scripts/scrape.sh
+git status --porcelain -- data/raw/matters/ | awk '{print $NF}' > /tmp/changed.txt
+python scripts/scrape_summary.py --report-dir /tmp/scrape-report \
+  --changed-paths /tmp/changed.txt
 ```

--- a/scripts/scrape.sh
+++ b/scripts/scrape.sh
@@ -12,6 +12,13 @@
 #                      or waiver decision)
 #   --clean-file <path>  Apply HTML cleaning to a single file and exit. Used by
 #                        the pipeline to re-clean files after a git rebase.
+#
+# Environment:
+#   SCRAPE_REPORT_DIR  If set, write a report of the run into this directory:
+#                      targets.json (what was selected, skipped and recovered)
+#                      and fetched.tsv (status, merger ID and path per fetch).
+#                      scripts/scrape_summary.py renders these for the run's
+#                      GitHub step summary.
 
 # Exit immediately if a command exits with a non-zero status.
 set -e
@@ -52,6 +59,17 @@ export USER_AGENT="Mozilla/5.0 (compatible; mergers-fyi/1.0; +https://mergers.fy
 export MERGERS_JSON="data/processed/mergers.json"
 export SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export PARALLEL_JOBS=24
+
+# Optional run report. When SCRAPE_REPORT_DIR is set (the pipeline sets it),
+# the scraper records which matters it selected and which it actually fetched,
+# so scrape_summary.py can list the merger IDs touched by the run.
+export SCRAPE_REPORT_DIR="${SCRAPE_REPORT_DIR:-}"
+export SCRAPE_MANIFEST=""
+if [ -n "$SCRAPE_REPORT_DIR" ]; then
+  mkdir -p "$SCRAPE_REPORT_DIR"
+  export SCRAPE_MANIFEST="${SCRAPE_REPORT_DIR}/fetched.tsv"
+  : > "$SCRAPE_MANIFEST"
+fi
 
 # --- Functions ---
 
@@ -117,6 +135,16 @@ clean_html() {
   echo "Successfully cleaned $file_count HTML file(s)"
 }
 
+# Record one fetch outcome in the run manifest, if one is being kept.
+# Called from the parallel xargs subshells: a single short line written in
+# append mode is atomic, so concurrent writers cannot interleave.
+record_fetch() {
+  local status="$1" merger_id="$2" link="$3"
+  [ -n "$SCRAPE_MANIFEST" ] || return 0
+  printf '%s\t%s\t%s\n' "$status" "${merger_id:-UNKNOWN}" "$link" >> "$SCRAPE_MANIFEST"
+}
+export -f record_fetch
+
 # Function to fetch and process a single matter page.
 # It's designed to be called by xargs for parallel execution.
 fetch_matter_page() {
@@ -131,6 +159,7 @@ fetch_matter_page() {
   # Download the page. The --fail flag ensures curl exits with an error on HTTP failures (like 404).
   if ! curl -s -L --compressed -A "$USER_AGENT" --fail "$full_url" -o "$temp_html"; then
       echo "FAILED: $full_url" >&2
+      record_fetch "failed" "" "$link"
       # Returning a non-zero status will cause xargs to stop
       return 1
   fi
@@ -159,6 +188,7 @@ fetch_matter_page() {
     fallback_name=$(echo "$fallback_name" | tr -cd 'A-Za-z0-9_.-')
     if [ -z "$fallback_name" ]; then
       echo "    Warning: Skipping $full_url (no safe filename)" >&2
+      record_fetch "failed" "" "$link"
       return 1
     fi
     filename="${SUBFOLDER}/${fallback_name}.html"
@@ -168,6 +198,7 @@ fetch_matter_page() {
 
   clean_file "$filename"
 
+  record_fetch "ok" "$matter_number" "$link"
 }
 # Export the function so it's available to subshells spawned by xargs
 export -f fetch_matter_page
@@ -260,6 +291,10 @@ if [ "$SCRAPE_ALL" = true ]; then
   select_args=(--all)
 else
   select_args=()
+fi
+
+if [ -n "$SCRAPE_REPORT_DIR" ]; then
+  select_args+=(--stats-json "${SCRAPE_REPORT_DIR}/targets.json")
 fi
 
 links_to_fetch=$(printf '%s\n' "$relative_links" \

--- a/scripts/scrape_summary.py
+++ b/scripts/scrape_summary.py
@@ -1,0 +1,179 @@
+"""Render a Markdown summary of what a scrape run fetched.
+
+The pipeline appends this to the GitHub Actions step summary so a run can be
+spot checked against the ACCC register emails: it names every merger ID the
+scraper fetched, flags which of those pages actually changed on disk, and —
+just as usefully when a change goes missing — names the matters the run
+never fetched because they are past the cutoff.
+
+Inputs are the report files ``scrape.sh`` writes when ``SCRAPE_REPORT_DIR``
+is set:
+
+* ``targets.json``  — selection stats from ``scrape_targets.py``
+* ``fetched.tsv``   — one ``status<TAB>merger_id<TAB>path`` row per fetch
+
+Usage:
+    python3 scripts/scrape_summary.py --report-dir /tmp/scrape-report \
+        [--changed-paths changed.txt] >> "$GITHUB_STEP_SUMMARY"
+"""
+
+import argparse
+import json
+import os
+
+# Long lists are collapsed behind a <details> block rather than dumped into
+# the summary; anything at or under this many entries is shown inline.
+INLINE_LIMIT = 25
+
+
+def load_stats(report_dir: str) -> dict:
+    """Read targets.json, treating a missing or unreadable file as empty."""
+    path = os.path.join(report_dir, 'targets.json')
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def load_fetched(report_dir: str):
+    """Read fetched.tsv into (ok, failed) lists of ``{merger_id, path}``."""
+    path = os.path.join(report_dir, 'fetched.tsv')
+    ok, failed = [], []
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            rows = f.read().splitlines()
+    except OSError:
+        return ok, failed
+
+    for row in rows:
+        if not row.strip():
+            continue
+        parts = row.split('\t')
+        if len(parts) != 3:
+            continue
+        status, merger_id, link = parts
+        entry = {'merger_id': merger_id, 'path': link}
+        (ok if status == 'ok' else failed).append(entry)
+    return ok, failed
+
+
+def load_changed_ids(changed_paths_file: str) -> set:
+    """Return merger IDs whose saved matter page changed in this run.
+
+    Takes a file of git-reported paths, one per line, and keys off the matter
+    page filename — data/raw/matters/MN-100123.html is merger MN-100123.
+    """
+    if not changed_paths_file:
+        return set()
+    try:
+        with open(changed_paths_file, 'r', encoding='utf-8') as f:
+            lines = f.read().splitlines()
+    except OSError:
+        return set()
+
+    changed = set()
+    for line in lines:
+        line = line.strip().strip('"')
+        if not line.endswith('.html'):
+            continue
+        if 'data/raw/matters/' not in line:
+            continue
+        changed.add(os.path.basename(line)[:-len('.html')])
+    return changed
+
+
+def _ids(entries) -> list:
+    """Sorted, de-duplicated merger IDs from a list of report entries."""
+    return sorted({e['merger_id'] for e in entries if e.get('merger_id')})
+
+
+def _code_list(ids) -> str:
+    return ', '.join(f'`{i}`' for i in ids)
+
+
+def _block(title: str, ids, empty: str = '') -> list:
+    """Render a labelled ID list, collapsing it when it is a long one."""
+    if not ids:
+        return [empty, ''] if empty else []
+    if len(ids) <= INLINE_LIMIT:
+        return [f'**{title} ({len(ids)}):** {_code_list(ids)}', '']
+    return [
+        '<details>',
+        f'<summary>{title} ({len(ids)})</summary>',
+        '',
+        _code_list(ids),
+        '',
+        '</details>',
+        '',
+    ]
+
+
+def render(stats: dict, fetched, failed, changed_ids) -> str:
+    """Build the Markdown summary for one scrape run."""
+    lines = ['### Scrape', '']
+
+    if not stats and not fetched and not failed:
+        lines += ['No scrape report was produced for this run.', '']
+        return '\n'.join(lines)
+
+    fetched_ids = _ids(fetched)
+    skipped_ids = _ids(stats.get('skipped_mergers', []))
+    recovered_ids = _ids(stats.get('recovered_mergers', []))
+    # Only count pages we fetched this run: a page can also show as changed
+    # because an earlier run left it dirty.
+    changed_fetched = [i for i in fetched_ids if i in changed_ids]
+
+    lines += [
+        '| | |',
+        '| --- | ---: |',
+        f"| Links in register listing | {stats.get('listing', 0)} |",
+        f"| Duplicate links dropped | {stats.get('duplicates', 0)} |",
+        f"| Skipped (past cutoff) | {stats.get('skipped', 0)} |",
+        f"| Recovered (missing from listing) | {stats.get('recovered', 0)} |",
+        f'| Pages fetched | {len(fetched)} |',
+        f'| Pages changed | {len(changed_fetched)} |',
+        f'| Fetch failures | {len(failed)} |',
+        '',
+    ]
+
+    lines += _block('Changed this run', changed_fetched,
+                    empty='No matter pages changed in this run.')
+    lines += _block('Merger IDs scraped', fetched_ids,
+                    empty='No matter pages were fetched.')
+    if recovered_ids:
+        lines += _block('Recovered from outside the listing', recovered_ids)
+    if skipped_ids:
+        lines += _block('Skipped — past cutoff, not scraped', skipped_ids)
+    if failed:
+        lines += _block('Fetch failures',
+                        [e['path'] for e in failed])
+
+    return '\n'.join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Render a Markdown summary of a scrape run.'
+    )
+    parser.add_argument(
+        '--report-dir',
+        required=True,
+        help='Directory scrape.sh wrote its run report into (SCRAPE_REPORT_DIR)'
+    )
+    parser.add_argument(
+        '--changed-paths',
+        help='File of git-reported changed paths, one per line'
+    )
+    args = parser.parse_args()
+
+    stats = load_stats(args.report_dir)
+    fetched, failed = load_fetched(args.report_dir)
+    changed_ids = load_changed_ids(args.changed_paths)
+
+    print(render(stats, fetched, failed, changed_ids))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/scrape_targets.py
+++ b/scripts/scrape_targets.py
@@ -63,6 +63,9 @@ def select_targets(listing_paths, mergers, cutoff_weeks: int = CUTOFF_WEEKS,
         (paths, stats) where paths preserves listing order (listing links
         first, then recovered ones) and stats reports what happened.
     """
+    # Merger IDs keyed by target so the run summary can name what was skipped
+    # or recovered, rather than only counting it.
+    ids_by_key = {}
     skip_keys = set()
     known_paths = []
     for merger in mergers:
@@ -72,8 +75,12 @@ def select_targets(listing_paths, mergers, cutoff_weeks: int = CUTOFF_WEEKS,
         path = urlparse(url).path
         if not path:
             continue
+        key = normalize_target(path)
+        merger_id = merger.get('merger_id')
+        if merger_id:
+            ids_by_key[key] = merger_id
         if not scrape_all and should_skip_merger(merger, cutoff_weeks=cutoff_weeks):
-            skip_keys.add(normalize_target(path))
+            skip_keys.add(key)
         else:
             known_paths.append(path)
 
@@ -83,8 +90,10 @@ def select_targets(listing_paths, mergers, cutoff_weeks: int = CUTOFF_WEEKS,
         'listing': 0,
         'duplicates': 0,
         'skipped': 0,
+        'skipped_mergers': [],
         'recovered': 0,
         'recovered_paths': [],
+        'recovered_mergers': [],
     }
 
     for path in listing_paths:
@@ -95,6 +104,9 @@ def select_targets(listing_paths, mergers, cutoff_weeks: int = CUTOFF_WEEKS,
         key = normalize_target(path)
         if key in skip_keys:
             stats['skipped'] += 1
+            stats['skipped_mergers'].append(
+                {'merger_id': ids_by_key.get(key), 'path': path}
+            )
             continue
         if key in seen:
             stats['duplicates'] += 1
@@ -112,6 +124,11 @@ def select_targets(listing_paths, mergers, cutoff_weeks: int = CUTOFF_WEEKS,
         paths.append(path)
         stats['recovered'] += 1
         stats['recovered_paths'].append(path)
+        stats['recovered_mergers'].append(
+            {'merger_id': ids_by_key.get(key), 'path': path}
+        )
+
+    stats['targets'] = len(paths)
 
     return paths, stats
 
@@ -158,6 +175,10 @@ def main():
         default=CUTOFF_WEEKS,
         help=f'Weeks after determination to cut off (default: {CUTOFF_WEEKS})'
     )
+    parser.add_argument(
+        '--stats-json',
+        help='Write the selection stats to this path as JSON (for run summaries)'
+    )
     args = parser.parse_args()
 
     listing_paths = [line.strip() for line in sys.stdin if line.strip()]
@@ -168,6 +189,10 @@ def main():
         cutoff_weeks=args.cutoff_weeks,
         scrape_all=args.all,
     )
+
+    if args.stats_json:
+        with open(args.stats_json, 'w', encoding='utf-8') as f:
+            json.dump(stats, f, indent=2)
 
     if stats['duplicates']:
         print(f"    Listing served {stats['duplicates']} duplicate link(s)", file=sys.stderr)

--- a/scripts/tests/README.md
+++ b/scripts/tests/README.md
@@ -17,6 +17,7 @@ without network or PDF tooling installed.
 | `test_pipeline.py` | End-to-end extraction behaviour against fixture HTML. |
 | `test_cutoff_io.py` | `cutoff.py` skip logic and CLI output. |
 | `test_scrape_targets.py` | Fetch-list selection in `scrape_targets.py`: cutoff skipping, de-duplication, and recovery of matters the register listing drops. |
+| `test_scrape_summary.py` | Run-summary rendering in `scrape_summary.py`: scraped merger IDs, changed pages, cutoff skips and fetch failures. |
 | `test_embed.py` | `embed.py` chunking and metadata serialisation. |
 | `test_generate_weekly_digest.py` | Bucketing + dedup vs. the prior week's digest. |
 | `test_merger_filters.py` | Canonical loaders and predicates in `merger_filters.py`. |

--- a/scripts/tests/test_scrape_summary.py
+++ b/scripts/tests/test_scrape_summary.py
@@ -1,0 +1,158 @@
+"""Tests for scrape_summary.py — the scrape run's step-summary Markdown.
+
+The summary exists for spot checking: when an ACCC register email says a
+matter changed, the run's summary has to show whether that merger ID was
+fetched at all, and whether its page actually changed.
+"""
+
+import json
+import os
+import sys
+import unittest.mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+sys.modules.setdefault('pdfplumber', unittest.mock.MagicMock())
+sys.modules.setdefault('markdownify', unittest.mock.MagicMock())
+sys.modules.setdefault('requests', unittest.mock.MagicMock())
+
+from scrape_summary import (INLINE_LIMIT, load_changed_ids, load_fetched,
+                            load_stats, render)
+
+
+def _report(tmp_path, fetched_rows=None, stats=None):
+    if fetched_rows is not None:
+        (tmp_path / 'fetched.tsv').write_text(
+            ''.join(f'{s}\t{m}\t{p}\n' for s, m, p in fetched_rows)
+        )
+    if stats is not None:
+        (tmp_path / 'targets.json').write_text(json.dumps(stats))
+    return str(tmp_path)
+
+
+class TestLoadFetched:
+    def test_splits_ok_from_failed(self, tmp_path):
+        report = _report(tmp_path, [('ok', 'MN-1', '/a'), ('failed', 'UNKNOWN', '/b')])
+
+        ok, failed = load_fetched(report)
+
+        assert [e['merger_id'] for e in ok] == ['MN-1']
+        assert [e['path'] for e in failed] == ['/b']
+
+    def test_missing_file(self, tmp_path):
+        assert load_fetched(str(tmp_path)) == ([], [])
+
+    def test_malformed_rows_are_ignored(self, tmp_path):
+        report = _report(tmp_path, None)
+        (tmp_path / 'fetched.tsv').write_text('ok\tMN-1\n\nok\tMN-2\t/b\n')
+
+        ok, failed = load_fetched(report)
+
+        assert [e['merger_id'] for e in ok] == ['MN-2']
+        assert failed == []
+
+
+class TestLoadStats:
+    def test_missing_file(self, tmp_path):
+        assert load_stats(str(tmp_path)) == {}
+
+    def test_malformed_json(self, tmp_path):
+        (tmp_path / 'targets.json').write_text('{not json')
+        assert load_stats(str(tmp_path)) == {}
+
+    def test_reads_stats(self, tmp_path):
+        report = _report(tmp_path, stats={'listing': 7})
+        assert load_stats(report)['listing'] == 7
+
+
+class TestLoadChangedIds:
+    def test_keys_off_the_matter_filename(self, tmp_path):
+        path = tmp_path / 'changed.txt'
+        path.write_text('data/raw/matters/MN-100123.html\n'
+                        'data/raw/matters/WA-100456.html\n')
+
+        assert load_changed_ids(str(path)) == {'MN-100123', 'WA-100456'}
+
+    def test_ignores_attachments_and_other_files(self, tmp_path):
+        path = tmp_path / 'changed.txt'
+        path.write_text('data/raw/matters/MN-1/questionnaire.pdf\n'
+                        'data/raw/acquisitions-register.html\n'
+                        'data/processed/mergers.json\n')
+
+        assert load_changed_ids(str(path)) == set()
+
+    def test_strips_quoting_git_adds_to_unusual_paths(self, tmp_path):
+        path = tmp_path / 'changed.txt'
+        path.write_text('"data/raw/matters/MN-100123.html"\n')
+
+        assert load_changed_ids(str(path)) == {'MN-100123'}
+
+    def test_no_file_given(self):
+        assert load_changed_ids(None) == set()
+
+
+class TestRender:
+    def test_lists_every_scraped_merger_id(self):
+        out = render({}, [{'merger_id': 'MN-2', 'path': '/b'},
+                          {'merger_id': 'MN-1', 'path': '/a'}], [], set())
+
+        assert '**Merger IDs scraped (2):** `MN-1`, `MN-2`' in out
+
+    def test_flags_which_pages_changed(self):
+        fetched = [{'merger_id': 'MN-1', 'path': '/a'},
+                   {'merger_id': 'MN-2', 'path': '/b'}]
+
+        out = render({}, fetched, [], {'MN-2'})
+
+        assert '**Changed this run (1):** `MN-2`' in out
+        assert '| Pages changed | 1 |' in out
+
+    def test_ignores_changed_pages_the_run_did_not_fetch(self):
+        # A page left dirty by an earlier run is not this run's doing.
+        out = render({}, [{'merger_id': 'MN-1', 'path': '/a'}], [], {'MN-9'})
+
+        assert '| Pages changed | 0 |' in out
+        assert 'MN-9' not in out
+
+    def test_names_matters_skipped_past_cutoff(self):
+        stats = {'skipped': 1,
+                 'skipped_mergers': [{'merger_id': 'MN-5', 'path': '/e'}]}
+
+        out = render(stats, [], [], set())
+
+        assert '| Skipped (past cutoff) | 1 |' in out
+        assert '`MN-5`' in out
+
+    def test_names_matters_recovered_from_outside_the_listing(self):
+        stats = {'recovered': 1,
+                 'recovered_mergers': [{'merger_id': 'MN-6', 'path': '/f'}]}
+
+        out = render(stats, [], [], set())
+
+        assert 'Recovered from outside the listing (1):** `MN-6`' in out
+
+    def test_reports_fetch_failures(self):
+        out = render({}, [], [{'merger_id': 'UNKNOWN', 'path': '/broken'}], set())
+
+        assert '| Fetch failures | 1 |' in out
+        assert '`/broken`' in out
+
+    def test_long_lists_are_collapsed(self):
+        fetched = [{'merger_id': f'MN-{i}', 'path': f'/{i}'}
+                   for i in range(INLINE_LIMIT + 1)]
+
+        out = render({}, fetched, [], set())
+
+        assert '<details>' in out
+        assert f'<summary>Merger IDs scraped ({INLINE_LIMIT + 1})</summary>' in out
+
+    def test_empty_run_says_so(self):
+        out = render({'listing': 0}, [], [], set())
+
+        assert 'No matter pages were fetched.' in out
+        assert 'No matter pages changed in this run.' in out
+
+    def test_no_report_at_all(self):
+        out = render({}, [], [], set())
+
+        assert 'No scrape report was produced' in out

--- a/scripts/tests/test_scrape_targets.py
+++ b/scripts/tests/test_scrape_targets.py
@@ -152,6 +152,35 @@ class TestSelectTargets:
         assert stats['listing'] == 1
 
 
+class TestSelectTargetsStats:
+    """Stats feed the run summary, which is read to spot check a scrape."""
+
+    def test_names_the_mergers_skipped_past_cutoff(self):
+        mergers = [_completed('MN-2', 'settled-deal')]
+
+        _, stats = select_targets([f'{REGISTER}/settled-deal'], mergers)
+
+        assert stats['skipped_mergers'] == [
+            {'merger_id': 'MN-2', 'path': f'{REGISTER}/settled-deal'}
+        ]
+
+    def test_names_the_mergers_recovered_from_outside_the_listing(self):
+        mergers = [_active('MN-3', 'dropped-deal')]
+
+        _, stats = select_targets([], mergers)
+
+        assert stats['recovered_mergers'] == [
+            {'merger_id': 'MN-3', 'path': f'{REGISTER}/dropped-deal'}
+        ]
+
+    def test_counts_the_targets_returned(self):
+        mergers = [_active('MN-3', 'dropped-deal')]
+
+        paths, stats = select_targets([f'{REGISTER}/new-deal'], mergers)
+
+        assert stats['targets'] == len(paths) == 2
+
+
 class TestLoadMergers:
     def test_missing_file(self, tmp_path):
         assert load_mergers(str(tmp_path / 'nope.json')) == []


### PR DESCRIPTION
Changes reported in ACCC register emails have been going missing from the
pipeline's output, with no way to tell from a run whether the matter was
fetched at all. Add a run report so a run can be checked against the email
that triggered it.

scrape.sh now writes a report into SCRAPE_REPORT_DIR when that is set: a
manifest of every fetch (status, merger ID, path) plus the selection stats
from scrape_targets.py, which now also names the matters it skipped past
cutoff and the ones it recovered from outside the listing rather than only
counting them.

scrape_summary.py renders that into Markdown for the job's step summary:
counts, the merger IDs fetched, which of their pages actually changed, and
the matters that were never fetched because they are past cutoff — the case
most likely to explain a change that never lands.