### PR TITLE
Show the estimated pre-notification start on merger detail pages

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -63,7 +63,7 @@ merger-tracker/frontend/src/
 │   ├── CollapsibleCard.jsx, CardCollapseGrid.jsx, ShowMoreDivider.jsx
 │   ├── UpcomingEventsTimeline.jsx, RecentDeterminationsCards.jsx, RecentMergersCards.jsx
 │   ├── MergerTimeline.jsx, Phase2Timeline.jsx, Phase2NoticeMattersSection.jsx
-│   ├── BusinessDayProgress.jsx, PhaseDurationComparison.jsx
+│   ├── BusinessDayProgress.jsx, PhaseDurationComparison.jsx, PreNotificationEstimate.jsx
 │   ├── DeterminationExplanationSection.jsx, QuestionnaireSection.jsx
 │   ├── IndustryTreemap.jsx, IndustryMergerGroups.jsx
 │   ├── NotificationPanel.jsx, BellIcon.jsx
@@ -75,7 +75,7 @@ merger-tracker/frontend/src/
 ├── hooks/                # useDebounce.js, useFetchData.js, useKeyboardShortcuts.js
 ├── utils/                # dates.js, dataCache.js, lastVisit.js, classNames.js, searchIndex.js,
 │                         #   businessDayProgress.js, fetchAllMergers.js, formatMedian.js,
-│                         #   industryGroups.js, slug.js
+│                         #   industryGroups.js, slug.js, preNotification.js
 └── data/                 # ACT public holidays JSON
                           #   (act-public-holidays.json — source of truth for both the Python
                           #   pipeline and the frontend; authoritative list published at

--- a/merger-tracker/frontend/src/components/PreNotificationEstimate.jsx
+++ b/merger-tracker/frontend/src/components/PreNotificationEstimate.jsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router';
+import { FaPencilAlt } from 'react-icons/fa';
 import { formatDateLong } from '../utils/dates';
 import {
   getPreNotificationEstimate,
@@ -14,6 +15,16 @@ const describe = ({ kind, startDate }) => {
     return `this merger entered pre-notification sometime after ${formatDateLong(startDate)}`;
   }
   return `this merger entered pre-notification around ${formatDateLong(startDate)}`;
+};
+
+/**
+ * The feedback page with the message box already naming the matter, so a
+ * correction arrives attached to the estimate it is about rather than as an
+ * orphaned "the date is wrong".
+ */
+const correctionLink = (mergerId) => {
+  const message = `${mergerId} pre-notification estimate looks wrong. It should be `;
+  return `/feedback?message=${encodeURIComponent(message)}`;
 };
 
 /**
@@ -33,18 +44,17 @@ function PreNotificationEstimate({ merger }) {
       </div>
       <p className="flex-1 min-w-0 text-sm font-medium text-gray-900">
         Our market intelligence suggests that {describe(estimate)}
-        {' '}
-        {/* Kept deliberately quiet — an invitation for the handful of readers
-            who know better, not a call to action for everyone else. */}
-        <span className="text-xs font-normal text-gray-400 whitespace-nowrap">
-          Not quite right?{' '}
-          <Link
-            to="/feedback"
-            className="underline decoration-dotted underline-offset-2 hover:text-primary transition-colors"
-          >
-            Let us know
-          </Link>
-        </span>
+        {/* Kept to a faint pencil: an invitation for the handful of readers who
+            know better, with the wording behind its tooltip rather than in
+            everyone's way. */}
+        <Link
+          to={correctionLink(merger.merger_id)}
+          title="Not quite right? Let us know what it should be"
+          aria-label={`Not quite right? Let us know what the pre-notification estimate for ${merger.merger_id} should be`}
+          className="inline-flex align-baseline ml-1.5 p-1 -m-1 text-gray-300 hover:text-primary transition-colors"
+        >
+          <FaPencilAlt className="h-3 w-3" aria-hidden="true" />
+        </Link>
       </p>
     </div>
   );

--- a/merger-tracker/frontend/src/components/PreNotificationEstimate.jsx
+++ b/merger-tracker/frontend/src/components/PreNotificationEstimate.jsx
@@ -1,9 +1,22 @@
-import { FaRegClock } from 'react-icons/fa';
 import { formatDateLong } from '../utils/dates';
-import { getPreNotificationEstimate } from '../utils/preNotification';
+import {
+  getPreNotificationEstimate,
+  PRE_NOTIFICATION_AFTER,
+  PRE_NOTIFICATION_NONE,
+} from '../utils/preNotification';
+
+const describe = ({ kind, startDate }) => {
+  if (kind === PRE_NOTIFICATION_NONE) {
+    return 'this merger had little or no pre-notification period';
+  }
+  if (kind === PRE_NOTIFICATION_AFTER) {
+    return `this merger entered pre-notification sometime after ${formatDateLong(startDate)}`;
+  }
+  return `this merger entered pre-notification around ${formatDateLong(startDate)}`;
+};
 
 /**
- * Callout on the merger detail page giving the estimated date a matter entered
+ * Callout on the merger detail page giving the estimated start of a matter's
  * pre-notification — the stretch of ACCC engagement that precedes filing and
  * never appears on the public register. Renders nothing when the matter has no
  * usable estimate (see getPreNotificationEstimate).
@@ -15,19 +28,11 @@ function PreNotificationEstimate({ merger }) {
   return (
     <div className="flex items-center gap-3 bg-gray-50/80 rounded-2xl border border-gray-200/60 shadow-card p-4 mb-6">
       <div className="flex-shrink-0 w-9 h-9 rounded-xl bg-gray-100 flex items-center justify-center">
-        <FaRegClock className="h-4 w-4 text-gray-500" aria-hidden="true" />
+        <span className="text-lg leading-none" aria-hidden="true">✨</span>
       </div>
-      <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium text-gray-900">
-          Our market intelligence suggests that this merger entered pre-notification
-          around {formatDateLong(estimate.startDate)}
-        </p>
-        <p className="text-xs text-gray-500 mt-0.5">
-          {estimate.bounds} before it was notified on {formatDateLong(estimate.notifiedDate)}
-          {' · '}
-          estimated from the order the ACCC issued case numbers in, not published by the ACCC
-        </p>
-      </div>
+      <p className="flex-1 min-w-0 text-sm font-medium text-gray-900">
+        Our market intelligence suggests that {describe(estimate)}
+      </p>
     </div>
   );
 }

--- a/merger-tracker/frontend/src/components/PreNotificationEstimate.jsx
+++ b/merger-tracker/frontend/src/components/PreNotificationEstimate.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Link } from 'react-router';
 import { FaRegQuestionCircle } from 'react-icons/fa';
 import { formatDateLong } from '../utils/dates';
@@ -6,6 +7,9 @@ import {
   PRE_NOTIFICATION_AFTER,
   PRE_NOTIFICATION_NONE,
 } from '../utils/preNotification';
+
+/** What the question mark means, said in full wherever there's room to say it. */
+const CORRECTION_PROMPT = 'Not quite right? Let us know what it should be';
 
 const describe = ({ kind, startDate }) => {
   if (kind === PRE_NOTIFICATION_NONE) {
@@ -28,18 +32,19 @@ const correctionLink = (mergerId) => {
 };
 
 /**
- * The invitation to correct the estimate, kept to a muted amber question mark
+ * The invitation to correct the estimate, kept to a muted red question mark
  * with the wording behind its tooltip. Rendered twice at different breakpoints
  * (see below) — only ever one of them visible, so only one reaches the
  * accessibility tree.
  */
-function CorrectionLink({ mergerId, className }) {
+function CorrectionLink({ mergerId, className, onClick }) {
   return (
     <Link
       to={correctionLink(mergerId)}
-      title="Not quite right? Let us know what it should be"
-      aria-label={`Not quite right? Let us know what the pre-notification estimate for ${mergerId} should be`}
-      className={`p-1 -m-1 text-amber-500/60 hover:text-amber-600 transition-colors ${className}`}
+      title={CORRECTION_PROMPT}
+      aria-label={`${CORRECTION_PROMPT} — pre-notification estimate for ${mergerId}`}
+      onClick={onClick}
+      className={`p-1 -m-1 text-red-500/60 hover:text-red-600 transition-colors ${className}`}
     >
       <FaRegQuestionCircle className="h-3.5 w-3.5" aria-hidden="true" />
     </Link>
@@ -53,24 +58,47 @@ function CorrectionLink({ mergerId, className }) {
  * usable estimate (see getPreNotificationEstimate).
  */
 function PreNotificationEstimate({ merger }) {
+  // Touch has no hover, so a tooltip never shows: on a narrow screen the first
+  // tap spells out what the question mark is offering and the second acts on
+  // it. Desktop keeps the tooltip and goes on the first click.
+  const [promptShown, setPromptShown] = useState(false);
   const estimate = getPreNotificationEstimate(merger);
   if (!estimate) return null;
+
+  const revealPrompt = (event) => {
+    // Keyboard activation reports no click detail, and already had the wording
+    // read out as the link's label — it goes straight through.
+    if (promptShown || event.detail === 0) return;
+    event.preventDefault();
+    setPromptShown(true);
+  };
 
   return (
     <div className="flex items-center gap-3 bg-gray-50/80 rounded-2xl border border-gray-200/60 shadow-card p-4 mb-6">
       <div className="flex-shrink-0 w-9 h-9 rounded-xl bg-gray-100 flex items-center justify-center">
         <span className="text-lg leading-none" aria-hidden="true">✨</span>
       </div>
-      <p className="flex-1 min-w-0 text-sm font-medium text-gray-900">
-        Our market intelligence suggests that {describe(estimate)}
-        {/* On a narrow screen the sentence already fills the width, so the
-            question mark trails the last word rather than stealing a column
-            from the wrapping text. */}
-        <CorrectionLink
-          mergerId={merger.merger_id}
-          className="sm:hidden inline-flex align-baseline ml-1.5"
-        />
-      </p>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-gray-900">
+          Our market intelligence suggests that {describe(estimate)}
+          {/* On a narrow screen the sentence already fills the width, so the
+              question mark trails the last word rather than stealing a column
+              from the wrapping text. */}
+          <CorrectionLink
+            mergerId={merger.merger_id}
+            onClick={revealPrompt}
+            className="sm:hidden inline-flex align-baseline ml-1.5"
+          />
+        </p>
+        {promptShown && (
+          <Link
+            to={correctionLink(merger.merger_id)}
+            className="sm:hidden block mt-1.5 text-xs text-red-500/80 hover:text-red-600 transition-colors"
+          >
+            {CORRECTION_PROMPT} →
+          </Link>
+        )}
+      </div>
       {/* With room to spare it sits out at the right edge instead, clear of the
           sentence. */}
       <CorrectionLink

--- a/merger-tracker/frontend/src/components/PreNotificationEstimate.jsx
+++ b/merger-tracker/frontend/src/components/PreNotificationEstimate.jsx
@@ -1,0 +1,35 @@
+import { FaRegClock } from 'react-icons/fa';
+import { formatDateLong } from '../utils/dates';
+import { getPreNotificationEstimate } from '../utils/preNotification';
+
+/**
+ * Callout on the merger detail page giving the estimated date a matter entered
+ * pre-notification — the stretch of ACCC engagement that precedes filing and
+ * never appears on the public register. Renders nothing when the matter has no
+ * usable estimate (see getPreNotificationEstimate).
+ */
+function PreNotificationEstimate({ merger }) {
+  const estimate = getPreNotificationEstimate(merger);
+  if (!estimate) return null;
+
+  return (
+    <div className="flex items-center gap-3 bg-gray-50/80 rounded-2xl border border-gray-200/60 shadow-card p-4 mb-6">
+      <div className="flex-shrink-0 w-9 h-9 rounded-xl bg-gray-100 flex items-center justify-center">
+        <FaRegClock className="h-4 w-4 text-gray-500" aria-hidden="true" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-gray-900">
+          Our market intelligence suggests that this merger entered pre-notification
+          around {formatDateLong(estimate.startDate)}
+        </p>
+        <p className="text-xs text-gray-500 mt-0.5">
+          {estimate.bounds} before it was notified on {formatDateLong(estimate.notifiedDate)}
+          {' · '}
+          estimated from the order the ACCC issued case numbers in, not published by the ACCC
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default PreNotificationEstimate;

--- a/merger-tracker/frontend/src/components/PreNotificationEstimate.jsx
+++ b/merger-tracker/frontend/src/components/PreNotificationEstimate.jsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router';
 import { formatDateLong } from '../utils/dates';
 import {
   getPreNotificationEstimate,
@@ -32,6 +33,18 @@ function PreNotificationEstimate({ merger }) {
       </div>
       <p className="flex-1 min-w-0 text-sm font-medium text-gray-900">
         Our market intelligence suggests that {describe(estimate)}
+        {' '}
+        {/* Kept deliberately quiet — an invitation for the handful of readers
+            who know better, not a call to action for everyone else. */}
+        <span className="text-xs font-normal text-gray-400 whitespace-nowrap">
+          Not quite right?{' '}
+          <Link
+            to="/feedback"
+            className="underline decoration-dotted underline-offset-2 hover:text-primary transition-colors"
+          >
+            Let us know
+          </Link>
+        </span>
       </p>
     </div>
   );

--- a/merger-tracker/frontend/src/components/PreNotificationEstimate.jsx
+++ b/merger-tracker/frontend/src/components/PreNotificationEstimate.jsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router';
-import { FaPencilAlt } from 'react-icons/fa';
+import { FaRegQuestionCircle } from 'react-icons/fa';
 import { formatDateLong } from '../utils/dates';
 import {
   getPreNotificationEstimate,
@@ -28,6 +28,25 @@ const correctionLink = (mergerId) => {
 };
 
 /**
+ * The invitation to correct the estimate, kept to a muted amber question mark
+ * with the wording behind its tooltip. Rendered twice at different breakpoints
+ * (see below) — only ever one of them visible, so only one reaches the
+ * accessibility tree.
+ */
+function CorrectionLink({ mergerId, className }) {
+  return (
+    <Link
+      to={correctionLink(mergerId)}
+      title="Not quite right? Let us know what it should be"
+      aria-label={`Not quite right? Let us know what the pre-notification estimate for ${mergerId} should be`}
+      className={`p-1 -m-1 text-amber-500/60 hover:text-amber-600 transition-colors ${className}`}
+    >
+      <FaRegQuestionCircle className="h-3.5 w-3.5" aria-hidden="true" />
+    </Link>
+  );
+}
+
+/**
  * Callout on the merger detail page giving the estimated start of a matter's
  * pre-notification — the stretch of ACCC engagement that precedes filing and
  * never appears on the public register. Renders nothing when the matter has no
@@ -44,18 +63,20 @@ function PreNotificationEstimate({ merger }) {
       </div>
       <p className="flex-1 min-w-0 text-sm font-medium text-gray-900">
         Our market intelligence suggests that {describe(estimate)}
-        {/* Kept to a faint pencil: an invitation for the handful of readers who
-            know better, with the wording behind its tooltip rather than in
-            everyone's way. */}
-        <Link
-          to={correctionLink(merger.merger_id)}
-          title="Not quite right? Let us know what it should be"
-          aria-label={`Not quite right? Let us know what the pre-notification estimate for ${merger.merger_id} should be`}
-          className="inline-flex align-baseline ml-1.5 p-1 -m-1 text-gray-300 hover:text-primary transition-colors"
-        >
-          <FaPencilAlt className="h-3 w-3" aria-hidden="true" />
-        </Link>
+        {/* On a narrow screen the sentence already fills the width, so the
+            question mark trails the last word rather than stealing a column
+            from the wrapping text. */}
+        <CorrectionLink
+          mergerId={merger.merger_id}
+          className="sm:hidden inline-flex align-baseline ml-1.5"
+        />
       </p>
+      {/* With room to spare it sits out at the right edge instead, clear of the
+          sentence. */}
+      <CorrectionLink
+        mergerId={merger.merger_id}
+        className="hidden sm:inline-flex flex-shrink-0"
+      />
     </div>
   );
 }

--- a/merger-tracker/frontend/src/components/__tests__/PreNotificationEstimate.test.jsx
+++ b/merger-tracker/frontend/src/components/__tests__/PreNotificationEstimate.test.jsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
 import { describe, expect, it } from 'vitest';
 import PreNotificationEstimate from '../PreNotificationEstimate';
 
@@ -19,9 +20,15 @@ const merger = (overrides = {}) => ({
   ...overrides,
 });
 
+const renderCallout = (merger) => render(
+  <MemoryRouter>
+    <PreNotificationEstimate merger={merger} />
+  </MemoryRouter>
+);
+
 describe('PreNotificationEstimate', () => {
   it('dates the start of pre-notification for a bracketed estimate', () => {
-    render(<PreNotificationEstimate merger={merger()} />);
+    renderCallout(merger());
 
     expect(
       screen.getByText(/Our market intelligence suggests that this merger entered pre-notification around 7 May 2026/)
@@ -29,7 +36,7 @@ describe('PreNotificationEstimate', () => {
   });
 
   it('dates the start of pre-notification when only a lower bound is proven', () => {
-    render(<PreNotificationEstimate merger={merger({
+    renderCallout(merger({
       pre_notification: {
         estimated_days: 7,
         min_days: 7,
@@ -37,13 +44,13 @@ describe('PreNotificationEstimate', () => {
         id_issued_estimated: '2026-05-20',
         basis: 'lower-bound-only',
       },
-    })} />);
+    }));
 
     expect(screen.getByText(/entered pre-notification around 20 May 2026/)).toBeInTheDocument();
   });
 
   it('gives the date as a floor when only an upper bound is known', () => {
-    render(<PreNotificationEstimate merger={merger({
+    renderCallout(merger({
       pre_notification: {
         estimated_days: 40,
         min_days: null,
@@ -51,7 +58,7 @@ describe('PreNotificationEstimate', () => {
         id_issued_estimated: '2026-04-17',
         basis: 'upper-bound-only',
       },
-    })} />);
+    }));
 
     expect(
       screen.getByText(/entered pre-notification sometime after 17 April 2026/)
@@ -60,7 +67,7 @@ describe('PreNotificationEstimate', () => {
   });
 
   it('reports little or no pre-notification for a nought-day estimate', () => {
-    render(<PreNotificationEstimate merger={merger({
+    renderCallout(merger({
       pre_notification: {
         estimated_days: 0,
         min_days: 0,
@@ -68,7 +75,7 @@ describe('PreNotificationEstimate', () => {
         id_issued_estimated: '2026-05-27',
         basis: 'lower-bound-only',
       },
-    })} />);
+    }));
 
     expect(
       screen.getByText(/this merger had little or no pre-notification period/)
@@ -76,18 +83,23 @@ describe('PreNotificationEstimate', () => {
   });
 
   it('renders nothing for a merger notified in the voluntary period', () => {
-    const { container } = render(<PreNotificationEstimate merger={merger({
+    const { container } = renderCallout(merger({
       original_notification_datetime: '2025-11-03T12:00:00Z',
       effective_notification_datetime: '2025-11-03T12:00:00Z',
-    })} />);
+    }));
 
     expect(container).toBeEmptyDOMElement();
   });
 
+  it('offers a quiet link to the feedback page', () => {
+    renderCallout(merger());
+
+    expect(screen.getByText(/Not quite right\?/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Let us know' })).toHaveAttribute('href', '/feedback');
+  });
+
   it('renders nothing when the merger has no estimate', () => {
-    const { container } = render(
-      <PreNotificationEstimate merger={merger({ pre_notification: undefined })} />
-    );
+    const { container } = renderCallout(merger({ pre_notification: undefined }));
 
     expect(container).toBeEmptyDOMElement();
   });

--- a/merger-tracker/frontend/src/components/__tests__/PreNotificationEstimate.test.jsx
+++ b/merger-tracker/frontend/src/components/__tests__/PreNotificationEstimate.test.jsx
@@ -91,11 +91,15 @@ describe('PreNotificationEstimate', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('offers a quiet link to the feedback page', () => {
+  it('offers a quiet link to the feedback page, naming the matter', () => {
     renderCallout(merger());
 
-    expect(screen.getByText(/Not quite right\?/)).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Let us know' })).toHaveAttribute('href', '/feedback');
+    const link = screen.getByRole('link', { name: /Not quite right/ });
+    expect(link).toHaveAttribute(
+      'href',
+      '/feedback?message=MN-01050%20pre-notification%20estimate%20looks%20wrong.%20It%20should%20be%20'
+    );
+    expect(link).toHaveAttribute('title', 'Not quite right? Let us know what it should be');
   });
 
   it('renders nothing when the merger has no estimate', () => {

--- a/merger-tracker/frontend/src/components/__tests__/PreNotificationEstimate.test.jsx
+++ b/merger-tracker/frontend/src/components/__tests__/PreNotificationEstimate.test.jsx
@@ -94,12 +94,19 @@ describe('PreNotificationEstimate', () => {
   it('offers a quiet link to the feedback page, naming the matter', () => {
     renderCallout(merger());
 
-    const link = screen.getByRole('link', { name: /Not quite right/ });
-    expect(link).toHaveAttribute(
-      'href',
-      '/feedback?message=MN-01050%20pre-notification%20estimate%20looks%20wrong.%20It%20should%20be%20'
-    );
-    expect(link).toHaveAttribute('title', 'Not quite right? Let us know what it should be');
+    // Two copies, one per breakpoint — inline after the sentence on a narrow
+    // screen, out at the right edge on a wide one. Only one is ever displayed.
+    const links = screen.getAllByRole('link', { name: /Not quite right/ });
+    expect(links).toHaveLength(2);
+    for (const link of links) {
+      expect(link).toHaveAttribute(
+        'href',
+        '/feedback?message=MN-01050%20pre-notification%20estimate%20looks%20wrong.%20It%20should%20be%20'
+      );
+      expect(link).toHaveAttribute('title', 'Not quite right? Let us know what it should be');
+    }
+    expect(links.filter(l => l.className.includes('sm:hidden'))).toHaveLength(1);
+    expect(links.filter(l => l.className.includes('hidden sm:inline-flex'))).toHaveLength(1);
   });
 
   it('renders nothing when the merger has no estimate', () => {

--- a/merger-tracker/frontend/src/components/__tests__/PreNotificationEstimate.test.jsx
+++ b/merger-tracker/frontend/src/components/__tests__/PreNotificationEstimate.test.jsx
@@ -1,0 +1,110 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import PreNotificationEstimate from '../PreNotificationEstimate';
+
+const merger = (overrides = {}) => ({
+  merger_id: 'MN-01050',
+  original_notification_datetime: '2026-05-27T12:00:00Z',
+  effective_notification_datetime: '2026-05-27T12:00:00Z',
+  pre_notification: {
+    estimated_days: 20,
+    min_days: 12,
+    max_days: 34,
+    id_issued_estimated: '2026-05-07',
+    id_issued_before: '2026-05-15',
+    id_issued_after: '2026-04-23',
+    basis: 'bracketed',
+    method_version: 1,
+  },
+  ...overrides,
+});
+
+describe('PreNotificationEstimate', () => {
+  it('states the estimated date pre-notification began', () => {
+    render(<PreNotificationEstimate merger={merger()} />);
+
+    expect(screen.getByText(/entered pre-notification around 7 May 2026/)).toBeInTheDocument();
+  });
+
+  it('shows both bounds for a bracketed estimate', () => {
+    render(<PreNotificationEstimate merger={merger()} />);
+
+    expect(
+      screen.getByText(/Between 12 and 34 days before it was notified on 27 May 2026/)
+    ).toBeInTheDocument();
+  });
+
+  it('states a floor when only a lower bound is proven', () => {
+    render(<PreNotificationEstimate merger={merger({
+      pre_notification: {
+        estimated_days: 7,
+        min_days: 7,
+        max_days: null,
+        id_issued_estimated: '2026-05-20',
+        basis: 'lower-bound-only',
+      },
+    })} />);
+
+    expect(screen.getByText(/At least 7 days before/)).toBeInTheDocument();
+  });
+
+  it('states a ceiling when only an upper bound is known', () => {
+    render(<PreNotificationEstimate merger={merger({
+      pre_notification: {
+        estimated_days: 40,
+        min_days: null,
+        max_days: 40,
+        id_issued_estimated: '2026-04-17',
+        basis: 'upper-bound-only',
+      },
+    })} />);
+
+    expect(screen.getByText(/No more than 40 days before/)).toBeInTheDocument();
+  });
+
+  it('states the ceiling alone when the bracket rests on a nought-day floor', () => {
+    render(<PreNotificationEstimate merger={merger({
+      pre_notification: {
+        estimated_days: 11,
+        min_days: 0,
+        max_days: 56,
+        id_issued_estimated: '2026-05-16',
+        basis: 'bracketed',
+      },
+    })} />);
+
+    expect(screen.getByText(/No more than 56 days before/)).toBeInTheDocument();
+    expect(screen.queryByText(/Between 0 and/)).not.toBeInTheDocument();
+  });
+
+  it('renders nothing for a merger notified in the voluntary period', () => {
+    const { container } = render(<PreNotificationEstimate merger={merger({
+      original_notification_datetime: '2025-11-03T12:00:00Z',
+      effective_notification_datetime: '2025-11-03T12:00:00Z',
+    })} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the estimate collapses to the filing date', () => {
+    const { container } = render(<PreNotificationEstimate merger={merger({
+      pre_notification: {
+        estimated_days: 0,
+        min_days: 0,
+        max_days: null,
+        id_issued_estimated: '2026-05-27',
+        basis: 'lower-bound-only',
+      },
+    })} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the merger has no estimate', () => {
+    const { container } = render(
+      <PreNotificationEstimate merger={merger({ pre_notification: undefined })} />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/merger-tracker/frontend/src/components/__tests__/PreNotificationEstimate.test.jsx
+++ b/merger-tracker/frontend/src/components/__tests__/PreNotificationEstimate.test.jsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { describe, expect, it } from 'vitest';
 import PreNotificationEstimate from '../PreNotificationEstimate';
 
@@ -107,6 +108,47 @@ describe('PreNotificationEstimate', () => {
     }
     expect(links.filter(l => l.className.includes('sm:hidden'))).toHaveLength(1);
     expect(links.filter(l => l.className.includes('hidden sm:inline-flex'))).toHaveLength(1);
+  });
+
+  it('spells the offer out on the first tap and follows it on the second', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={['/mergers/MN-01050']}>
+        <Routes>
+          <Route path="/mergers/:id" element={<PreNotificationEstimate merger={merger()} />} />
+          <Route path="/feedback" element={<p>feedback page</p>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    const narrowScreenLink = screen
+      .getAllByRole('link', { name: /Not quite right/ })
+      .find(link => link.className.includes('sm:hidden'));
+
+    await user.click(narrowScreenLink);
+    expect(screen.getByText(/Not quite right\? Let us know what it should be/)).toBeInTheDocument();
+    expect(screen.queryByText('feedback page')).not.toBeInTheDocument();
+
+    await user.click(narrowScreenLink);
+    expect(screen.getByText('feedback page')).toBeInTheDocument();
+  });
+
+  it('keeps keyboard activation to a single step', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={['/mergers/MN-01050']}>
+        <Routes>
+          <Route path="/mergers/:id" element={<PreNotificationEstimate merger={merger()} />} />
+          <Route path="/feedback" element={<p>feedback page</p>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    // The link's own label already carries the wording, so there's nothing to
+    // reveal first.
+    await user.tab();
+    await user.keyboard('{Enter}');
+
+    expect(screen.getByText('feedback page')).toBeInTheDocument();
   });
 
   it('renders nothing when the merger has no estimate', () => {

--- a/merger-tracker/frontend/src/components/__tests__/PreNotificationEstimate.test.jsx
+++ b/merger-tracker/frontend/src/components/__tests__/PreNotificationEstimate.test.jsx
@@ -20,21 +20,15 @@ const merger = (overrides = {}) => ({
 });
 
 describe('PreNotificationEstimate', () => {
-  it('states the estimated date pre-notification began', () => {
-    render(<PreNotificationEstimate merger={merger()} />);
-
-    expect(screen.getByText(/entered pre-notification around 7 May 2026/)).toBeInTheDocument();
-  });
-
-  it('shows both bounds for a bracketed estimate', () => {
+  it('dates the start of pre-notification for a bracketed estimate', () => {
     render(<PreNotificationEstimate merger={merger()} />);
 
     expect(
-      screen.getByText(/Between 12 and 34 days before it was notified on 27 May 2026/)
+      screen.getByText(/Our market intelligence suggests that this merger entered pre-notification around 7 May 2026/)
     ).toBeInTheDocument();
   });
 
-  it('states a floor when only a lower bound is proven', () => {
+  it('dates the start of pre-notification when only a lower bound is proven', () => {
     render(<PreNotificationEstimate merger={merger({
       pre_notification: {
         estimated_days: 7,
@@ -45,10 +39,10 @@ describe('PreNotificationEstimate', () => {
       },
     })} />);
 
-    expect(screen.getByText(/At least 7 days before/)).toBeInTheDocument();
+    expect(screen.getByText(/entered pre-notification around 20 May 2026/)).toBeInTheDocument();
   });
 
-  it('states a ceiling when only an upper bound is known', () => {
+  it('gives the date as a floor when only an upper bound is known', () => {
     render(<PreNotificationEstimate merger={merger({
       pre_notification: {
         estimated_days: 40,
@@ -59,35 +53,14 @@ describe('PreNotificationEstimate', () => {
       },
     })} />);
 
-    expect(screen.getByText(/No more than 40 days before/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/entered pre-notification sometime after 17 April 2026/)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/around/)).not.toBeInTheDocument();
   });
 
-  it('states the ceiling alone when the bracket rests on a nought-day floor', () => {
+  it('reports little or no pre-notification for a nought-day estimate', () => {
     render(<PreNotificationEstimate merger={merger({
-      pre_notification: {
-        estimated_days: 11,
-        min_days: 0,
-        max_days: 56,
-        id_issued_estimated: '2026-05-16',
-        basis: 'bracketed',
-      },
-    })} />);
-
-    expect(screen.getByText(/No more than 56 days before/)).toBeInTheDocument();
-    expect(screen.queryByText(/Between 0 and/)).not.toBeInTheDocument();
-  });
-
-  it('renders nothing for a merger notified in the voluntary period', () => {
-    const { container } = render(<PreNotificationEstimate merger={merger({
-      original_notification_datetime: '2025-11-03T12:00:00Z',
-      effective_notification_datetime: '2025-11-03T12:00:00Z',
-    })} />);
-
-    expect(container).toBeEmptyDOMElement();
-  });
-
-  it('renders nothing when the estimate collapses to the filing date', () => {
-    const { container } = render(<PreNotificationEstimate merger={merger({
       pre_notification: {
         estimated_days: 0,
         min_days: 0,
@@ -95,6 +68,17 @@ describe('PreNotificationEstimate', () => {
         id_issued_estimated: '2026-05-27',
         basis: 'lower-bound-only',
       },
+    })} />);
+
+    expect(
+      screen.getByText(/this merger had little or no pre-notification period/)
+    ).toBeInTheDocument();
+  });
+
+  it('renders nothing for a merger notified in the voluntary period', () => {
+    const { container } = render(<PreNotificationEstimate merger={merger({
+      original_notification_datetime: '2025-11-03T12:00:00Z',
+      effective_notification_datetime: '2025-11-03T12:00:00Z',
     })} />);
 
     expect(container).toBeEmptyDOMElement();

--- a/merger-tracker/frontend/src/constants/regime.js
+++ b/merger-tracker/frontend/src/constants/regime.js
@@ -1,0 +1,25 @@
+/**
+ * Key dates in Australia's merger notification regime.
+ *
+ * The new regime opened for business on 1 July 2025, but notifying was
+ * optional until 1 January 2026 — matters filed in between are "voluntary
+ * period" notifications. They behave differently enough (a thin, self-selected
+ * caseload, filed before the register had any waiver applications to date the
+ * case-number counter against) that inferences drawn from the shape of the
+ * caseload don't carry over to them.
+ */
+
+/** First day notification became mandatory. Compared against a YYYY-MM-DD prefix. */
+export const MANDATORY_REGIME_START = '2026-01-01';
+
+/**
+ * Whether a merger was notified before the mandatory regime began.
+ * @param {object} merger - A merger record
+ * @returns {boolean} True when the matter was filed in the voluntary period
+ */
+export const isVoluntaryPeriodNotification = (merger) => {
+  const notified = merger?.original_notification_datetime
+    || merger?.effective_notification_datetime;
+  if (!notified) return false;
+  return notified.slice(0, 10) < MANDATORY_REGIME_START;
+};

--- a/merger-tracker/frontend/src/pages/Feedback.jsx
+++ b/merger-tracker/frontend/src/pages/Feedback.jsx
@@ -1,17 +1,38 @@
 import { useState, useEffect, useRef } from 'react';
+import { useSearchParams } from 'react-router';
 import { FaCheckCircle } from 'react-icons/fa';
 import { FEEDBACK_ENDPOINT, TURNSTILE_SITE_KEY } from '../config';
 import SEO from '../components/SEO';
 import { CARD } from '../utils/classNames';
 
+// Matches the textarea's maxLength — a ?message= link can seed the box, but
+// never with more than someone could have typed into it themselves.
+const MAX_MESSAGE_LENGTH = 5000;
+
 export default function Feedback() {
-  const [message, setMessage] = useState('');
+  // Pages that know what they'd like reported (e.g. the pre-notification
+  // estimate callout) link here with the message part-written, naming the
+  // matter so the reply arrives attached to something.
+  const [searchParams] = useSearchParams();
+  const prefill = (searchParams.get('message') || '').slice(0, MAX_MESSAGE_LENGTH);
+  const [message, setMessage] = useState(prefill);
   const [email, setEmail] = useState('');
   const [status, setStatus] = useState('idle'); // idle | loading | success | error
   const [errorMsg, setErrorMsg] = useState('');
   const [turnstileToken, setTurnstileToken] = useState('');
   const turnstileRef = useRef(null);
   const widgetIdRef = useRef(null);
+  const messageRef = useRef(null);
+
+  // Land in the message box with the caret after the part already written, so
+  // a seeded message is finished rather than edited.
+  useEffect(() => {
+    if (!prefill || !messageRef.current) return;
+    messageRef.current.focus();
+    messageRef.current.setSelectionRange(prefill.length, prefill.length);
+    // Seeded once on arrival; retyping the URL is what changes it after that.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     let scriptEl = null;
@@ -110,11 +131,12 @@ export default function Feedback() {
                 </label>
                 <textarea
                   id="feedback-message"
+                  ref={messageRef}
                   value={message}
                   onChange={(e) => setMessage(e.target.value)}
                   placeholder="Your feedback…"
                   rows={5}
-                  maxLength={5000}
+                  maxLength={MAX_MESSAGE_LENGTH}
                   disabled={status === 'loading'}
                   className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary resize-none disabled:opacity-50"
                 />

--- a/merger-tracker/frontend/src/pages/MergerDetail.jsx
+++ b/merger-tracker/frontend/src/pages/MergerDetail.jsx
@@ -10,6 +10,7 @@ import WaiverBadge from '../components/WaiverBadge';
 import AppealBadge from '../components/AppealBadge';
 import BusinessDayProgress from '../components/BusinessDayProgress';
 import Phase2OddsReveal from '../components/Phase2OddsReveal';
+import PreNotificationEstimate from '../components/PreNotificationEstimate';
 import { getBusinessDayProgress } from '../utils/businessDayProgress';
 import SEO from '../components/SEO';
 import ExternalLinkIcon from '../components/ExternalLinkIcon';
@@ -354,6 +355,10 @@ function MergerDetail() {
             )}
           </div>
         </div>
+
+        {/* Estimated start of pre-notification (inferred, mandatory-regime
+            notifications only) */}
+        <PreNotificationEstimate merger={merger} />
 
         {/* Related Merger Link */}
         {merger.related_merger && (

--- a/merger-tracker/frontend/src/pages/__tests__/Feedback.test.jsx
+++ b/merger-tracker/frontend/src/pages/__tests__/Feedback.test.jsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { HelmetProvider } from 'react-helmet-async';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Feedback from '../Feedback';
+
+const renderAt = (path) => render(
+  <HelmetProvider>
+    <MemoryRouter initialEntries={[path]}>
+      <Feedback />
+    </MemoryRouter>
+  </HelmetProvider>
+);
+
+describe('Feedback', () => {
+  beforeEach(() => {
+    // The page renders a Turnstile widget on mount; stub it out so the form
+    // itself is what's under test.
+    window.turnstile = { render: vi.fn(() => 'widget'), remove: vi.fn(), reset: vi.fn() };
+  });
+
+  it('starts with an empty message box', () => {
+    renderAt('/feedback');
+
+    expect(screen.getByLabelText(/Message/)).toHaveValue('');
+  });
+
+  it('seeds the message box from the ?message= param', () => {
+    renderAt('/feedback?message=MN-01050%20pre-notification%20estimate%20looks%20wrong.%20It%20should%20be%20');
+
+    const box = screen.getByLabelText(/Message/);
+    expect(box).toHaveValue('MN-01050 pre-notification estimate looks wrong. It should be ');
+    // Focused with the caret at the end, ready to be finished rather than edited.
+    expect(box).toHaveFocus();
+    expect(box.selectionStart).toBe(box.value.length);
+  });
+
+  it('caps a seeded message at what the box itself accepts', () => {
+    renderAt(`/feedback?message=${'x'.repeat(6000)}`);
+
+    expect(screen.getByLabelText(/Message/)).toHaveValue('x'.repeat(5000));
+  });
+});

--- a/merger-tracker/frontend/src/utils/preNotification.js
+++ b/merger-tracker/frontend/src/utils/preNotification.js
@@ -1,0 +1,64 @@
+/**
+ * Reading the pipeline's pre-notification estimate (see
+ * scripts/static_data/prenotification.py) into something displayable.
+ *
+ * Pre-notification — the stretch of ACCC engagement before a notification is
+ * formally filed — never appears on the public register. The pipeline infers it
+ * from the order ACCC case numbers were issued in, and hands each notification
+ * a bracket of dates rather than a single fact.
+ */
+
+import { isVoluntaryPeriodNotification } from '../constants/regime';
+
+/**
+ * How confidently the estimate can be stated, keyed off the `basis` the
+ * pipeline recorded. A matter bracketed by waiver applications on both sides of
+ * its case number gets a range; one with evidence from a single side only gets
+ * the bound that side proves.
+ * @param {object} estimate - A merger's pre_notification record
+ * @returns {string} A phrase describing the period, e.g. "At least 7 days"
+ */
+const describeBounds = (estimate) => {
+  const { basis, min_days: minDays, max_days: maxDays } = estimate;
+
+  if (basis === 'bracketed' && minDays > 0 && maxDays != null && minDays !== maxDays) {
+    return `Between ${minDays} and ${maxDays} days`;
+  }
+  // A nought-day floor proves nothing, so a bracket resting on one is stated as
+  // the ceiling alone rather than as a range starting at zero.
+  if (maxDays != null) {
+    return `No more than ${maxDays} days`;
+  }
+  if (minDays > 0) {
+    return `At least ${minDays} days`;
+  }
+  return `About ${estimate.estimated_days} days`;
+};
+
+/**
+ * The estimated start of a merger's pre-notification period, or null when
+ * there's nothing worth showing.
+ *
+ * Skipped for voluntary-period notifications, and for matters where the
+ * estimate collapses to the filing date itself — a nought-day estimate says the
+ * case number was issued the day the notification landed, which is the absence
+ * of a pre-notification period rather than a measurement of one.
+ * @param {object} merger - A merger record
+ * @returns {{startDate: string, notifiedDate: string, bounds: string}|null}
+ */
+export const getPreNotificationEstimate = (merger) => {
+  const estimate = merger?.pre_notification;
+  if (!estimate?.id_issued_estimated) return null;
+  if (!(estimate.estimated_days > 0)) return null;
+  if (isVoluntaryPeriodNotification(merger)) return null;
+
+  const notifiedDate = merger.original_notification_datetime
+    || merger.effective_notification_datetime;
+  if (!notifiedDate) return null;
+
+  return {
+    startDate: estimate.id_issued_estimated,
+    notifiedDate,
+    bounds: describeBounds(estimate),
+  };
+};

--- a/merger-tracker/frontend/src/utils/preNotification.js
+++ b/merger-tracker/frontend/src/utils/preNotification.js
@@ -4,61 +4,46 @@
  *
  * Pre-notification — the stretch of ACCC engagement before a notification is
  * formally filed — never appears on the public register. The pipeline infers it
- * from the order ACCC case numbers were issued in, and hands each notification
- * a bracket of dates rather than a single fact.
+ * from the order ACCC case numbers were issued in, and how firmly it can date
+ * the start decides how the estimate is worded.
  */
 
 import { isVoluntaryPeriodNotification } from '../constants/regime';
 
-/**
- * How confidently the estimate can be stated, keyed off the `basis` the
- * pipeline recorded. A matter bracketed by waiver applications on both sides of
- * its case number gets a range; one with evidence from a single side only gets
- * the bound that side proves.
- * @param {object} estimate - A merger's pre_notification record
- * @returns {string} A phrase describing the period, e.g. "At least 7 days"
- */
-const describeBounds = (estimate) => {
-  const { basis, min_days: minDays, max_days: maxDays } = estimate;
-
-  if (basis === 'bracketed' && minDays > 0 && maxDays != null && minDays !== maxDays) {
-    return `Between ${minDays} and ${maxDays} days`;
-  }
-  // A nought-day floor proves nothing, so a bracket resting on one is stated as
-  // the ceiling alone rather than as a range starting at zero.
-  if (maxDays != null) {
-    return `No more than ${maxDays} days`;
-  }
-  if (minDays > 0) {
-    return `At least ${minDays} days`;
-  }
-  return `About ${estimate.estimated_days} days`;
-};
+/** No pre-notification period is detectable — the case number was issued the day the notification landed. */
+export const PRE_NOTIFICATION_NONE = 'none';
+/** The start is bracketed, so it can be given as a date. */
+export const PRE_NOTIFICATION_AROUND = 'around';
+/** Only the earliest possible start is known, so the date is a floor rather than a point. */
+export const PRE_NOTIFICATION_AFTER = 'after';
 
 /**
- * The estimated start of a merger's pre-notification period, or null when
- * there's nothing worth showing.
+ * How a merger's pre-notification period should be described, or null when
+ * there's nothing to say.
  *
- * Skipped for voluntary-period notifications, and for matters where the
- * estimate collapses to the filing date itself — a nought-day estimate says the
- * case number was issued the day the notification landed, which is the absence
- * of a pre-notification period rather than a measurement of one.
+ * Skipped entirely for voluntary-period notifications, which predate the waiver
+ * applications that date the case-number counter.
  * @param {object} merger - A merger record
- * @returns {{startDate: string, notifiedDate: string, bounds: string}|null}
+ * @returns {{kind: string, startDate: string|null}|null}
  */
 export const getPreNotificationEstimate = (merger) => {
   const estimate = merger?.pre_notification;
   if (!estimate?.id_issued_estimated) return null;
-  if (!(estimate.estimated_days > 0)) return null;
+  if (estimate.estimated_days == null) return null;
   if (isVoluntaryPeriodNotification(merger)) return null;
 
-  const notifiedDate = merger.original_notification_datetime
-    || merger.effective_notification_datetime;
-  if (!notifiedDate) return null;
+  // A nought-day estimate dates the case number to the filing day itself, which
+  // is the absence of a pre-notification period rather than a measurement of
+  // one — there's no date to give.
+  if (estimate.estimated_days <= 0) {
+    return { kind: PRE_NOTIFICATION_NONE, startDate: null };
+  }
 
-  return {
-    startDate: estimate.id_issued_estimated,
-    notifiedDate,
-    bounds: describeBounds(estimate),
-  };
+  // An upper bound alone says only that the case number can't have been issued
+  // before its anchor, so the date is where the period starts at the earliest.
+  const kind = estimate.basis === 'upper-bound-only'
+    ? PRE_NOTIFICATION_AFTER
+    : PRE_NOTIFICATION_AROUND;
+
+  return { kind, startDate: estimate.id_issued_estimated };
 };


### PR DESCRIPTION
The pipeline already infers how long each notification sat in
pre-notification from the order ACCC case numbers were issued in, but
nothing surfaced it. Add a callout on the merger detail page giving the
date the matter is reckoned to have entered pre-notification, with the
bounds behind it and a note that it is inferred rather than published.

Skipped for voluntary-period notifications (filed before 1 January
2026), which predate the waiver applications that date the counter, and
for estimates that collapse to the filing date itself — a nought-day
estimate is the absence of a pre-notification period, not a measurement
of one.