### PR TITLE
Simplify hover text for expected-determination soon pip

### DIFF
--- a/merger-tracker/frontend/src/components/MergerTimeline.jsx
+++ b/merger-tracker/frontend/src/components/MergerTimeline.jsx
@@ -458,7 +458,10 @@ function MergerTimeline({ merger }) {
           )}
 
           {/* The same forecast once its window has closed: a pip just clear of
-              the today marker, held inside the track's right edge. */}
+              the today marker, held inside the track's right edge. The forecast
+              window is in the past at this point, so the date/band detail in
+              expectedTitle would be describing a window we're already past —
+              the hover just confirms the "soon" label instead. */}
           {expectedSoon && (
             <span
               className="absolute top-1/2 -translate-y-1/2 h-3 rounded-full bg-phase-1/50 cursor-help"
@@ -466,8 +469,8 @@ function MergerTimeline({ merger }) {
                 left: `min(calc(${midPct}% + ${SOON_PIP_GAP_PX}px), calc(100% - ${SOON_PIP_PX}px))`,
                 width: `${SOON_PIP_PX}px`,
               }}
-              title={expectedTitle}
-              aria-label={expectedTitle}
+              title="Determination expected soon"
+              aria-label="Determination expected soon"
             />
           )}
 

--- a/merger-tracker/frontend/src/components/__tests__/MergerTimeline.test.jsx
+++ b/merger-tracker/frontend/src/components/__tests__/MergerTimeline.test.jsx
@@ -281,7 +281,7 @@ describe('MergerTimeline', () => {
         />
       );
 
-      const pip = screen.getByLabelText(/Expected determination/);
+      const pip = screen.getByLabelText('Determination expected soon');
       // Fixed-size, since the window it described no longer maps to the axis.
       expect(pip.style.width).toBe('24px');
       expect(screen.getByText('Expected determination soon')).toBeInTheDocument();
@@ -412,7 +412,7 @@ describe('MergerTimeline', () => {
       );
 
       // The pip stays; only its label gives way to "Today".
-      expect(screen.getByLabelText(/Expected determination/)).toBeInTheDocument();
+      expect(screen.getByLabelText('Determination expected soon')).toBeInTheDocument();
       expect(screen.queryByText('Expected determination soon')).not.toBeInTheDocument();
       expect(screen.getByText('Today')).toBeInTheDocument();
     });


### PR DESCRIPTION
Once the forecast window has closed, the pip's tooltip no longer
carries the (now-past) window's date/band detail — it just confirms
"Determination expected soon", matching its visible label.