### PR TITLE
Keep pre-notification guesses in ACCC counter order

### DIFF
--- a/data/output/mergers.json
+++ b/data/output/mergers.json
@@ -12257,10 +12257,10 @@
         "method_version": 1
       },
       "pre_notification": {
-        "estimated_days": 17,
+        "estimated_days": 13,
         "min_days": 3,
         "max_days": 30,
-        "id_issued_estimated": "2026-07-27",
+        "id_issued_estimated": "2026-07-31",
         "id_issued_before": "2026-08-10",
         "id_issued_after": "2026-07-14",
         "min_days_witness": "MN-05044",
@@ -12460,10 +12460,10 @@
         "method_version": 1
       },
       "pre_notification": {
-        "estimated_days": 14,
+        "estimated_days": 10,
         "min_days": 0,
         "max_days": 27,
-        "id_issued_estimated": "2026-07-27",
+        "id_issued_estimated": "2026-07-31",
         "id_issued_before": "2026-08-10",
         "id_issued_after": "2026-07-14",
         "min_days_witness": "MN-05046",
@@ -12693,10 +12693,10 @@
         "method_version": 1
       },
       "pre_notification": {
-        "estimated_days": 29,
+        "estimated_days": 19,
         "min_days": null,
         "max_days": 36,
-        "id_issued_estimated": "2026-07-21",
+        "id_issued_estimated": "2026-07-31",
         "id_issued_before": null,
         "id_issued_after": "2026-07-14",
         "min_days_witness": null,
@@ -28504,10 +28504,10 @@
         "method_version": 1
       },
       "pre_notification": {
-        "estimated_days": 18,
+        "estimated_days": 14,
         "min_days": 8,
         "max_days": 27,
-        "id_issued_estimated": "2026-07-26",
+        "id_issued_estimated": "2026-07-30",
         "id_issued_before": "2026-08-05",
         "id_issued_after": "2026-07-17",
         "min_days_witness": "MN-30030",
@@ -28723,10 +28723,10 @@
         "method_version": 1
       },
       "pre_notification": {
-        "estimated_days": 12,
+        "estimated_days": 6,
         "min_days": null,
         "max_days": 19,
-        "id_issued_estimated": "2026-07-24",
+        "id_issued_estimated": "2026-07-30",
         "id_issued_before": null,
         "id_issued_after": "2026-07-17",
         "min_days_witness": null,
@@ -56975,10 +56975,10 @@
         "method_version": 1
       },
       "pre_notification": {
-        "estimated_days": 8,
+        "estimated_days": 5,
         "min_days": 0,
         "max_days": 16,
-        "id_issued_estimated": "2026-08-06",
+        "id_issued_estimated": "2026-08-09",
         "id_issued_before": "2026-08-14",
         "id_issued_after": "2026-07-29",
         "min_days_witness": "MN-75044",
@@ -57207,10 +57207,10 @@
         "method_version": 1
       },
       "pre_notification": {
-        "estimated_days": 15,
+        "estimated_days": 11,
         "min_days": null,
         "max_days": 22,
-        "id_issued_estimated": "2026-08-05",
+        "id_issued_estimated": "2026-08-09",
         "id_issued_before": null,
         "id_issued_after": "2026-07-29",
         "min_days_witness": null,
@@ -65731,10 +65731,10 @@
         "method_version": 1
       },
       "pre_notification": {
-        "estimated_days": 23,
+        "estimated_days": 19,
         "min_days": 14,
         "max_days": 31,
-        "id_issued_estimated": "2026-07-04",
+        "id_issued_estimated": "2026-07-08",
         "id_issued_before": "2026-07-13",
         "id_issued_after": "2026-06-26",
         "min_days_witness": "MN-90028",
@@ -66020,10 +66020,10 @@
         "method_version": 1
       },
       "pre_notification": {
-        "estimated_days": 9,
+        "estimated_days": 5,
         "min_days": 0,
         "max_days": 17,
-        "id_issued_estimated": "2026-07-04",
+        "id_issued_estimated": "2026-07-08",
         "id_issued_before": "2026-07-13",
         "id_issued_after": "2026-06-26",
         "min_days_witness": "MN-90029",
@@ -66283,10 +66283,10 @@
         "method_version": 1
       },
       "pre_notification": {
-        "estimated_days": 46,
+        "estimated_days": 41,
         "min_days": null,
         "max_days": 53,
-        "id_issued_estimated": "2026-07-03",
+        "id_issued_estimated": "2026-07-08",
         "id_issued_before": null,
         "id_issued_after": "2026-06-26",
         "min_days_witness": null,

--- a/merger-tracker/frontend/public/data/mergers/MN-05043.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-05043.json
@@ -220,10 +220,10 @@
     "method_version": 1
   },
   "pre_notification": {
-    "estimated_days": 17,
+    "estimated_days": 13,
     "min_days": 3,
     "max_days": 30,
-    "id_issued_estimated": "2026-07-27",
+    "id_issued_estimated": "2026-07-31",
     "id_issued_before": "2026-08-10",
     "id_issued_after": "2026-07-14",
     "min_days_witness": "MN-05044",

--- a/merger-tracker/frontend/public/data/mergers/MN-05044.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-05044.json
@@ -189,10 +189,10 @@
     "method_version": 1
   },
   "pre_notification": {
-    "estimated_days": 14,
+    "estimated_days": 10,
     "min_days": 0,
     "max_days": 27,
-    "id_issued_estimated": "2026-07-27",
+    "id_issued_estimated": "2026-07-31",
     "id_issued_before": "2026-08-10",
     "id_issued_after": "2026-07-14",
     "min_days_witness": "MN-05046",

--- a/merger-tracker/frontend/public/data/mergers/MN-05046.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-05046.json
@@ -219,10 +219,10 @@
     "method_version": 1
   },
   "pre_notification": {
-    "estimated_days": 29,
+    "estimated_days": 19,
     "min_days": null,
     "max_days": 36,
-    "id_issued_estimated": "2026-07-21",
+    "id_issued_estimated": "2026-07-31",
     "id_issued_before": null,
     "id_issued_after": "2026-07-14",
     "min_days_witness": null,

--- a/merger-tracker/frontend/public/data/mergers/MN-30028.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-30028.json
@@ -198,10 +198,10 @@
     "method_version": 1
   },
   "pre_notification": {
-    "estimated_days": 18,
+    "estimated_days": 14,
     "min_days": 8,
     "max_days": 27,
-    "id_issued_estimated": "2026-07-26",
+    "id_issued_estimated": "2026-07-30",
     "id_issued_before": "2026-08-05",
     "id_issued_after": "2026-07-17",
     "min_days_witness": "MN-30030",

--- a/merger-tracker/frontend/public/data/mergers/MN-30030.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-30030.json
@@ -205,10 +205,10 @@
     "method_version": 1
   },
   "pre_notification": {
-    "estimated_days": 12,
+    "estimated_days": 6,
     "min_days": null,
     "max_days": 19,
-    "id_issued_estimated": "2026-07-24",
+    "id_issued_estimated": "2026-07-30",
     "id_issued_before": null,
     "id_issued_after": "2026-07-17",
     "min_days_witness": null,

--- a/merger-tracker/frontend/public/data/mergers/MN-75041.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-75041.json
@@ -208,10 +208,10 @@
     "method_version": 1
   },
   "pre_notification": {
-    "estimated_days": 8,
+    "estimated_days": 5,
     "min_days": 0,
     "max_days": 16,
-    "id_issued_estimated": "2026-08-06",
+    "id_issued_estimated": "2026-08-09",
     "id_issued_before": "2026-08-14",
     "id_issued_after": "2026-07-29",
     "min_days_witness": "MN-75044",

--- a/merger-tracker/frontend/public/data/mergers/MN-75044.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-75044.json
@@ -218,10 +218,10 @@
     "method_version": 1
   },
   "pre_notification": {
-    "estimated_days": 15,
+    "estimated_days": 11,
     "min_days": null,
     "max_days": 22,
-    "id_issued_estimated": "2026-08-05",
+    "id_issued_estimated": "2026-08-09",
     "id_issued_before": null,
     "id_issued_after": "2026-07-29",
     "min_days_witness": null,

--- a/merger-tracker/frontend/public/data/mergers/MN-90027.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-90027.json
@@ -277,10 +277,10 @@
     "method_version": 1
   },
   "pre_notification": {
-    "estimated_days": 23,
+    "estimated_days": 19,
     "min_days": 14,
     "max_days": 31,
-    "id_issued_estimated": "2026-07-04",
+    "id_issued_estimated": "2026-07-08",
     "id_issued_before": "2026-07-13",
     "id_issued_after": "2026-06-26",
     "min_days_witness": "MN-90028",

--- a/merger-tracker/frontend/public/data/mergers/MN-90028.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-90028.json
@@ -275,10 +275,10 @@
     "method_version": 1
   },
   "pre_notification": {
-    "estimated_days": 9,
+    "estimated_days": 5,
     "min_days": 0,
     "max_days": 17,
-    "id_issued_estimated": "2026-07-04",
+    "id_issued_estimated": "2026-07-08",
     "id_issued_before": "2026-07-13",
     "id_issued_after": "2026-06-26",
     "min_days_witness": "MN-90029",

--- a/merger-tracker/frontend/public/data/mergers/MN-90029.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-90029.json
@@ -249,10 +249,10 @@
     "method_version": 1
   },
   "pre_notification": {
-    "estimated_days": 46,
+    "estimated_days": 41,
     "min_days": null,
     "max_days": 53,
-    "id_issued_estimated": "2026-07-03",
+    "id_issued_estimated": "2026-07-08",
     "id_issued_before": null,
     "id_issued_after": "2026-06-26",
     "min_days_witness": null,

--- a/scripts/static_data/prenotification.py
+++ b/scripts/static_data/prenotification.py
@@ -73,6 +73,11 @@ deliberately generous ceiling (``max_days``) — each also given as the date the
 ID is reckoned to have been issued, which is where pre-notification started.
 See :func:`compute_estimate`.
 
+Those guesses are then reconciled along each counter by
+:func:`_enforce_counter_order`, because a case weighed on its own witnesses can
+otherwise come out ahead of one below it in the sequence — which is precisely
+what the counter says cannot happen.
+
 Unlike :mod:`static_data.phase1_estimate`, these estimates are **not** frozen.
 A bound is only as tight as the cases sitting above and below it in the
 counter, so it genuinely improves as later IDs surface; recomputing every run
@@ -263,6 +268,10 @@ def compute_estimate(
     bounds were already carrying, ``id_issued_before`` for the floor and
     ``id_issued_after`` for the ceiling.
 
+    This weighs one case against its own witnesses only;
+    :func:`_enforce_counter_order` afterwards reconciles the guesses of a whole
+    group so they run in sequence order.
+
     ``None`` when the counter says nothing about this case — it sits at the top
     of its group with nothing above it and no waiver below it.
     """
@@ -283,6 +292,16 @@ def compute_estimate(
         issued_after = min(lower_witness[0], filed)
         max_days = (filed - issued_after).days
 
+    # ``issued_after`` above is deliberately generous: it pads every waiver
+    # anchor with lag_max, the most lodgement delay any waiver is known to have
+    # taken, so that max_days stays a safe ceiling. The central guess is a
+    # different question and answers to ``lag`` throughout — the same anchor
+    # read at the lag we actually believe. Mixing the padded date into it drags
+    # the guess earlier than the method claims, and can push it past a
+    # neighbouring case's guess in a direction the counter rules out.
+    tight_witness = _issued_after(group, position["seq"], lag)
+    issued_after_tight = min(tight_witness[0], filed) if tight_witness else issued_after
+
     # Both sides known: read the issue date off the counter by interpolating
     # between the waivers bracketing this sequence number, then clamp it into
     # the range the bounds already proved. Falls back to the midpoint of the
@@ -290,24 +309,15 @@ def compute_estimate(
     if issued_before is not None and issued_after is not None:
         interpolated = _interpolate_issue_date(group, position["seq"], lag)
         if interpolated is None:
-            interpolated = issued_after + (issued_before - issued_after) / 2
-        issued = min(max(interpolated, issued_after), issued_before)
+            interpolated = issued_after_tight + (issued_before - issued_after_tight) / 2
+        issued = min(max(interpolated, issued_after_tight), issued_before)
         estimated_days = (filed - issued).days
         basis = "bracketed"
     elif min_days is not None:
         estimated_days = min_days
         basis = "lower-bound-only"
     else:
-        # max_days deliberately uses lag_max, the most generous lodgement delay
-        # any waiver is known to have taken, to keep it a safe ceiling. Reusing
-        # that padded value as the central guess would understate id_issued_estimated,
-        # sometimes past a neighbouring, more tightly bracketed case with a
-        # lower sequence number — which can never have been issued later.
-        # Re-anchor the central guess on the same witness using the tight
-        # `lag`, matching every other basis.
-        tight_witness = _issued_after(group, position["seq"], lag)
-        issued_central = min(tight_witness[0], filed) if tight_witness else issued_after
-        estimated_days = (filed - issued_central).days
+        estimated_days = (filed - issued_after_tight).days
         basis = "upper-bound-only"
 
     # The same estimate as a date: the day pre-notification is reckoned to have
@@ -328,6 +338,36 @@ def compute_estimate(
     }
 
 
+def _enforce_counter_order(estimates: list[tuple[dict, dict]]) -> None:
+    """Make estimated issue dates run in sequence order, in place.
+
+    :func:`compute_estimate` weighs each case on its own witnesses, so two
+    neighbours can come out in an order the counter forbids — most visibly
+    where a case at the very top of its group has only a waiver below it to go
+    on and lands earlier than a better-bracketed case beneath it.
+    ``seq(A) < seq(B) => issued(A) <= issued(B)`` is the assumption the whole
+    method rests on, so a case is dragged up to its predecessor's estimate
+    whenever it falls behind: the case with witnesses on both sides is the
+    better informed of the two, and its estimate is evidence about everything
+    above it.
+
+    Raising is always the safe direction. ``id_issued_before`` is itself
+    non-decreasing in sequence (anything above B is also above A, and A's own
+    ceiling includes B), so an estimate lifted to a lower-sequence neighbour's
+    can never overshoot its own proven ceiling, and lifting only ever moves an
+    estimate further from ``id_issued_after``. Both bounds therefore still hold
+    afterwards, unchanged.
+    """
+    earliest: date | None = None
+    for position, estimate in sorted(estimates, key=lambda pair: pair[0]["seq"]):
+        issued = date.fromisoformat(estimate["id_issued_estimated"])
+        if earliest is not None and issued < earliest:
+            issued = earliest
+            estimate["estimated_days"] = (position["filed"] - issued).days
+            estimate["id_issued_estimated"] = issued.isoformat()
+        earliest = issued
+
+
 def attach_prenotification_estimates(
     enriched: list,
     lag: int = WAIVER_LODGEMENT_LAG_DAYS,
@@ -344,7 +384,7 @@ def attach_prenotification_estimates(
     for position in positions:
         groups.setdefault(position["group"], []).append(position)
 
-    attached = 0
+    attached: dict[str, list[tuple[dict, dict]]] = {}
     for position in positions:
         if position["kind"] != "MN":
             continue
@@ -354,5 +394,10 @@ def attach_prenotification_estimates(
         if estimate is None:
             continue
         position["merger"]["pre_notification"] = estimate
-        attached += 1
-    return attached
+        attached.setdefault(position["group"], []).append((position, estimate))
+
+    # Each group's counter runs on its own, so the ordering is reconciled within
+    # a group and never across them.
+    for group_estimates in attached.values():
+        _enforce_counter_order(group_estimates)
+    return sum(len(group_estimates) for group_estimates in attached.values())

--- a/scripts/tests/test_prenotification.py
+++ b/scripts/tests/test_prenotification.py
@@ -323,3 +323,71 @@ class TestAttachment:
         assert estimates['MN-01028']['basis'] == 'bracketed'
         assert estimates['MN-01030']['basis'] == 'upper-bound-only'
         assert estimates['MN-01030']['id_issued_estimated'] >= estimates['MN-01028']['id_issued_estimated']
+
+
+# ---------------------------------------------------------------------------
+# The counter's own ordering, across a whole group
+# ---------------------------------------------------------------------------
+
+class TestCounterOrder:
+    def test_midpoint_fallback_ignores_the_generous_lag(self):
+        # No waiver sits above MN-01010, so the guess falls back to the
+        # midpoint of its bounds rather than interpolating. That midpoint is a
+        # central guess and must be measured at `lag`: taking it from the
+        # lag_max-padded floor instead would drag it earlier the more generous
+        # the ceiling is allowed to be.
+        mergers = [
+            _merger('WA-01005', '2026-01-01'),
+            _merger('MN-01010', '2026-04-01'),
+            _merger('MN-01012', '2026-03-01'),  # later ID filed first: the ceiling
+        ]
+        tight = _estimates([dict(m) for m in mergers], lag=0, lag_max=0)['MN-01010']
+        padded = _estimates([dict(m) for m in mergers], lag=0, lag_max=34)['MN-01010']
+        assert tight['basis'] == 'bracketed'
+        # Halfway between 1 Jan (the waiver) and 1 Mar (the ceiling) is 30 Jan.
+        assert tight['id_issued_estimated'] == '2026-01-30'
+        assert padded['estimated_days'] == tight['estimated_days']
+        assert padded['max_days'] == tight['max_days'] + 34
+
+    def test_a_higher_sequence_cannot_be_issued_before_a_lower_one(self):
+        # The shape MN-75041/MN-75044 had on the register: 41 is bracketed by
+        # the waiver below and 44 above, while 44 tops the counter and has only
+        # that same waiver to go on, so it landed on the waiver's own date —
+        # earlier than 41's guess, which the counter forbids. 44 is dragged up
+        # to 41, the better-witnessed of the two.
+        mergers = [
+            _merger('WA-75040', '2026-08-05'),
+            _merger('MN-75041', '2026-08-14'),
+            _merger('MN-75044', '2026-08-20'),
+        ]
+        estimates = _estimates(mergers, lag=0, lag_max=7)
+        assert estimates['MN-75041']['basis'] == 'bracketed'
+        assert estimates['MN-75044']['basis'] == 'upper-bound-only'
+        assert estimates['MN-75041']['id_issued_estimated'] == '2026-08-09'
+        assert estimates['MN-75044']['id_issued_estimated'] == '2026-08-09'
+        assert estimates['MN-75044']['estimated_days'] == 11
+
+    def test_reconciling_the_order_keeps_both_bounds_intact(self):
+        mergers = [
+            _merger('WA-75040', '2026-08-05'),
+            _merger('MN-75041', '2026-08-14'),
+            _merger('MN-75044', '2026-08-20'),
+        ]
+        estimates = _estimates(mergers, lag=0, lag_max=7)
+        for merger_id in ('MN-75041', 'MN-75044'):
+            estimate = estimates[merger_id]
+            floor = estimate['min_days'] or 0
+            assert floor <= estimate['estimated_days'] <= estimate['max_days']
+
+    def test_each_group_is_reconciled_on_its_own_counter(self):
+        # Group 01's late guess must not follow the loop into group 05: the two
+        # counters run independently and say nothing about each other.
+        mergers = [
+            _merger('WA-01005', '2026-06-01'),
+            _merger('MN-01010', '2026-09-01'),
+            _merger('WA-05005', '2026-01-01'),
+            _merger('MN-05010', '2026-04-01'),
+        ]
+        estimates = _estimates(mergers, lag=0, lag_max=7)
+        assert estimates['MN-05010']['id_issued_estimated'] == '2026-01-01'
+        assert estimates['MN-01010']['id_issued_estimated'] == '2026-06-01'


### PR DESCRIPTION
MN-75041 and MN-75044 sit on the same group counter with one waiver
(WA-75040) below them and nothing above, and came out contradicting each
other: 75041's ID was estimated as issued on 6 August and 75044's — four
sequence numbers later, so issued no earlier — on 5 August. The site read
that back as "entered pre-notification around 6 August" on one and
"sometime after 5 August" on the other.

Two things caused it, both on the paths taken by cases near the top of a
counter, where no waiver sits above to interpolate against:

* The midpoint fallback in the bracketed branch measured from the
  lag_max-padded floor. lag_max exists to keep max_days a safe ceiling;
  feeding it into the central guess drags that guess earlier than the
  method claims, and it is the same mix-up already fixed for
  upper-bound-only cases in #806. The central guess now reads its anchor
  at the tight lag on every path.
* The two degenerate paths disagreed anyway. A bracketed case with no
  waiver above takes the midpoint of its bounds; a top-of-counter case
  pins its guess to the anchor below, the earliest date in its range. The
  second lands before the first even though it sits higher on the counter.

seq(A) < seq(B) => issued(A) <= issued(B) is the assumption the whole
method rests on, so the guesses are now reconciled along each group's
counter after they are computed: a case falling behind its predecessor is
raised to it, the predecessor being the better-witnessed of the two.
Raising is provably safe — id_issued_before is itself non-decreasing in
sequence — so both bounds survive unchanged, and each counter is
reconciled on its own.

Ten estimates move; MN-75044 now reads 9 August, matching MN-75041, and
no pair on the register is left out of order.