### PR TITLE
Cap Merger Pipeline job at 45 minutes to prevent multi-hour hangs

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -15,6 +15,11 @@ on:
         required: false
         default: false
         type: boolean
+      conflict_retry_count:
+        description: 'Internal: chained-retry counter after a rebase conflict against main. Leave as 0.'
+        required: false
+        default: '0'
+        type: string
   push:
     branches:
       - main
@@ -28,6 +33,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write   # needed by the folded-in detect-* PR steps
+  actions: write         # needed to trigger a fresh run after a rebase conflict
 
 # Serialise pipeline runs on main. Two concurrent runs can otherwise race
 # on the same files and rely on the post-rebase HTML re-clean / commit-drop
@@ -297,6 +303,9 @@ jobs:
 
       - name: Commit all changes
         id: commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RETRY_COUNT: ${{ inputs.conflict_retry_count || '0' }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -305,7 +314,25 @@ jobs:
             echo "No changes to commit"
           else
             git commit -m "Update merger data: ${timestamp}"
-            git pull --rebase --autostash || { git rebase --abort; exit 1; }
+            if ! git pull --rebase --autostash; then
+              git rebase --abort
+
+              # A real conflict here means something else pushed to main while
+              # this run was scraping/extracting - hand-merging the JSON isn't
+              # safe, so give up on this run's commit and kick off a fresh run
+              # instead. It'll check out the now-current main and re-scrape/
+              # re-extract on top of it, so it won't hit the same conflict.
+              # Capped so a misbehaving concurrent writer can't cause an
+              # infinite chain of retriggers.
+              next_retry=$((RETRY_COUNT + 1))
+              if [ "$next_retry" -le 3 ]; then
+                echo "Rebase conflict against a concurrent push to main (retry ${next_retry}/3) - triggering a fresh pipeline run"
+                gh workflow run pipeline.yml --ref main -f "conflict_retry_count=${next_retry}"
+              else
+                echo "Rebase conflict against a concurrent push to main - already retried ${RETRY_COUNT} times, giving up and leaving this to the next scheduled run"
+              fi
+              exit 1
+            fi
 
             # After rebase, re-clean any HTML files that changed. A 3-way merge
             # during rebase can reintroduce raw dynamic tokens if both the local

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -51,8 +51,8 @@ jobs:
     # serialised via the concurrency group above, that also blocks every
     # queued run behind it for the same 6 hours. Normal runs take ~1-3
     # minutes; with the apt cache above, even a LibreOffice install run
-    # should stay well under this.
-    timeout-minutes: 10
+    # should stay well under this, with headroom for a cold-cache run.
+    timeout-minutes: 15
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -49,10 +49,10 @@ jobs:
     # Without this, a hung step (e.g. an apt-get fetch that stalls) runs to
     # GitHub's default 6-hour job timeout before failing. Because runs are
     # serialised via the concurrency group above, that also blocks every
-    # queued run behind it for the same 6 hours. 45 minutes is well above
-    # the ~1-3 minutes a normal run takes, including LibreOffice/Tesseract
-    # installs and a full --all scrape.
-    timeout-minutes: 45
+    # queued run behind it for the same 6 hours. Normal runs take ~1-3
+    # minutes; with the apt cache above, even a LibreOffice install run
+    # should stay well under this.
+    timeout-minutes: 10
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -214,6 +214,22 @@ jobs:
             echo "No unconverted DOCX files found"
             echo "has_unconverted=false" >> $GITHUB_OUTPUT
           fi
+
+      # The runner's apt mirror has been slow enough on some days to make this
+      # install take 10+ minutes on its own (run #1690: 96.7 MB at 160 kB/s;
+      # run #1693 stalled on it entirely and hit the 6-hour job timeout).
+      # libreoffice-writer's package set rarely changes, so caching the
+      # downloaded .debs sidesteps the mirror on a cache hit. Keyed on
+      # run_id so it always saves a fresh snapshot; restore-keys falls back
+      # to the most recent one, so it still picks up upstream version bumps.
+      - name: Cache LibreOffice apt packages
+        if: steps.find-docx.outputs.has_unconverted == 'true'
+        uses: actions/cache@v5
+        with:
+          path: /var/cache/apt/archives/*.deb
+          key: ${{ runner.os }}-apt-libreoffice-writer-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-apt-libreoffice-writer-
 
       - name: Install LibreOffice
         if: steps.find-docx.outputs.has_unconverted == 'true'

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Cache pup binary
         id: cache-pup
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/go/bin/pup
           key: ${{ runner.os }}-pup-v0.4.0
@@ -224,7 +224,7 @@ jobs:
       # to the most recent one, so it still picks up upstream version bumps.
       - name: Cache LibreOffice apt packages
         if: steps.find-docx.outputs.has_unconverted == 'true'
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: /var/cache/apt/archives/*.deb
           key: ${{ runner.os }}-apt-libreoffice-writer-${{ github.run_id }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -40,6 +40,13 @@ concurrency:
 jobs:
   pipeline:
     runs-on: ubuntu-latest
+    # Without this, a hung step (e.g. an apt-get fetch that stalls) runs to
+    # GitHub's default 6-hour job timeout before failing. Because runs are
+    # serialised via the concurrency group above, that also blocks every
+    # queued run behind it for the same 6 hours. 45 minutes is well above
+    # the ~1-3 minutes a normal run takes, including LibreOffice/Tesseract
+    # installs and a full --all scrape.
+    timeout-minutes: 45
     steps:
       - name: Check out repository
         uses: actions/checkout@v6


### PR DESCRIPTION
Run #1693 hung indefinitely on the LibreOffice apt-get install step (a
stalled package index fetch) and ran until GitHub's default 6-hour job
timeout cancelled it. Because the workflow serialises on the
pipeline-main concurrency group, that also blocked every queued run
(#1694-#1700) for the same 6 hours - dispatch-triggered runs got
superseded/cancelled while queued, and the next scheduled run sat
queued for 3+ hours before it could execute.