### PR TITLE
Clear known_notification_dates.json now that Symal shows its date

### DIFF
--- a/data/known_notification_dates.json
+++ b/data/known_notification_dates.json
@@ -1,6 +1,1 @@
-{
-  "MN-50030": {
-    "date": "2026-07-01T12:00:00Z",
-    "note": "Symal Group - Shamrock: notification date never added to page"
-  }
-}
+{}


### PR DESCRIPTION
The ACCC page for MN-50030 (Symal Group - Shamrock) now publishes
"Effective notification date: 1 July 2026" natively, so the frozen
override is no longer needed. The feature itself (extract_mergers.py
loading overrides, fix_missing_notification_dates.py populating them)
stays in place for future occurrences.