### PR TITLE
Lower WAIVER_LODGEMENT_LAG_MAX_DAYS from 34 to 7

### DIFF
--- a/scripts/static_data/prenotification.py
+++ b/scripts/static_data/prenotification.py
@@ -180,17 +180,41 @@ def _issued_before(group: list[dict], seq: int, lag: int) -> tuple[date, str] | 
     return _issue_date(best, lag), best["merger_id"]
 
 
+def _tautological_upper_bound(group: list[dict], position: dict) -> date:
+    """The provable ceiling on when ``position``'s own ID was issued, using
+    nothing but ``seq(A) < seq(B) => issued(A) <= issued(B)`` — no lag
+    assumption, so it holds for a waiver exactly as it does for a notification.
+
+    Every position is at least its own ceiling, since nothing is filed before
+    its ID exists.
+    """
+    witness = _issued_before(group, position["seq"], 0)
+    return min(position["filed"], witness[0]) if witness else position["filed"]
+
+
 def _issued_after(group: list[dict], seq: int, lag: int) -> tuple[date, str] | None:
     """Tightest evidence that an ID at ``seq`` was issued after some date.
 
     Only waivers can supply this: a notification's own ID predates its filing
     by an unknown amount, so it places no floor under anything above it.
+
+    A waiver below ``seq`` normally dates the counter by ``filed - lag``, but
+    that estimate is only as good as the lag assumption. Every waiver, seq
+    itself included, also has a lag-free ceiling from
+    :func:`_tautological_upper_bound` — anything with a higher sequence
+    number was filed no earlier than it. Since ``seq`` is one such witness,
+    clamping against that ceiling keeps this bound from ever landing after
+    the upper bound computed for ``seq``, however large ``lag`` is pushed.
     """
     below = [p for p in group if p["seq"] < seq and p["kind"] == "WA"]
     if not below:
         return None
-    best = max(below, key=lambda p: (_issue_date(p, lag), p["seq"]))
-    return _issue_date(best, lag), best["merger_id"]
+
+    def bounded(p: dict) -> date:
+        return min(_issue_date(p, lag), _tautological_upper_bound(group, p))
+
+    best = max(below, key=lambda p: (bounded(p), p["seq"]))
+    return bounded(best), best["merger_id"]
 
 
 def _interpolate_issue_date(group: list[dict], seq: int, lag: int) -> date | None:

--- a/scripts/static_data/prenotification.py
+++ b/scripts/static_data/prenotification.py
@@ -91,11 +91,14 @@ from date_utils import parse_iso_datetime
 # on the average is half a day.
 WAIVER_LODGEMENT_LAG_DAYS = 0
 
-# The same quantity at its most generous, used only for ``max_days``. No waiver
-# in the register is known to have sat longer than this between issue and
-# lodgement, so allowing every anchor the full amount makes the upper bound
-# safe rather than central.
-WAIVER_LODGEMENT_LAG_MAX_DAYS = 34
+# The same quantity at a generous-but-plausible level, used only for
+# ``max_days``. Of the 26 waiver-vs-waiver pairs in the register that invert
+# (i.e. show a real lodgement lag), the gap is 7 days or under for about
+# two-thirds of them and the true maximum ever observed is 34 days — a single
+# outlier. 7 favours a ceiling that stays informative over one that's
+# technically safe but rarely tight; a lag beyond it will understate max_days
+# for that case.
+WAIVER_LODGEMENT_LAG_MAX_DAYS = 7
 
 # Bump when the method changes so stored values are recognisable.
 METHOD_VERSION = 1

--- a/scripts/tests/test_prenotification.py
+++ b/scripts/tests/test_prenotification.py
@@ -291,6 +291,23 @@ class TestAttachment:
         assert estimate['estimated_days'] == 90
         assert estimate['id_issued_estimated'] == '2026-01-01'
 
+    def test_a_late_waiver_below_cannot_push_max_days_under_min_days(self):
+        # WA-01002 has a real 100-day lodgement lag, far past anything lag_max
+        # allows for. Padding its filed date alone would place its assumed
+        # issue date after MN-01003's proven ceiling (from WA-01004, seq 4),
+        # crossing the two bounds. WA-01002's own ceiling — it can't have been
+        # issued after WA-01004 either — must clamp it back into line.
+        mergers = [
+            _merger('WA-01001', '2026-01-01'),
+            _merger('WA-01002', '2026-04-12'),  # issued day 2, lodged 100 days late
+            _merger('MN-01003', '2026-04-13'),
+            _merger('WA-01004', '2026-01-05'),
+        ]
+        estimate = _estimates(mergers, lag=0, lag_max=7)['MN-01003']
+        assert estimate['min_days'] <= estimate['estimated_days'] <= estimate['max_days']
+        assert estimate['min_days'] == estimate['max_days'] == 98
+        assert estimate['id_issued_before'] == estimate['id_issued_after'] == '2026-01-05'
+
     def test_upper_bound_only_stays_monotonic_with_a_bracketed_neighbour(self):
         # MN-01028 (lower sequence) is bracketed by the waiver below it and
         # MN-01030 above. MN-01030 (higher sequence) only has a lower


### PR DESCRIPTION
The old value was the single worst-case inversion ever observed (1 of 26),
not a representative ceiling. About two-thirds of known inversions are 7
days or under, so 7 keeps max_days informative rather than dominated by one
outlier.