### PR TITLE
Show Phase 1 clearance rate and Phase 2 legs on refiled notifications

### DIFF
--- a/merger-tracker/frontend/public/data/refiled-notifications.json
+++ b/merger-tracker/frontend/public/data/refiled-notifications.json
@@ -10,7 +10,10 @@
       "notification_filed_date": "2026-07-22T12:00:00Z",
       "notification_status": "Under assessment",
       "notification_determination": null,
-      "notification_determination_date": null
+      "notification_determination_date": null,
+      "notification_phase_1_determination": null,
+      "notification_phase_1_end_date": null,
+      "notification_end_of_determination_period": "2026-09-02T12:00:00Z"
     },
     {
       "waiver_id": "WA-85016",
@@ -22,7 +25,10 @@
       "notification_filed_date": "2026-07-01T12:00:00Z",
       "notification_status": "Under assessment",
       "notification_determination": null,
-      "notification_determination_date": null
+      "notification_determination_date": null,
+      "notification_phase_1_determination": "Referred to phase 2",
+      "notification_phase_1_end_date": "2026-08-18T12:00:00Z",
+      "notification_end_of_determination_period": "2027-01-12T12:00:00Z"
     }
   ],
   "completed": [
@@ -36,7 +42,10 @@
       "notification_filed_date": "2026-07-15T12:00:00Z",
       "notification_status": "Assessment completed",
       "notification_determination": "Approved",
-      "notification_determination_date": "2026-08-13T12:00:00Z"
+      "notification_determination_date": "2026-08-13T12:00:00Z",
+      "notification_phase_1_determination": "Approved",
+      "notification_phase_1_end_date": "2026-08-13T12:00:00Z",
+      "notification_end_of_determination_period": "2026-08-26T12:00:00Z"
     },
     {
       "waiver_id": "WA-01094",
@@ -48,7 +57,10 @@
       "notification_filed_date": "2026-07-10T12:00:00Z",
       "notification_status": "Assessment completed",
       "notification_determination": "Approved",
-      "notification_determination_date": "2026-08-05T12:00:00Z"
+      "notification_determination_date": "2026-08-05T12:00:00Z",
+      "notification_phase_1_determination": "Approved",
+      "notification_phase_1_end_date": "2026-08-05T12:00:00Z",
+      "notification_end_of_determination_period": "2026-08-21T12:00:00Z"
     },
     {
       "waiver_id": "WA-25010",
@@ -60,7 +72,10 @@
       "notification_filed_date": "2026-06-25T12:00:00Z",
       "notification_status": "Assessment completed",
       "notification_determination": "Approved",
-      "notification_determination_date": "2026-07-27T12:00:00Z"
+      "notification_determination_date": "2026-07-27T12:00:00Z",
+      "notification_phase_1_determination": "Approved",
+      "notification_phase_1_end_date": "2026-07-27T12:00:00Z",
+      "notification_end_of_determination_period": "2026-08-06T12:00:00Z"
     },
     {
       "waiver_id": "WA-10008",
@@ -72,7 +87,10 @@
       "notification_filed_date": "2026-06-04T12:00:00Z",
       "notification_status": "Assessment completed",
       "notification_determination": "Approved",
-      "notification_determination_date": "2026-07-01T12:00:00Z"
+      "notification_determination_date": "2026-07-01T12:00:00Z",
+      "notification_phase_1_determination": "Approved",
+      "notification_phase_1_end_date": "2026-07-01T12:00:00Z",
+      "notification_end_of_determination_period": "2026-07-17T12:00:00Z"
     },
     {
       "waiver_id": "WA-20010",
@@ -84,7 +102,10 @@
       "notification_filed_date": "2026-05-13T12:00:00Z",
       "notification_status": "Assessment completed",
       "notification_determination": "Approved",
-      "notification_determination_date": "2026-06-24T12:00:00Z"
+      "notification_determination_date": "2026-06-24T12:00:00Z",
+      "notification_phase_1_determination": "Approved",
+      "notification_phase_1_end_date": "2026-06-24T12:00:00Z",
+      "notification_end_of_determination_period": "2026-06-26T12:00:00Z"
     },
     {
       "waiver_id": "WA-65011",
@@ -96,7 +117,10 @@
       "notification_filed_date": "2026-05-12T12:00:00Z",
       "notification_status": "Assessment completed",
       "notification_determination": "Approved",
-      "notification_determination_date": "2026-06-09T12:00:00Z"
+      "notification_determination_date": "2026-06-09T12:00:00Z",
+      "notification_phase_1_determination": "Approved",
+      "notification_phase_1_end_date": "2026-06-09T12:00:00Z",
+      "notification_end_of_determination_period": "2026-06-25T12:00:00Z"
     },
     {
       "waiver_id": "WA-01087",
@@ -108,7 +132,10 @@
       "notification_filed_date": "2026-04-08T12:00:00Z",
       "notification_status": "Assessment completed",
       "notification_determination": "Approved",
-      "notification_determination_date": "2026-05-04T12:00:00Z"
+      "notification_determination_date": "2026-05-04T12:00:00Z",
+      "notification_phase_1_determination": "Approved",
+      "notification_phase_1_end_date": "2026-05-04T12:00:00Z",
+      "notification_end_of_determination_period": "2026-05-21T12:00:00Z"
     },
     {
       "waiver_id": "WA-70003",
@@ -120,7 +147,10 @@
       "notification_filed_date": "2026-03-23T12:00:00Z",
       "notification_status": "Assessment completed",
       "notification_determination": "Approved",
-      "notification_determination_date": "2026-04-16T12:00:00Z"
+      "notification_determination_date": "2026-04-16T12:00:00Z",
+      "notification_phase_1_determination": "Approved",
+      "notification_phase_1_end_date": "2026-04-16T12:00:00Z",
+      "notification_end_of_determination_period": "2026-05-07T12:00:00Z"
     },
     {
       "waiver_id": "WA-35003",
@@ -132,7 +162,10 @@
       "notification_filed_date": "2026-02-19T12:00:00Z",
       "notification_status": "Assessment completed",
       "notification_determination": "Approved",
-      "notification_determination_date": "2026-03-17T12:00:00Z"
+      "notification_determination_date": "2026-03-17T12:00:00Z",
+      "notification_phase_1_determination": "Approved",
+      "notification_phase_1_end_date": "2026-03-17T12:00:00Z",
+      "notification_end_of_determination_period": "2026-04-07T12:00:00Z"
     },
     {
       "waiver_id": "WA-65003",
@@ -144,18 +177,27 @@
       "notification_filed_date": "2026-02-18T12:00:00Z",
       "notification_status": "Assessment completed",
       "notification_determination": "Approved",
-      "notification_determination_date": "2026-03-12T12:00:00Z"
+      "notification_determination_date": "2026-03-12T12:00:00Z",
+      "notification_phase_1_determination": "Approved",
+      "notification_phase_1_end_date": "2026-03-12T12:00:00Z",
+      "notification_end_of_determination_period": "2026-04-02T12:00:00Z"
     }
   ],
   "count": {
     "current": 2,
     "completed": 10
   },
-  "clearance_rate": {
+  "phase_1_clearance_rate": {
     "cleared": 10,
-    "not_cleared": 0,
-    "total": 10,
-    "rate": 1.0
+    "referred": 1,
+    "total": 11,
+    "rate": 0.909
+  },
+  "straight_phase_1_clearance_rate": {
+    "cleared": 159,
+    "referred": 8,
+    "total": 167,
+    "rate": 0.952
   },
   "phase_duration": {
     "average_days": 30.0,

--- a/merger-tracker/frontend/src/pages/RefiledNotifications.jsx
+++ b/merger-tracker/frontend/src/pages/RefiledNotifications.jsx
@@ -11,6 +11,7 @@ import { API_ENDPOINTS } from '../config';
 import { useFetchData } from '../hooks/useFetchData';
 import { mergerPath } from '../utils/slug';
 import { formatDateMedium, calculateDuration } from '../utils/dates';
+import { MERGER_STATUS } from '../constants/mergerStatus';
 import { CARD } from '../utils/classNames';
 import { STATIC_PAGE_META } from '../utils/pageMeta';
 
@@ -45,22 +46,72 @@ const BELOW_LINE = 'absolute top-1/2 mt-2';
 
 // The "days to re-file" pill sits centred between the declined and re-filed
 // dots, clamped to stay inside the track on narrow screens — the same
-// technique Phase2Timeline uses for its NOCC label.
+// technique Phase2Timeline uses for its NOCC label. The "Phase 2" label above
+// the track is centred on its own leg the same way.
 const GAP_HALF = '1.75rem';
+const PHASE_2_HALF = '1.5rem';
+
+// Centre `percent` along the track, clamped so a label sitting near either end
+// stops at the edge instead of hanging off it.
+function clampedLabelStyle(percent, half, translate) {
+  return {
+    left: `clamp(${half}, ${percent}%, calc(100% - ${half}))`,
+    transform: translate,
+  };
+}
 
 function RefiledCard({ pair, showOutcome }) {
+  // A re-filed notification can itself be referred to Phase 2 (MN-40017 was),
+  // so the track carries a third leg: waiver → notification's Phase 1 →
+  // Phase 2. phase_1_determination is the referral for referred matters, the
+  // Phase 1 determination for the rest, so it is what tells the two apart.
+  const referred = pair.notification_phase_1_determination === MERGER_STATUS.REFERRED_TO_PHASE_2;
+  const referralDate = referred ? pair.notification_phase_1_end_date : null;
+  // While a referred matter is still running, the track runs on to the
+  // statutory Phase 2 deadline — otherwise the Phase 2 leg would have nowhere
+  // to go, and the deadline is the more useful endpoint than "today".
+  const phase2Deadline = referred && !showOutcome
+    ? pair.notification_end_of_determination_period
+    : null;
+
   const start = pair.waiver_filed_date;
-  const end = showOutcome ? pair.notification_determination_date : new Date().toISOString();
+  const end = showOutcome
+    ? pair.notification_determination_date
+    : phase2Deadline || new Date().toISOString();
   const declinedPercent = percentAlong(pair.waiver_declined_date, start, end);
   const filedPercent = percentAlong(pair.notification_filed_date, start, end);
+  const referralPercent = percentAlong(referralDate, start, end);
+  // Only worth marking while the track extends past today, i.e. out to a
+  // pending Phase 2 deadline.
+  const todayPercent = phase2Deadline ? percentAlong(new Date().toISOString(), start, end) : null;
   const daysToRefile = calculateDuration(pair.waiver_declined_date, pair.notification_filed_date);
   const gapPercent = declinedPercent !== null && filedPercent !== null
     ? (declinedPercent + filedPercent) / 2
     : null;
-  const gapLabelStyle = gapPercent === null ? null : {
-    left: `clamp(${GAP_HALF}, ${gapPercent}%, calc(100% - ${GAP_HALF}))`,
-    transform: 'translate(-50%, -50%)',
-  };
+  const gapLabelStyle = gapPercent === null
+    ? null
+    : clampedLabelStyle(gapPercent, GAP_HALF, 'translate(-50%, -50%)');
+  const phase2LabelStyle = referralPercent === null
+    ? null
+    : clampedLabelStyle((referralPercent + 100) / 2, PHASE_2_HALF, 'translateX(-50%)');
+
+  const endLabel = showOutcome ? 'Determined' : phase2Deadline ? 'Due by' : 'Today';
+  const endValue = showOutcome
+    ? formatDateMedium(pair.notification_determination_date)
+    : phase2Deadline ? formatDateMedium(phase2Deadline) : 'Ongoing';
+
+  const trackDescription = [
+    `Timeline for ${pair.notification_name}`,
+    `waiver filed ${formatDateMedium(start)}`,
+    `declined ${formatDateMedium(pair.waiver_declined_date)}`,
+    `re-filed as a notification ${formatDateMedium(pair.notification_filed_date)}`,
+    ...(referralDate ? [`referred to Phase 2 ${formatDateMedium(referralDate)}`] : []),
+    showOutcome
+      ? `determined ${formatDateMedium(pair.notification_determination_date)}`
+      : phase2Deadline
+        ? `determination due by ${formatDateMedium(phase2Deadline)}`
+        : 'still under assessment',
+  ].join(', ');
 
   return (
     <li className="py-4 first:pt-0 last:pb-0">
@@ -80,9 +131,11 @@ function RefiledCard({ pair, showOutcome }) {
             {pair.notification_id}
           </p>
         </div>
-        {showOutcome && (
+        {(showOutcome || referred) && (
           <div className="flex-shrink-0">
-            <StatusBadge determination={pair.notification_determination} />
+            <StatusBadge
+              determination={showOutcome ? pair.notification_determination : MERGER_STATUS.REFERRED_TO_PHASE_2}
+            />
           </div>
         )}
       </div>
@@ -94,18 +147,35 @@ function RefiledCard({ pair, showOutcome }) {
         </div>
 
         <div className="relative flex-1 min-w-0 h-11">
+          {referralPercent !== null && (
+            <span
+              className={`${ABOVE_LINE} whitespace-nowrap text-[10px] font-semibold text-phase-2-dark`}
+              style={phase2LabelStyle}
+            >
+              Phase 2
+            </span>
+          )}
+
           <div
             className="absolute inset-x-0 top-1/2 -translate-y-1/2 h-5 rounded-full bg-gray-100"
             role="img"
-            aria-label={`Timeline for ${pair.notification_name}: waiver filed ${formatDateMedium(start)}, declined ${formatDateMedium(pair.waiver_declined_date)}, re-filed as a notification ${formatDateMedium(pair.notification_filed_date)}${showOutcome ? `, determined ${formatDateMedium(pair.notification_determination_date)}` : ', still under assessment'}`}
+            aria-label={trackDescription}
           >
             {declinedPercent !== null && (
               <div className="absolute inset-y-0 left-0 rounded-full bg-phase-1/50" style={{ width: `${declinedPercent}%` }} />
             )}
             {filedPercent !== null && (
               <div
-                className={`absolute inset-y-0 right-0 rounded-full ${showOutcome ? 'bg-accent/60' : 'bg-accent/30'}`}
-                style={{ left: `${filedPercent}%` }}
+                className={`absolute inset-y-0 rounded-full ${showOutcome ? 'bg-accent/60' : 'bg-accent/30'}`}
+                // Stops at the referral when there is one, so the notification's
+                // Phase 1 and its Phase 2 read as separate legs.
+                style={{ left: `${filedPercent}%`, right: `${100 - (referralPercent ?? 100)}%` }}
+              />
+            )}
+            {referralPercent !== null && (
+              <div
+                className={`absolute inset-y-0 right-0 rounded-full ${showOutcome ? 'bg-phase-2/60' : 'bg-phase-2/30'}`}
+                style={{ left: `${referralPercent}%` }}
               />
             )}
             {gapPercent !== null && daysToRefile !== null && (
@@ -130,15 +200,29 @@ function RefiledCard({ pair, showOutcome }) {
                 title={`Re-filed as notification: ${formatDateMedium(pair.notification_filed_date)}`}
               />
             )}
+            {referralPercent !== null && (
+              <div
+                className="absolute top-1/2 h-3 w-3 rounded-full ring-2 ring-white bg-phase-2-dark"
+                style={{ left: `${referralPercent}%`, transform: 'translate(-50%, -50%)' }}
+                title={`Referred to Phase 2: ${formatDateMedium(referralDate)}`}
+              />
+            )}
+            {todayPercent !== null && (
+              <div
+                className="absolute top-1/2 -translate-y-1/2 h-7 w-0.5 bg-gray-900"
+                style={{ left: `${todayPercent}%` }}
+                title="Today"
+              />
+            )}
           </div>
         </div>
 
         <div className="relative w-14 sm:w-20 shrink-0 h-11">
           <span className={`${ABOVE_LINE} inset-x-0 text-left text-[11px] font-medium text-gray-500`}>
-            {showOutcome ? 'Determined' : 'Today'}
+            {endLabel}
           </span>
           <span className={`${BELOW_LINE} inset-x-0 text-left text-xs font-medium text-gray-900`}>
-            {showOutcome ? formatDateMedium(pair.notification_determination_date) : 'Ongoing'}
+            {endValue}
           </span>
         </div>
       </div>
@@ -169,13 +253,6 @@ function RefiledList({ pairs, showOutcome, emptyMessage }) {
 function RefiledNotifications() {
   const { data, loading, error } = useFetchData(API_ENDPOINTS.refiledNotifications, { cacheKey: 'refiled-notifications' });
 
-  // Overall Phase 1 clearance rate, for comparing refiled notifications
-  // against the market as a whole. Non-fatal if it fails to load.
-  const { data: statsData } = useFetchData(
-    data ? API_ENDPOINTS.stats : null,
-    data ? { cacheKey: 'dashboard-stats' } : {}
-  );
-
   if (loading) return <LoadingSpinner />;
   if (error) return <ErrorMessage error={error} />;
 
@@ -189,11 +266,14 @@ function RefiledNotifications() {
       .filter((d) => d !== null)
   );
 
-  const clearanceRate = data?.clearance_rate;
-  const overallClearanceRate = statsData?.clearance_rate;
+  // Share of concluded Phase 1 reviews that cleared rather than being referred
+  // to Phase 2, alongside the same figure for notifications that were never
+  // waivers — the comparison the duration chart below draws too.
+  const clearanceRate = data?.phase_1_clearance_rate;
+  const straightClearanceRate = data?.straight_phase_1_clearance_rate;
   const clearancePct = clearanceRate?.rate != null ? Math.round(clearanceRate.rate * 100) : null;
-  const overallClearancePct = overallClearanceRate?.rate != null
-    ? Math.round(overallClearanceRate.rate * 100)
+  const straightClearancePct = straightClearanceRate?.rate != null
+    ? Math.round(straightClearanceRate.rate * 100)
     : null;
 
   const phaseDuration = data?.phase_duration;
@@ -233,13 +313,11 @@ function RefiledNotifications() {
             icon={<FaCalendarDays />}
           />
           <StatCard
-            title="Clearance rate"
+            title="Phase 1 clearance rate"
             value={clearancePct !== null ? `${clearancePct}%` : 'N/A'}
             subtitle={
-              clearancePct !== null && overallClearancePct !== null
-                // stats.clearance_rate covers every notified merger with a
-                // published final determination, whichever phase decided it.
-                ? `${overallClearancePct}% for all notified mergers`
+              clearancePct !== null && straightClearancePct !== null
+                ? `${straightClearancePct}% filed as Phase 1 from the outset`
                 : undefined
             }
             icon={<FaCircleCheck />}

--- a/merger-tracker/frontend/src/pages/__tests__/RefiledNotifications.test.jsx
+++ b/merger-tracker/frontend/src/pages/__tests__/RefiledNotifications.test.jsx
@@ -1,0 +1,141 @@
+import { render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router';
+import { HelmetProvider } from 'react-helmet-async';
+import RefiledNotifications from '../RefiledNotifications';
+import { dataCache } from '../../utils/dataCache';
+
+function ok(json) {
+  return { ok: true, status: 200, json: () => Promise.resolve(json) };
+}
+
+// A re-filed notification that was itself referred to Phase 2 (the MN-40017
+// shape): Phase 1 ended at the referral, and the review now runs to the
+// statutory Phase 2 deadline rather than to a determination.
+const REFERRED_PAIR = {
+  waiver_id: 'WA-85016',
+  waiver_name: 'Vets Central – Hills Veterinary Centre',
+  waiver_filed_date: '2026-03-16T12:00:00Z',
+  waiver_declined_date: '2026-04-14T12:00:00Z',
+  notification_id: 'MN-40017',
+  notification_name: 'Vets Central – Hills Veterinary Centre',
+  notification_filed_date: '2026-07-01T12:00:00Z',
+  notification_status: 'Under assessment',
+  notification_determination: null,
+  notification_determination_date: null,
+  notification_phase_1_determination: 'Referred to phase 2',
+  notification_phase_1_end_date: '2026-08-18T12:00:00Z',
+  notification_end_of_determination_period: '2027-01-12T12:00:00Z',
+};
+
+const PHASE_1_PAIR = {
+  waiver_id: 'WA-30010',
+  waiver_name: 'MAG South Coast',
+  waiver_filed_date: '2026-04-20T12:00:00Z',
+  waiver_declined_date: '2026-05-15T12:00:00Z',
+  notification_id: 'MN-65026',
+  notification_name: "McCarroll's Automotive Group",
+  notification_filed_date: '2026-07-22T12:00:00Z',
+  notification_status: 'Under assessment',
+  notification_determination: null,
+  notification_determination_date: null,
+  notification_phase_1_determination: null,
+  notification_phase_1_end_date: null,
+  notification_end_of_determination_period: '2026-09-02T12:00:00Z',
+};
+
+function payload(overrides = {}) {
+  return {
+    current: [PHASE_1_PAIR, REFERRED_PAIR],
+    completed: [],
+    count: { current: 2, completed: 0 },
+    phase_1_clearance_rate: { cleared: 10, referred: 1, total: 11, rate: 0.909 },
+    straight_phase_1_clearance_rate: { cleared: 159, referred: 8, total: 167, rate: 0.952 },
+    phase_duration: null,
+    straight_phase_duration: null,
+    ...overrides,
+  };
+}
+
+function renderPage(data) {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(() => Promise.resolve(ok(data)));
+  return render(
+    <HelmetProvider>
+      <MemoryRouter>
+        <RefiledNotifications />
+      </MemoryRouter>
+    </HelmetProvider>
+  );
+}
+
+// Each pair's timeline carries a descriptive aria-label, which is also the
+// handle for the card it sits in (the merger IDs are split across elements).
+function timelineFor(name) {
+  return screen.findByRole('img', { name: new RegExp(`^Timeline for ${name}`) });
+}
+
+async function cardFor(name) {
+  return (await timelineFor(name)).closest('li');
+}
+
+describe('RefiledNotifications', () => {
+  beforeEach(() => {
+    dataCache.clear();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    dataCache.clear();
+  });
+
+  it('reports the Phase 1 clearance rate against the straight-to-Phase-1 baseline', async () => {
+    renderPage(payload());
+
+    const card = (await screen.findByText('Phase 1 clearance rate')).closest('dl');
+    expect(within(card).getByText('91%')).toBeInTheDocument();
+    expect(within(card).getByText('95% filed as Phase 1 from the outset')).toBeInTheDocument();
+  });
+
+  it('shows a referred matter as being in Phase 2, running to its deadline', async () => {
+    renderPage(payload());
+
+    const card = await cardFor('Vets Central – Hills Veterinary Centre');
+    expect(within(card).getByText('Referred to phase 2')).toBeInTheDocument();
+    expect(within(card).getByText('Phase 2')).toBeInTheDocument();
+    // The track ends at the statutory Phase 2 deadline, not at "today".
+    expect(within(card).getByText('Due by')).toBeInTheDocument();
+    expect(within(card).getByText('12 Jan 2027')).toBeInTheDocument();
+    expect(await timelineFor('Vets Central – Hills Veterinary Centre')).toHaveAccessibleName(
+      /referred to Phase 2 18 Aug 2026, determination due by 12 Jan 2027$/
+    );
+  });
+
+  it('leaves a matter still in Phase 1 running to today', async () => {
+    renderPage(payload());
+
+    const card = await cardFor("McCarroll's Automotive Group");
+    expect(within(card).getByText('Today')).toBeInTheDocument();
+    expect(within(card).getByText('Ongoing')).toBeInTheDocument();
+    expect(within(card).queryByText('Phase 2')).not.toBeInTheDocument();
+    expect(within(card).queryByText('Referred to phase 2')).not.toBeInTheDocument();
+  });
+
+  it('draws the Phase 2 leg on a completed matter that went through Phase 2', async () => {
+    const determined = {
+      ...REFERRED_PAIR,
+      notification_status: 'Assessment completed',
+      notification_determination: 'Approved',
+      notification_determination_date: '2026-12-10T12:00:00Z',
+    };
+    renderPage(payload({ current: [], completed: [determined], count: { current: 0, completed: 1 } }));
+
+    const card = await cardFor('Vets Central – Hills Veterinary Centre');
+    // The determination, not the referral, is what the badge and the track end
+    // report once the matter is done.
+    expect(within(card).getByText('Approved')).toBeInTheDocument();
+    expect(within(card).getByText('Determined')).toBeInTheDocument();
+    expect(within(card).getByText('10 Dec 2026')).toBeInTheDocument();
+    expect(within(card).getByText('Phase 2')).toBeInTheDocument();
+  });
+});

--- a/scripts/static_data/outputs/refiled.py
+++ b/scripts/static_data/outputs/refiled.py
@@ -16,7 +16,6 @@ from ..filters import filter_notifications
 #: the cleared/declined split used elsewhere (e.g. OUTCOME_DOT_COLORS on the
 #: frontend, deals_cleared in the weekly digest).
 CLEARED_DETERMINATIONS = merger_status.CLEARED_DETERMINATIONS
-NOT_CLEARED_DETERMINATIONS = merger_status.BLOCKED_DETERMINATIONS
 
 
 def _entry(waiver: dict, notification: dict) -> dict:
@@ -31,22 +30,43 @@ def _entry(waiver: dict, notification: dict) -> dict:
         'notification_status': notification.get('status'),
         'notification_determination': notification.get('accc_determination'),
         'notification_determination_date': notification.get('determination_publication_date'),
+        # How Phase 1 ended and when: 'Referred to phase 2' plus the referral
+        # date for a matter sent to Phase 2, the Phase 1 determination
+        # otherwise, both None while Phase 1 is still running. The timeline
+        # card draws its Phase 2 leg from these.
+        'notification_phase_1_determination': notification.get('phase_1_determination'),
+        'notification_phase_1_end_date': notification.get('phase_1_determination_date'),
+        # Statutory Phase 2 deadline — the right-hand end of the timeline for a
+        # referred matter that hasn't been determined yet.
+        'notification_end_of_determination_period': notification.get('end_of_determination_period'),
     }
 
 
-def _clearance_rate(completed: list) -> dict:
-    """Cleared-vs-blocked split for completed refiled notifications.
+def _phase_1_clearance_rate(notifications: list) -> dict:
+    """Cleared-at-Phase-1 vs referred-to-Phase-2 split for concluded reviews.
 
-    Only counts determinations recognised as cleared or not cleared (see
-    :data:`CLEARED_DETERMINATIONS`), so a stray value can't silently distort
-    the rate.
+    Counts every notification whose Phase 1 has ended — ``phase_1_determination``
+    holds the referral for matters sent to Phase 2 and the determination for the
+    rest, and is None while Phase 1 is still running. Measuring the Phase 1
+    outcome (rather than the final determination) means a referral counts
+    against the rate as soon as it happens instead of waiting months for the
+    Phase 2 result, and puts the rate on the same denominator as
+    :func:`_phase_duration`. Outcomes that are neither a clearance nor a
+    referral are skipped: Phase 1 does not block a merger, so a stray value
+    can't silently distort the rate.
     """
-    cleared = sum(1 for e in completed if e['notification_determination'] in CLEARED_DETERMINATIONS)
-    not_cleared = sum(1 for e in completed if e['notification_determination'] in NOT_CLEARED_DETERMINATIONS)
-    total = cleared + not_cleared
+    cleared = sum(
+        1 for m in notifications
+        if m.get('phase_1_determination') in CLEARED_DETERMINATIONS
+    )
+    referred = sum(
+        1 for m in notifications
+        if m.get('phase_1_determination') == merger_status.REFERRED_TO_PHASE_2
+    )
+    total = cleared + referred
     return {
         'cleared': cleared,
-        'not_cleared': not_cleared,
+        'referred': referred,
         'total': total,
         'rate': round(cleared / total, 3) if total else None,
     }
@@ -87,6 +107,9 @@ def generate(mergers: list) -> dict:
     notifications that were filed as a Phase 1 review from the outset (i.e.
     everything else). Both sides use the same rule: any matter whose Phase 1
     has concluded counts, including referrals still awaiting a Phase 2 outcome.
+    ``phase_1_clearance_rate`` / ``straight_phase_1_clearance_rate`` split the
+    same two populations by Phase 1 outcome — cleared in Phase 1 vs referred to
+    Phase 2.
     """
     by_id = {m.get('merger_id'): m for m in mergers if m.get('merger_id')}
 
@@ -125,7 +148,8 @@ def generate(mergers: list) -> dict:
         'current': current,
         'completed': completed,
         'count': {'current': len(current), 'completed': len(completed)},
-        'clearance_rate': _clearance_rate(completed),
+        'phase_1_clearance_rate': _phase_1_clearance_rate(refiled_notifications),
+        'straight_phase_1_clearance_rate': _phase_1_clearance_rate(straight_notifications),
         'phase_duration': _phase_duration(refiled_notifications),
         'straight_phase_duration': _phase_duration(straight_notifications),
     }

--- a/scripts/tests/test_refiled.py
+++ b/scripts/tests/test_refiled.py
@@ -63,7 +63,8 @@ class TestReturnsValidShape:
             'current': [],
             'completed': [],
             'count': {'current': 0, 'completed': 0},
-            'clearance_rate': {'cleared': 0, 'not_cleared': 0, 'total': 0, 'rate': None},
+            'phase_1_clearance_rate': {'cleared': 0, 'referred': 0, 'total': 0, 'rate': None},
+            'straight_phase_1_clearance_rate': {'cleared': 0, 'referred': 0, 'total': 0, 'rate': None},
             'phase_duration': None,
             'straight_phase_duration': None,
         }
@@ -77,6 +78,8 @@ class TestReturnsValidShape:
             'waiver_id', 'waiver_name', 'waiver_filed_date', 'waiver_declined_date',
             'notification_id', 'notification_name', 'notification_filed_date',
             'notification_status', 'notification_determination', 'notification_determination_date',
+            'notification_phase_1_determination', 'notification_phase_1_end_date',
+            'notification_end_of_determination_period',
         }
 
 
@@ -121,22 +124,98 @@ class TestCurrentVsCompleted:
         assert payload['count'] == {'current': 0, 'completed': 0}
 
 
-class TestClearanceRate:
-    def test_no_completed_pairs(self):
+class TestPhase1ClearanceRate:
+    def test_no_concluded_phase_1_reviews(self):
         payload = refiled.generate([_waiver(), _current_notification()])
-        assert payload['clearance_rate'] == {'cleared': 0, 'not_cleared': 0, 'total': 0, 'rate': None}
+        assert payload['phase_1_clearance_rate'] == {
+            'cleared': 0, 'referred': 0, 'total': 0, 'rate': None,
+        }
 
-    def test_mixed_outcomes(self):
+    def test_referral_counts_against_the_rate_before_its_determination(self):
+        # The Phase 1 outcome is what the rate measures, so a matter sitting in
+        # Phase 2 counts the moment it is referred rather than waiting months
+        # for the Phase 2 determination.
+        cleared = _completed_notification(merger_id='MN-0001', waiver_id='WA-0001')
+        cleared['phase_1_determination'] = 'Approved'
+        cleared['phase_1_determination_date'] = '2025-04-01T09:00:00Z'
+        referred = _current_notification(merger_id='MN-0002', waiver_id='WA-0002')
+        referred['phase_1_determination'] = 'Referred to phase 2'
+        referred['phase_1_determination_date'] = '2025-03-01T09:00:00Z'
         mergers = [
             _waiver(merger_id='WA-0001', notification_id='MN-0001'),
-            _completed_notification(merger_id='MN-0001', waiver_id='WA-0001', determination='Approved'),
+            cleared,
             _waiver(merger_id='WA-0002', notification_id='MN-0002'),
-            _completed_notification(merger_id='MN-0002', waiver_id='WA-0002', determination='Not opposed'),
-            _waiver(merger_id='WA-0003', notification_id='MN-0003'),
-            _completed_notification(merger_id='MN-0003', waiver_id='WA-0003', determination='Declined'),
+            referred,
         ]
         payload = refiled.generate(mergers)
-        assert payload['clearance_rate'] == {'cleared': 2, 'not_cleared': 1, 'total': 3, 'rate': round(2 / 3, 3)}
+        assert payload['phase_1_clearance_rate'] == {
+            'cleared': 1, 'referred': 1, 'total': 2, 'rate': 0.5,
+        }
+
+    def test_open_phase_1_reviews_are_excluded(self):
+        # No Phase 1 outcome yet: counts towards neither side of the rate.
+        cleared = _completed_notification(merger_id='MN-0001', waiver_id='WA-0001')
+        cleared['phase_1_determination'] = 'Approved'
+        cleared['phase_1_determination_date'] = '2025-04-01T09:00:00Z'
+        mergers = [
+            _waiver(merger_id='WA-0001', notification_id='MN-0001'),
+            cleared,
+            _waiver(merger_id='WA-0002', notification_id='MN-0002'),
+            _current_notification(merger_id='MN-0002', waiver_id='WA-0002'),
+        ]
+        payload = refiled.generate(mergers)
+        assert payload['phase_1_clearance_rate'] == {
+            'cleared': 1, 'referred': 0, 'total': 1, 'rate': 1.0,
+        }
+
+    def test_straight_baseline_covers_notifications_that_were_never_waivers(self):
+        refiled_notification = _completed_notification(merger_id='MN-0002', waiver_id='WA-0002')
+        refiled_notification['phase_1_determination'] = 'Referred to phase 2'
+        refiled_notification['phase_1_determination_date'] = '2025-03-15T09:00:00Z'
+        straight_notification = {
+            'merger_id': 'MN-9000',
+            'merger_name': 'Straight notification',
+            'status': 'Assessment completed',
+            'accc_determination': 'Approved',
+            'effective_notification_datetime': '2025-01-01T09:00:00Z',
+            'phase_1_determination': 'Approved',
+            'phase_1_determination_date': '2025-01-20T09:00:00Z',
+            'determination_publication_date': '2025-01-20T09:00:00Z',
+        }
+        mergers = [
+            _waiver(merger_id='WA-0002', notification_id='MN-0002'),
+            refiled_notification,
+            straight_notification,
+        ]
+        payload = refiled.generate(mergers)
+        assert payload['phase_1_clearance_rate'] == {
+            'cleared': 0, 'referred': 1, 'total': 1, 'rate': 0.0,
+        }
+        assert payload['straight_phase_1_clearance_rate'] == {
+            'cleared': 1, 'referred': 0, 'total': 1, 'rate': 1.0,
+        }
+
+
+class TestPhase2Milestones:
+    def test_referred_notification_carries_its_phase_2_milestones(self):
+        referred = _current_notification(merger_id='MN-0005', waiver_id='WA-0005')
+        referred['phase_1_determination'] = 'Referred to phase 2'
+        referred['phase_1_determination_date'] = '2025-03-01T09:00:00Z'
+        referred['end_of_determination_period'] = '2025-09-01T09:00:00Z'
+        mergers = [
+            _waiver(merger_id='WA-0005', notification_id='MN-0005'),
+            referred,
+        ]
+        entry = refiled.generate(mergers)['current'][0]
+        assert entry['notification_phase_1_determination'] == 'Referred to phase 2'
+        assert entry['notification_phase_1_end_date'] == '2025-03-01T09:00:00Z'
+        assert entry['notification_end_of_determination_period'] == '2025-09-01T09:00:00Z'
+
+    def test_notification_still_in_phase_1_has_no_phase_1_outcome(self):
+        mergers = [_waiver(), _current_notification()]
+        entry = refiled.generate(mergers)['current'][0]
+        assert entry['notification_phase_1_determination'] is None
+        assert entry['notification_phase_1_end_date'] is None
 
 
 class TestPhaseDuration:


### PR DESCRIPTION
The clearance-rate card measured final determinations, so a re-filed
notification only counted once its whole review had ended — MN-40017 sat
in Phase 2 without registering anywhere on the page, and the card read
100% off ten cleared matters. Measure the Phase 1 outcome instead:
phase_1_determination holds the referral for matters sent to Phase 2 and
the determination for the rest, so a referral counts against the rate
straight away, on the same denominator as the Phase 1 duration chart
below it (11 reviews, 91%). The baseline it compares against becomes the
same Phase 1 rate for notifications that were never waivers (95%),
replacing the all-determinations figure the card borrowed from
stats.json.

Each pair's timeline gains a third leg for a notification that was itself
referred: the notification's Phase 1 now stops at the referral dot and a
Phase 2 leg runs on from there, out to the statutory determination
deadline while the matter is live ("Due by 12 Jan 2027" rather than
"Today"/"Ongoing"), or to the determination once it lands. The card also
carries a "Referred to phase 2" badge, and a today marker on the track
while the deadline is still ahead.