### PR TITLE
Fix pre-notification best estimate for top-of-counter notifications

### DIFF
--- a/data/output/mergers.json
+++ b/data/output/mergers.json
@@ -12401,10 +12401,10 @@
         "method_version": 1
       },
       "pre_notification": {
-        "estimated_days": 56,
+        "estimated_days": 22,
         "min_days": null,
         "max_days": 56,
-        "id_issued_estimated": "2026-06-15",
+        "id_issued_estimated": "2026-07-19",
         "id_issued_before": null,
         "id_issued_after": "2026-06-15",
         "min_days_witness": null,
@@ -15805,10 +15805,10 @@
         "method_version": 1
       },
       "pre_notification": {
-        "estimated_days": 70,
+        "estimated_days": 36,
         "min_days": null,
         "max_days": 70,
-        "id_issued_estimated": "2026-06-05",
+        "id_issued_estimated": "2026-07-09",
         "id_issued_before": null,
         "id_issued_after": "2026-06-05",
         "min_days_witness": null,
@@ -24462,10 +24462,10 @@
         "method_version": 1
       },
       "pre_notification": {
-        "estimated_days": 62,
+        "estimated_days": 28,
         "min_days": null,
         "max_days": 62,
-        "id_issued_estimated": "2026-06-04",
+        "id_issued_estimated": "2026-07-08",
         "id_issued_before": null,
         "id_issued_after": "2026-06-04",
         "min_days_witness": null,
@@ -28031,10 +28031,10 @@
         "method_version": 1
       },
       "pre_notification": {
-        "estimated_days": 60,
+        "estimated_days": 26,
         "min_days": null,
         "max_days": 60,
-        "id_issued_estimated": "2026-06-06",
+        "id_issued_estimated": "2026-07-10",
         "id_issued_before": null,
         "id_issued_after": "2026-06-06",
         "min_days_witness": null,
@@ -35993,10 +35993,10 @@
         "method_version": 1
       },
       "pre_notification": {
-        "estimated_days": 49,
+        "estimated_days": 15,
         "min_days": null,
         "max_days": 49,
-        "id_issued_estimated": "2026-06-27",
+        "id_issued_estimated": "2026-07-31",
         "id_issued_before": null,
         "id_issued_after": "2026-06-27",
         "min_days_witness": null,
@@ -40553,10 +40553,10 @@
         "method_version": 1
       },
       "pre_notification": {
-        "estimated_days": 60,
+        "estimated_days": 26,
         "min_days": null,
         "max_days": 60,
-        "id_issued_estimated": "2026-06-13",
+        "id_issued_estimated": "2026-07-17",
         "id_issued_before": null,
         "id_issued_after": "2026-06-13",
         "min_days_witness": null,
@@ -42984,10 +42984,10 @@
         "method_version": 1
       },
       "pre_notification": {
-        "estimated_days": 49,
+        "estimated_days": 15,
         "min_days": null,
         "max_days": 49,
-        "id_issued_estimated": "2026-06-17",
+        "id_issued_estimated": "2026-07-21",
         "id_issued_before": null,
         "id_issued_after": "2026-06-17",
         "min_days_witness": null,
@@ -48829,10 +48829,10 @@
         "method_version": 1
       },
       "pre_notification": {
-        "estimated_days": 56,
+        "estimated_days": 22,
         "min_days": null,
         "max_days": 56,
-        "id_issued_estimated": "2026-06-19",
+        "id_issued_estimated": "2026-07-23",
         "id_issued_before": null,
         "id_issued_after": "2026-06-19",
         "min_days_witness": null,
@@ -55546,10 +55546,10 @@
         "method_version": 1
       },
       "pre_notification": {
-        "estimated_days": 43,
+        "estimated_days": 9,
         "min_days": null,
         "max_days": 43,
-        "id_issued_estimated": "2026-07-02",
+        "id_issued_estimated": "2026-08-05",
         "id_issued_before": null,
         "id_issued_after": "2026-07-02",
         "min_days_witness": null,
@@ -58326,10 +58326,10 @@
         "method_version": 1
       },
       "pre_notification": {
-        "estimated_days": 58,
+        "estimated_days": 24,
         "min_days": null,
         "max_days": 58,
-        "id_issued_estimated": "2026-06-20",
+        "id_issued_estimated": "2026-07-24",
         "id_issued_before": null,
         "id_issued_after": "2026-06-20",
         "min_days_witness": null,
@@ -64314,10 +64314,10 @@
         "method_version": 1
       },
       "pre_notification": {
-        "estimated_days": 44,
+        "estimated_days": 10,
         "min_days": null,
         "max_days": 44,
-        "id_issued_estimated": "2026-05-30",
+        "id_issued_estimated": "2026-07-03",
         "id_issued_before": null,
         "id_issued_after": "2026-05-30",
         "min_days_witness": null,
@@ -67710,10 +67710,10 @@
         "method_version": 1
       },
       "pre_notification": {
-        "estimated_days": 55,
+        "estimated_days": 21,
         "min_days": null,
         "max_days": 55,
-        "id_issued_estimated": "2026-06-10",
+        "id_issued_estimated": "2026-07-14",
         "id_issued_before": null,
         "id_issued_after": "2026-06-10",
         "min_days_witness": null,

--- a/merger-tracker/frontend/public/data/mergers/MN-05044.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-05044.json
@@ -189,10 +189,10 @@
     "method_version": 1
   },
   "pre_notification": {
-    "estimated_days": 56,
+    "estimated_days": 22,
     "min_days": null,
     "max_days": 56,
-    "id_issued_estimated": "2026-06-15",
+    "id_issued_estimated": "2026-07-19",
     "id_issued_before": null,
     "id_issued_after": "2026-06-15",
     "min_days_witness": null,

--- a/merger-tracker/frontend/public/data/mergers/MN-10027.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-10027.json
@@ -196,10 +196,10 @@
     "method_version": 1
   },
   "pre_notification": {
-    "estimated_days": 70,
+    "estimated_days": 36,
     "min_days": null,
     "max_days": 70,
-    "id_issued_estimated": "2026-06-05",
+    "id_issued_estimated": "2026-07-09",
     "id_issued_before": null,
     "id_issued_after": "2026-06-05",
     "min_days_witness": null,

--- a/merger-tracker/frontend/public/data/mergers/MN-25040.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-25040.json
@@ -333,10 +333,10 @@
     "method_version": 1
   },
   "pre_notification": {
-    "estimated_days": 62,
+    "estimated_days": 28,
     "min_days": null,
     "max_days": 62,
-    "id_issued_estimated": "2026-06-04",
+    "id_issued_estimated": "2026-07-08",
     "id_issued_before": null,
     "id_issued_after": "2026-06-04",
     "min_days_witness": null,

--- a/merger-tracker/frontend/public/data/mergers/MN-30030.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-30030.json
@@ -205,10 +205,10 @@
     "method_version": 1
   },
   "pre_notification": {
-    "estimated_days": 60,
+    "estimated_days": 26,
     "min_days": null,
     "max_days": 60,
-    "id_issued_estimated": "2026-06-06",
+    "id_issued_estimated": "2026-07-10",
     "id_issued_before": null,
     "id_issued_after": "2026-06-06",
     "min_days_witness": null,

--- a/merger-tracker/frontend/public/data/mergers/MN-45024.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-45024.json
@@ -216,10 +216,10 @@
     "method_version": 1
   },
   "pre_notification": {
-    "estimated_days": 49,
+    "estimated_days": 15,
     "min_days": null,
     "max_days": 49,
-    "id_issued_estimated": "2026-06-27",
+    "id_issued_estimated": "2026-07-31",
     "id_issued_before": null,
     "id_issued_after": "2026-06-27",
     "min_days_witness": null,

--- a/merger-tracker/frontend/public/data/mergers/MN-50035.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-50035.json
@@ -311,10 +311,10 @@
     "method_version": 1
   },
   "pre_notification": {
-    "estimated_days": 60,
+    "estimated_days": 26,
     "min_days": null,
     "max_days": 60,
-    "id_issued_estimated": "2026-06-13",
+    "id_issued_estimated": "2026-07-17",
     "id_issued_before": null,
     "id_issued_after": "2026-06-13",
     "min_days_witness": null,

--- a/merger-tracker/frontend/public/data/mergers/MN-55031.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-55031.json
@@ -297,10 +297,10 @@
     "method_version": 1
   },
   "pre_notification": {
-    "estimated_days": 49,
+    "estimated_days": 15,
     "min_days": null,
     "max_days": 49,
-    "id_issued_estimated": "2026-06-17",
+    "id_issued_estimated": "2026-07-21",
     "id_issued_before": null,
     "id_issued_after": "2026-06-17",
     "min_days_witness": null,

--- a/merger-tracker/frontend/public/data/mergers/MN-65031.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-65031.json
@@ -198,10 +198,10 @@
     "method_version": 1
   },
   "pre_notification": {
-    "estimated_days": 56,
+    "estimated_days": 22,
     "min_days": null,
     "max_days": 56,
-    "id_issued_estimated": "2026-06-19",
+    "id_issued_estimated": "2026-07-23",
     "id_issued_before": null,
     "id_issued_after": "2026-06-19",
     "min_days_witness": null,

--- a/merger-tracker/frontend/public/data/mergers/MN-75041.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-75041.json
@@ -207,10 +207,10 @@
     "method_version": 1
   },
   "pre_notification": {
-    "estimated_days": 43,
+    "estimated_days": 9,
     "min_days": null,
     "max_days": 43,
-    "id_issued_estimated": "2026-07-02",
+    "id_issued_estimated": "2026-08-05",
     "id_issued_before": null,
     "id_issued_after": "2026-07-02",
     "min_days_witness": null,

--- a/merger-tracker/frontend/public/data/mergers/MN-80035.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-80035.json
@@ -255,10 +255,10 @@
     "method_version": 1
   },
   "pre_notification": {
-    "estimated_days": 58,
+    "estimated_days": 24,
     "min_days": null,
     "max_days": 58,
-    "id_issued_estimated": "2026-06-20",
+    "id_issued_estimated": "2026-07-24",
     "id_issued_before": null,
     "id_issued_after": "2026-06-20",
     "min_days_witness": null,

--- a/merger-tracker/frontend/public/data/mergers/MN-90028.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-90028.json
@@ -269,10 +269,10 @@
     "method_version": 1
   },
   "pre_notification": {
-    "estimated_days": 44,
+    "estimated_days": 10,
     "min_days": null,
     "max_days": 44,
-    "id_issued_estimated": "2026-05-30",
+    "id_issued_estimated": "2026-07-03",
     "id_issued_before": null,
     "id_issued_after": "2026-05-30",
     "min_days_witness": null,

--- a/merger-tracker/frontend/public/data/mergers/MN-95038.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-95038.json
@@ -212,10 +212,10 @@
     "method_version": 1
   },
   "pre_notification": {
-    "estimated_days": 55,
+    "estimated_days": 21,
     "min_days": null,
     "max_days": 55,
-    "id_issued_estimated": "2026-06-10",
+    "id_issued_estimated": "2026-07-14",
     "id_issued_before": null,
     "id_issued_after": "2026-06-10",
     "min_days_witness": null,

--- a/scripts/static_data/prenotification.py
+++ b/scripts/static_data/prenotification.py
@@ -271,7 +271,16 @@ def compute_estimate(
         estimated_days = min_days
         basis = "lower-bound-only"
     else:
-        estimated_days = max_days
+        # max_days deliberately uses lag_max, the most generous lodgement delay
+        # any waiver is known to have taken, to keep it a safe ceiling. Reusing
+        # that padded value as the central guess would understate id_issued_estimated,
+        # sometimes past a neighbouring, more tightly bracketed case with a
+        # lower sequence number — which can never have been issued later.
+        # Re-anchor the central guess on the same witness using the tight
+        # `lag`, matching every other basis.
+        tight_witness = _issued_after(group, position["seq"], lag)
+        issued_central = min(tight_witness[0], filed) if tight_witness else issued_after
+        estimated_days = (filed - issued_central).days
         basis = "upper-bound-only"
 
     # The same estimate as a date: the day pre-notification is reckoned to have

--- a/scripts/tests/test_prenotification.py
+++ b/scripts/tests/test_prenotification.py
@@ -277,3 +277,32 @@ class TestAttachment:
         # first, which assumes nothing about how waivers behave.
         mergers = [_merger('MN-01010', '2026-04-01'), _merger('MN-01011', '2026-03-01')]
         assert _estimates(mergers, lag=WAIVER_LODGEMENT_LAG_DAYS)['MN-01010']['min_days'] == 31
+
+    def test_upper_bound_only_central_guess_uses_the_tight_lag(self):
+        # MN-01011 sits at the top of the counter (nothing above it), so its
+        # only witness is the waiver below, and its ceiling is deliberately
+        # padded with lag_max. The central guess must not inherit that
+        # padding, or it becomes more pessimistic than a same-witness case
+        # that also gets a proven floor.
+        mergers = [_merger('WA-01005', '2026-01-01'), _merger('MN-01011', '2026-04-01')]
+        estimate = _estimates(mergers, lag=0, lag_max=34)['MN-01011']
+        assert estimate['basis'] == 'upper-bound-only'
+        assert estimate['max_days'] == 90 + 34
+        assert estimate['estimated_days'] == 90
+        assert estimate['id_issued_estimated'] == '2026-01-01'
+
+    def test_upper_bound_only_stays_monotonic_with_a_bracketed_neighbour(self):
+        # MN-01028 (lower sequence) is bracketed by the waiver below it and
+        # MN-01030 above. MN-01030 (higher sequence) only has a lower
+        # witness, so it falls into upper-bound-only. Since 28 was issued no
+        # later than 30, 30's best-guess issue date must not land before
+        # 28's — which it did before this basis stopped using lag_max.
+        mergers = [
+            _merger('WA-01026', '2026-07-10'),
+            _merger('MN-01028', '2026-08-13'),
+            _merger('MN-01030', '2026-08-05'),
+        ]
+        estimates = _estimates(mergers, lag=0, lag_max=34)
+        assert estimates['MN-01028']['basis'] == 'bracketed'
+        assert estimates['MN-01030']['basis'] == 'upper-bound-only'
+        assert estimates['MN-01030']['id_issued_estimated'] >= estimates['MN-01028']['id_issued_estimated']


### PR DESCRIPTION
Notifications with no witness above them in their group's ID counter
(basis "upper-bound-only") reused max_days — computed with the generous
WAIVER_LODGEMENT_LAG_MAX_DAYS — as their central estimate too. That made
the guess deliberately pessimistic instead of central, and could push a
higher-sequence case's estimated issue date earlier than a lower-sequence
neighbour's (e.g. MN-30030 estimated earlier than MN-30028), which the
counter ordering rules out. The central guess now re-anchors on the same
witness using the tight WAIVER_LODGEMENT_LAG_DAYS, matching every other
basis; max_days is unaffected.