### PR TITLE
Group same-type dashboard events and add a Later timeline

### DIFF
--- a/merger-tracker/frontend/src/components/UpcomingEventsTimeline.jsx
+++ b/merger-tracker/frontend/src/components/UpcomingEventsTimeline.jsx
@@ -277,9 +277,9 @@ function UpcomingEventsTimeline({ events }) {
               {/* Day content */}
               <div className={`min-w-0 flex-1 ${isLast ? '' : 'pb-6'}`}>
                 <div className="flex items-baseline gap-2">
-                  <span className={`text-sm font-semibold ${urgency.text}`}>
+                  <h3 className={`text-sm font-semibold ${urgency.text}`}>
                     {day.later ? 'Later' : relativeLabel(daysRemaining)}
-                  </span>
+                  </h3>
                   <span className="text-xs text-gray-500">
                     {day.later ? formatDateRange(day.rangeStart, day.rangeEnd) : formatWeekday(day.date)}
                   </span>

--- a/merger-tracker/frontend/src/components/UpcomingEventsTimeline.jsx
+++ b/merger-tracker/frontend/src/components/UpcomingEventsTimeline.jsx
@@ -173,7 +173,7 @@ function EventGroupSummary({ group, expanded, onToggle, panelId }) {
         <Icon className="h-3.5 w-3.5" />
       </span>
       <div className="min-w-0 flex-1 text-sm font-semibold text-gray-900">
-        {group.events.length} {eventType.label}s due
+        {group.events.length} {eventType.label.toLowerCase()}s due
       </div>
       <FaChevronDown
         className={`h-3.5 w-3.5 flex-none text-gray-500 transition-transform ${expanded ? 'rotate-180' : ''}`}

--- a/merger-tracker/frontend/src/components/UpcomingEventsTimeline.jsx
+++ b/merger-tracker/frontend/src/components/UpcomingEventsTimeline.jsx
@@ -155,7 +155,7 @@ function EventRow({ event }) {
   );
 }
 
-function EventGroupSummary({ group, expanded, onToggle }) {
+function EventGroupSummary({ group, expanded, onToggle, panelId }) {
   const eventType = getEventType(group.type);
   const { Icon } = eventType;
   return (
@@ -163,6 +163,7 @@ function EventGroupSummary({ group, expanded, onToggle }) {
       type="button"
       onClick={onToggle}
       aria-expanded={expanded}
+      aria-controls={panelId}
       className="flex w-full items-center gap-3 rounded-xl -mx-2 px-2 py-2 text-left transition-colors hover:bg-gray-50"
     >
       <span
@@ -175,7 +176,7 @@ function EventGroupSummary({ group, expanded, onToggle }) {
         {group.events.length} {eventType.label}s due
       </div>
       <FaChevronDown
-        className={`h-3.5 w-3.5 flex-none text-gray-400 transition-transform ${expanded ? 'rotate-180' : ''}`}
+        className={`h-3.5 w-3.5 flex-none text-gray-500 transition-transform ${expanded ? 'rotate-180' : ''}`}
         aria-hidden="true"
       />
     </button>
@@ -298,6 +299,7 @@ function UpcomingEventsTimeline({ events }) {
                     }
 
                     const groupKey = `${dayKey}-${group.type}`;
+                    const panelId = `events-${groupKey}`;
                     const expanded = expandedGroups.has(groupKey);
                     return [
                       <li key={groupKey}>
@@ -305,14 +307,21 @@ function UpcomingEventsTimeline({ events }) {
                           group={group}
                           expanded={expanded}
                           onToggle={() => toggleGroup(groupKey)}
+                          panelId={panelId}
                         />
                       </li>,
                       ...(expanded
-                        ? group.events.map((event) => (
-                            <li key={`${event.merger_id}-${event.date}-${event.type}`} className="pl-4">
-                              <EventRow event={event} />
-                            </li>
-                          ))
+                        ? [
+                            <li key={panelId}>
+                              <ul id={panelId} className="space-y-1 pl-4">
+                                {group.events.map((event) => (
+                                  <li key={`${event.merger_id}-${event.date}-${event.type}`}>
+                                    <EventRow event={event} />
+                                  </li>
+                                ))}
+                              </ul>
+                            </li>,
+                          ]
                         : []),
                     ];
                   })}

--- a/merger-tracker/frontend/src/components/UpcomingEventsTimeline.jsx
+++ b/merger-tracker/frontend/src/components/UpcomingEventsTimeline.jsx
@@ -8,7 +8,7 @@ import {
   FaChevronDown,
 } from 'react-icons/fa6';
 import { mergerPath } from '../utils/slug';
-import { formatWeekday, getCalendarDaysUntil } from '../utils/dates';
+import { formatWeekday, formatDateRange, getCalendarDaysUntil } from '../utils/dates';
 import { PHASES } from '../constants/mergerStatus';
 import { CARD } from '../utils/classNames';
 import EmptyStateCard from './EmptyStateCard';
@@ -215,9 +215,18 @@ function UpcomingEventsTimeline({ events }) {
         const isLater = daysRemaining !== null && daysRemaining > 7;
         const key = isLater ? LATER_KEY : event.date.slice(0, 10);
         if (!byDay.has(key)) {
-          byDay.set(key, isLater ? { key, later: true, events: [] } : { key, date: event.date, events: [] });
+          byDay.set(
+            key,
+            isLater
+              ? { key, later: true, events: [], rangeStart: event.date, rangeEnd: event.date }
+              : { key, date: event.date, events: [] }
+          );
         }
-        byDay.get(key).events.push(event);
+        const bucket = byDay.get(key);
+        bucket.events.push(event);
+        // Events are still date-sorted at this point, so the running range
+        // just tracks the first and most recent later event seen.
+        if (isLater) bucket.rangeEnd = event.date;
       });
     // The later bucket's events were sorted chronologically above; re-sort by
     // type/phase/name only, since it's presented as one combined entry rather
@@ -270,9 +279,9 @@ function UpcomingEventsTimeline({ events }) {
                   <span className={`text-sm font-semibold ${urgency.text}`}>
                     {day.later ? 'Later' : relativeLabel(daysRemaining)}
                   </span>
-                  {!day.later && (
-                    <span className="text-xs text-gray-500">{formatWeekday(day.date)}</span>
-                  )}
+                  <span className="text-xs text-gray-500">
+                    {day.later ? formatDateRange(day.rangeStart, day.rangeEnd) : formatWeekday(day.date)}
+                  </span>
                 </div>
 
                 <ul className="mt-1.5 space-y-1">

--- a/merger-tracker/frontend/src/components/UpcomingEventsTimeline.jsx
+++ b/merger-tracker/frontend/src/components/UpcomingEventsTimeline.jsx
@@ -15,8 +15,12 @@ import EmptyStateCard from './EmptyStateCard';
 
 // A day with this many or more events of the same type collapses into a
 // single "N Consultations due" summary row, expandable on click/tap, so a
-// busy day doesn't push everything else off screen.
+// busy day doesn't push everything else off screen. The combined "Later"
+// entry already bundles a whole week, so it collapses a type as soon as
+// there's more than one — otherwise it tends to be the longest, least
+// scannable entry in the list.
 const GROUP_COLLAPSE_THRESHOLD = 3;
+const LATER_GROUP_COLLAPSE_THRESHOLD = 2;
 
 // Each event type carries its own accent (icon tile + chip) so the kind of
 // deadline is recognisable at a glance, independent of the urgency colouring
@@ -290,7 +294,10 @@ function UpcomingEventsTimeline({ events }) {
                     // A handful of same-type events on one day collapse into
                     // a single summary row so a busy day doesn't crowd out
                     // everything else on the timeline.
-                    if (group.events.length < GROUP_COLLAPSE_THRESHOLD) {
+                    const collapseThreshold = day.later
+                      ? LATER_GROUP_COLLAPSE_THRESHOLD
+                      : GROUP_COLLAPSE_THRESHOLD;
+                    if (group.events.length < collapseThreshold) {
                       return group.events.map((event) => (
                         <li key={`${event.merger_id}-${event.date}-${event.type}`}>
                           <EventRow event={event} />

--- a/merger-tracker/frontend/src/components/UpcomingEventsTimeline.jsx
+++ b/merger-tracker/frontend/src/components/UpcomingEventsTimeline.jsx
@@ -1,11 +1,22 @@
-import { useMemo } from 'react';
+import { useId, useMemo, useState } from 'react';
 import { Link } from 'react-router';
-import { FaRegComments, FaGavel, FaTriangleExclamation, FaScaleBalanced } from 'react-icons/fa6';
+import {
+  FaRegComments,
+  FaGavel,
+  FaTriangleExclamation,
+  FaScaleBalanced,
+  FaChevronDown,
+} from 'react-icons/fa6';
 import { mergerPath } from '../utils/slug';
 import { formatWeekday, getCalendarDaysUntil } from '../utils/dates';
 import { PHASES } from '../constants/mergerStatus';
 import { CARD } from '../utils/classNames';
 import EmptyStateCard from './EmptyStateCard';
+
+// A day with this many or more events of the same type collapses into a
+// single "N Consultations due" summary row, expandable on click/tap, so a
+// busy day doesn't push everything else off screen.
+const GROUP_COLLAPSE_THRESHOLD = 3;
 
 // Each event type carries its own accent (icon tile + chip) so the kind of
 // deadline is recognisable at a glance, independent of the urgency colouring
@@ -88,7 +99,104 @@ function relativeLabel(daysRemaining) {
   return `In ${daysRemaining} days`;
 }
 
-function UpcomingEventsTimeline({ events }) {
+// Split a day's already-sorted events into runs of consecutive same-type
+// events. compareWithinDay sorts by type first, so each type appears in at
+// most one run per day.
+function groupByType(events) {
+  const groups = [];
+  events.forEach((event) => {
+    const current = groups[groups.length - 1];
+    if (current && current.type === event.type) {
+      current.events.push(event);
+    } else {
+      groups.push({ type: event.type, events: [event] });
+    }
+  });
+  return groups;
+}
+
+function EventRow({ event }) {
+  const eventType = getEventType(event.type);
+  const { Icon } = eventType;
+  return (
+    <Link
+      to={mergerPath(event.merger_id, event.merger_name)}
+      className="group relative flex items-center gap-3 rounded-xl -mx-2 px-2 py-2 transition-colors hover:bg-gray-50"
+      aria-label={`${eventType.label} for ${event.merger_name}`}
+    >
+      <span
+        className={`flex h-8 w-8 flex-none items-center justify-center rounded-lg ${eventType.tile}`}
+        aria-hidden="true"
+      >
+        <Icon className="h-3.5 w-3.5" />
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-semibold text-gray-900 transition-colors group-hover:text-primary">
+          {event.merger_name}
+        </div>
+        <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-gray-500">
+          <span
+            className={`inline-flex items-center rounded-md border px-1.5 py-0.5 font-medium ${eventType.chip}`}
+          >
+            {eventType.label}
+          </span>
+          <span>{event.merger_id}</span>
+          <span aria-hidden="true">·</span>
+          <span className="truncate">{event.stage}</span>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+function EventGroupSummary({ group, expanded, onToggle }) {
+  const eventType = getEventType(group.type);
+  const { Icon } = eventType;
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-expanded={expanded}
+      className="flex w-full items-center gap-3 rounded-xl -mx-2 px-2 py-2 text-left transition-colors hover:bg-gray-50"
+    >
+      <span
+        className={`flex h-8 w-8 flex-none items-center justify-center rounded-lg ${eventType.tile}`}
+        aria-hidden="true"
+      >
+        <Icon className="h-3.5 w-3.5" />
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="text-sm font-semibold text-gray-900">
+          {group.events.length} {eventType.label}s due
+        </div>
+        <div className="mt-1 text-xs text-gray-500">
+          {expanded ? 'Tap to collapse' : 'Tap to expand'}
+        </div>
+      </div>
+      <FaChevronDown
+        className={`h-3.5 w-3.5 flex-none text-gray-400 transition-transform ${expanded ? 'rotate-180' : ''}`}
+        aria-hidden="true"
+      />
+    </button>
+  );
+}
+
+function UpcomingEventsTimeline({ events, heading = 'Upcoming events' }) {
+  const headingId = useId();
+  const [expandedGroups, setExpandedGroups] = useState(() => new Set());
+
+  const toggleGroup = (key) => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
+
   // Group events into one entry per calendar day, ordered earliest first. The
   // date portion (YYYY-MM-DD) is a stable key because every event is stamped at
   // the same UTC noon time.
@@ -109,16 +217,16 @@ function UpcomingEventsTimeline({ events }) {
   }, [events]);
 
   if (days.length === 0) {
-    return <EmptyStateCard heading="Upcoming events" message="No upcoming events." />;
+    return <EmptyStateCard heading={heading} message="No upcoming events." />;
   }
 
   return (
-    <section aria-labelledby="upcoming-events-heading">
+    <section aria-labelledby={headingId}>
       <h2
-        id="upcoming-events-heading"
+        id={headingId}
         className="text-lg font-semibold text-gray-900 mb-4"
       >
-        Upcoming events
+        {heading}
       </h2>
       <div className={`${CARD} overflow-hidden`}>
       <ol className="px-5 sm:px-6 py-5">
@@ -126,9 +234,10 @@ function UpcomingEventsTimeline({ events }) {
           const daysRemaining = getCalendarDaysUntil(day.date);
           const urgency = getUrgency(daysRemaining);
           const isLast = dayIndex === days.length - 1;
+          const dayKey = day.date.slice(0, 10);
 
           return (
-            <li key={day.date.slice(0, 10)} className="relative flex gap-3 sm:gap-4">
+            <li key={dayKey} className="relative flex gap-3 sm:gap-4">
               {/* Timeline rail: a node per day, joined by a line that stops at
                   the final day. */}
               <div className="relative flex w-3 flex-none justify-center">
@@ -154,40 +263,36 @@ function UpcomingEventsTimeline({ events }) {
                 </div>
 
                 <ul className="mt-1.5 space-y-1">
-                  {day.events.map((event) => {
-                    const eventType = getEventType(event.type);
-                    const { Icon } = eventType;
-                    return (
-                      <li key={`${event.merger_id}-${event.date}-${event.type}`}>
-                        <Link
-                          to={mergerPath(event.merger_id, event.merger_name)}
-                          className="group relative flex items-center gap-3 rounded-xl -mx-2 px-2 py-2 transition-colors hover:bg-gray-50"
-                          aria-label={`${eventType.label} for ${event.merger_name}`}
-                        >
-                          <span
-                            className={`flex h-8 w-8 flex-none items-center justify-center rounded-lg ${eventType.tile}`}
-                            aria-hidden="true"
-                          >
-                            <Icon className="h-3.5 w-3.5" />
-                          </span>
-                          <div className="min-w-0 flex-1">
-                            <div className="truncate text-sm font-semibold text-gray-900 transition-colors group-hover:text-primary">
-                              {event.merger_name}
-                            </div>
-                            <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-gray-500">
-                              <span
-                                className={`inline-flex items-center rounded-md border px-1.5 py-0.5 font-medium ${eventType.chip}`}
-                              >
-                                {eventType.label}
-                              </span>
-                              <span>{event.merger_id}</span>
-                              <span aria-hidden="true">·</span>
-                              <span className="truncate">{event.stage}</span>
-                            </div>
-                          </div>
-                        </Link>
-                      </li>
-                    );
+                  {groupByType(day.events).flatMap((group) => {
+                    // A handful of same-type events on one day collapse into
+                    // a single summary row so a busy day doesn't crowd out
+                    // everything else on the timeline.
+                    if (group.events.length < GROUP_COLLAPSE_THRESHOLD) {
+                      return group.events.map((event) => (
+                        <li key={`${event.merger_id}-${event.date}-${event.type}`}>
+                          <EventRow event={event} />
+                        </li>
+                      ));
+                    }
+
+                    const groupKey = `${dayKey}-${group.type}`;
+                    const expanded = expandedGroups.has(groupKey);
+                    return [
+                      <li key={groupKey}>
+                        <EventGroupSummary
+                          group={group}
+                          expanded={expanded}
+                          onToggle={() => toggleGroup(groupKey)}
+                        />
+                      </li>,
+                      ...(expanded
+                        ? group.events.map((event) => (
+                            <li key={`${event.merger_id}-${event.date}-${event.type}`} className="pl-4">
+                              <EventRow event={event} />
+                            </li>
+                          ))
+                        : []),
+                    ];
                   })}
                 </ul>
               </div>

--- a/merger-tracker/frontend/src/components/UpcomingEventsTimeline.jsx
+++ b/merger-tracker/frontend/src/components/UpcomingEventsTimeline.jsx
@@ -1,4 +1,4 @@
-import { useId, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Link } from 'react-router';
 import {
   FaRegComments,
@@ -99,6 +99,12 @@ function relativeLabel(daysRemaining) {
   return `In ${daysRemaining} days`;
 }
 
+// Everything more than a week out is bundled into a single trailing "Later"
+// entry rather than one row per day, so the timeline doesn't stretch across
+// two weeks of individual days. It always reads as calm/far-off.
+const LATER_URGENCY = { dot: 'bg-primary', text: 'text-gray-900' };
+const LATER_KEY = 'later';
+
 // Split a day's already-sorted events into runs of consecutive same-type
 // events. compareWithinDay sorts by type first, so each type appears in at
 // most one run per day.
@@ -165,13 +171,8 @@ function EventGroupSummary({ group, expanded, onToggle }) {
       >
         <Icon className="h-3.5 w-3.5" />
       </span>
-      <div className="min-w-0 flex-1">
-        <div className="text-sm font-semibold text-gray-900">
-          {group.events.length} {eventType.label}s due
-        </div>
-        <div className="mt-1 text-xs text-gray-500">
-          {expanded ? 'Tap to collapse' : 'Tap to expand'}
-        </div>
+      <div className="min-w-0 flex-1 text-sm font-semibold text-gray-900">
+        {group.events.length} {eventType.label}s due
       </div>
       <FaChevronDown
         className={`h-3.5 w-3.5 flex-none text-gray-400 transition-transform ${expanded ? 'rotate-180' : ''}`}
@@ -181,8 +182,7 @@ function EventGroupSummary({ group, expanded, onToggle }) {
   );
 }
 
-function UpcomingEventsTimeline({ events, heading = 'Upcoming events' }) {
-  const headingId = useId();
+function UpcomingEventsTimeline({ events }) {
   const [expandedGroups, setExpandedGroups] = useState(() => new Set());
 
   const toggleGroup = (key) => {
@@ -197,9 +197,11 @@ function UpcomingEventsTimeline({ events, heading = 'Upcoming events' }) {
     });
   };
 
-  // Group events into one entry per calendar day, ordered earliest first. The
-  // date portion (YYYY-MM-DD) is a stable key because every event is stamped at
-  // the same UTC noon time.
+  // Group events into one entry per calendar day for the coming week, ordered
+  // earliest first (the date portion, YYYY-MM-DD, is a stable key because
+  // every event is stamped at the same UTC noon time). Anything more than a
+  // week out is bundled into a single trailing "later" entry instead of one
+  // row per day.
   const days = useMemo(() => {
     if (!events) return [];
     const byDay = new Map();
@@ -209,32 +211,41 @@ function UpcomingEventsTimeline({ events, heading = 'Upcoming events' }) {
         return dayDelta !== 0 ? dayDelta : compareWithinDay(a, b);
       })
       .forEach((event) => {
-        const key = event.date.slice(0, 10);
-        if (!byDay.has(key)) byDay.set(key, { date: event.date, events: [] });
+        const daysRemaining = getCalendarDaysUntil(event.date);
+        const isLater = daysRemaining !== null && daysRemaining > 7;
+        const key = isLater ? LATER_KEY : event.date.slice(0, 10);
+        if (!byDay.has(key)) {
+          byDay.set(key, isLater ? { key, later: true, events: [] } : { key, date: event.date, events: [] });
+        }
         byDay.get(key).events.push(event);
       });
+    // The later bucket's events were sorted chronologically above; re-sort by
+    // type/phase/name only, since it's presented as one combined entry rather
+    // than day-by-day.
+    const later = byDay.get(LATER_KEY);
+    if (later) later.events.sort(compareWithinDay);
     return [...byDay.values()];
   }, [events]);
 
   if (days.length === 0) {
-    return <EmptyStateCard heading={heading} message="No upcoming events." />;
+    return <EmptyStateCard heading="Upcoming events" message="No upcoming events." />;
   }
 
   return (
-    <section aria-labelledby={headingId}>
+    <section aria-labelledby="upcoming-events-heading">
       <h2
-        id={headingId}
+        id="upcoming-events-heading"
         className="text-lg font-semibold text-gray-900 mb-4"
       >
-        {heading}
+        Upcoming events
       </h2>
       <div className={`${CARD} overflow-hidden`}>
       <ol className="px-5 sm:px-6 py-5">
         {days.map((day, dayIndex) => {
-          const daysRemaining = getCalendarDaysUntil(day.date);
-          const urgency = getUrgency(daysRemaining);
+          const daysRemaining = day.later ? null : getCalendarDaysUntil(day.date);
+          const urgency = day.later ? LATER_URGENCY : getUrgency(daysRemaining);
           const isLast = dayIndex === days.length - 1;
-          const dayKey = day.date.slice(0, 10);
+          const dayKey = day.key;
 
           return (
             <li key={dayKey} className="relative flex gap-3 sm:gap-4">
@@ -257,9 +268,11 @@ function UpcomingEventsTimeline({ events, heading = 'Upcoming events' }) {
               <div className={`min-w-0 flex-1 ${isLast ? '' : 'pb-6'}`}>
                 <div className="flex items-baseline gap-2">
                   <span className={`text-sm font-semibold ${urgency.text}`}>
-                    {relativeLabel(daysRemaining)}
+                    {day.later ? 'Later' : relativeLabel(daysRemaining)}
                   </span>
-                  <span className="text-xs text-gray-500">{formatWeekday(day.date)}</span>
+                  {!day.later && (
+                    <span className="text-xs text-gray-500">{formatWeekday(day.date)}</span>
+                  )}
                 </div>
 
                 <ul className="mt-1.5 space-y-1">

--- a/merger-tracker/frontend/src/components/__tests__/UpcomingEventsTimeline.test.jsx
+++ b/merger-tracker/frontend/src/components/__tests__/UpcomingEventsTimeline.test.jsx
@@ -36,6 +36,17 @@ describe('UpcomingEventsTimeline', () => {
     expect(screen.getByText('No upcoming events.')).toBeInTheDocument();
   });
 
+  it('exposes each day as a heading under the section heading, for screen-reader navigation', () => {
+    renderTimeline([
+      makeEvent({ date: '2026-06-28T12:00:00Z', merger_id: 'MN-1' }),
+      makeEvent({ date: '2026-06-29T12:00:00Z', merger_id: 'MN-2' }),
+    ]);
+
+    expect(screen.getByRole('heading', { level: 2, name: 'Upcoming events' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 3, name: 'Today' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 3, name: 'Tomorrow' })).toBeInTheDocument();
+  });
+
   it('groups events by day with relative labels and the event date', () => {
     renderTimeline([
       makeEvent({ date: '2026-06-28T12:00:00Z', merger_id: 'MN-1' }),

--- a/merger-tracker/frontend/src/components/__tests__/UpcomingEventsTimeline.test.jsx
+++ b/merger-tracker/frontend/src/components/__tests__/UpcomingEventsTimeline.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import UpcomingEventsTimeline from '../UpcomingEventsTimeline';
@@ -99,6 +99,10 @@ describe('UpcomingEventsTimeline', () => {
       }),
     ]);
 
+    // Three determination_due events collapse into a summary by default;
+    // expand it to check the ordering underneath.
+    fireEvent.click(screen.getByRole('button', { name: /3 Determinations due/ }));
+
     const links = screen.getAllByRole('link');
     const names = links.map((link) => within(link).getByText(/–/).textContent);
 
@@ -159,5 +163,49 @@ describe('UpcomingEventsTimeline', () => {
     const links = screen.getAllByRole('link');
     const names = links.map((l) => within(l).getByText(/–/).textContent);
     expect(names).toEqual(['Coles – Kalgoorlie', 'Zed – Determination']);
+  });
+
+  it('collapses 3+ same-type events on a day into a summary, expandable on click', () => {
+    renderTimeline([
+      makeEvent({ date: '2026-06-30T12:00:00Z', merger_id: 'MN-1', merger_name: 'Alpha – One' }),
+      makeEvent({ date: '2026-06-30T12:00:00Z', merger_id: 'MN-2', merger_name: 'Bravo – Two' }),
+      makeEvent({ date: '2026-06-30T12:00:00Z', merger_id: 'MN-3', merger_name: 'Charlie – Three' }),
+      makeEvent({ date: '2026-06-30T12:00:00Z', merger_id: 'MN-4', merger_name: 'Delta – Four' }),
+    ]);
+
+    const summary = screen.getByRole('button', { name: /4 Consultations due/ });
+    expect(summary).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByText('Alpha – One')).not.toBeInTheDocument();
+
+    fireEvent.click(summary);
+
+    expect(summary).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('Alpha – One')).toBeInTheDocument();
+    expect(screen.getByText('Delta – Four')).toBeInTheDocument();
+
+    fireEvent.click(summary);
+    expect(summary).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByText('Alpha – One')).not.toBeInTheDocument();
+  });
+
+  it('does not collapse a group of fewer than 3 same-type events', () => {
+    renderTimeline([
+      makeEvent({ date: '2026-06-30T12:00:00Z', merger_id: 'MN-1', merger_name: 'Alpha – One' }),
+      makeEvent({ date: '2026-06-30T12:00:00Z', merger_id: 'MN-2', merger_name: 'Bravo – Two' }),
+    ]);
+
+    expect(screen.queryByRole('button', { name: /Consultations due/ })).not.toBeInTheDocument();
+    expect(screen.getByText('Alpha – One')).toBeInTheDocument();
+    expect(screen.getByText('Bravo – Two')).toBeInTheDocument();
+  });
+
+  it('renders a custom heading', () => {
+    render(
+      <MemoryRouter>
+        <UpcomingEventsTimeline events={[makeEvent({})]} heading="Later" />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('heading', { name: 'Later' })).toBeInTheDocument();
   });
 });

--- a/merger-tracker/frontend/src/components/__tests__/UpcomingEventsTimeline.test.jsx
+++ b/merger-tracker/frontend/src/components/__tests__/UpcomingEventsTimeline.test.jsx
@@ -199,13 +199,49 @@ describe('UpcomingEventsTimeline', () => {
     expect(screen.getByText('Bravo – Two')).toBeInTheDocument();
   });
 
-  it('renders a custom heading', () => {
-    render(
-      <MemoryRouter>
-        <UpcomingEventsTimeline events={[makeEvent({})]} heading="Later" />
-      </MemoryRouter>
-    );
+  it('bundles events more than a week out into a single trailing "Later" entry', () => {
+    renderTimeline([
+      makeEvent({ date: '2026-06-29T12:00:00Z', merger_id: 'MN-1', merger_name: 'Alpha – Soon' }),
+      // 8 and 12 days out: different calendar days, but both beyond the
+      // 7-day cutoff, so both land under the same "Later" heading.
+      makeEvent({ date: '2026-07-06T12:00:00Z', merger_id: 'MN-2', merger_name: 'Bravo – Later' }),
+      makeEvent({ date: '2026-07-10T12:00:00Z', merger_id: 'MN-3', merger_name: 'Charlie – Later' }),
+    ]);
 
-    expect(screen.getByRole('heading', { name: 'Later' })).toBeInTheDocument();
+    expect(screen.getByText('Tomorrow')).toBeInTheDocument();
+    expect(screen.getByText('Alpha – Soon')).toBeInTheDocument();
+
+    expect(screen.getAllByText('Later')).toHaveLength(1);
+    expect(screen.getByText('Bravo – Later')).toBeInTheDocument();
+    expect(screen.getByText('Charlie – Later')).toBeInTheDocument();
+    // No per-day weekday label for the combined entry.
+    expect(screen.queryByText(/Jul/)).not.toBeInTheDocument();
+  });
+
+  it('applies the same 3+ collapse threshold within the combined "Later" entry', () => {
+    renderTimeline([
+      makeEvent({ date: '2026-07-06T12:00:00Z', merger_id: 'MN-1', merger_name: 'Alpha – One' }),
+      makeEvent({ date: '2026-07-08T12:00:00Z', merger_id: 'MN-2', merger_name: 'Bravo – Two' }),
+      makeEvent({ date: '2026-07-10T12:00:00Z', merger_id: 'MN-3', merger_name: 'Charlie – Three' }),
+    ]);
+
+    const summary = screen.getByRole('button', { name: /3 Consultations due/ });
+    expect(screen.queryByText('Alpha – One')).not.toBeInTheDocument();
+
+    fireEvent.click(summary);
+    expect(screen.getByText('Alpha – One')).toBeInTheDocument();
+    expect(screen.getByText('Charlie – Three')).toBeInTheDocument();
+  });
+
+  it('shows only a chevron on a collapsed group, with no expand/collapse hint text', () => {
+    renderTimeline([
+      makeEvent({ date: '2026-06-30T12:00:00Z', merger_id: 'MN-1', merger_name: 'Alpha – One' }),
+      makeEvent({ date: '2026-06-30T12:00:00Z', merger_id: 'MN-2', merger_name: 'Bravo – Two' }),
+      makeEvent({ date: '2026-06-30T12:00:00Z', merger_id: 'MN-3', merger_name: 'Charlie – Three' }),
+    ]);
+
+    expect(screen.queryByText('Tap to expand')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /3 Consultations due/ }));
+    expect(screen.queryByText('Tap to collapse')).not.toBeInTheDocument();
   });
 });

--- a/merger-tracker/frontend/src/components/__tests__/UpcomingEventsTimeline.test.jsx
+++ b/merger-tracker/frontend/src/components/__tests__/UpcomingEventsTimeline.test.jsx
@@ -229,9 +229,10 @@ describe('UpcomingEventsTimeline', () => {
     renderTimeline([
       makeEvent({ date: '2026-06-29T12:00:00Z', merger_id: 'MN-1', merger_name: 'Alpha – Soon' }),
       // 8 and 12 days out: different calendar days, but both beyond the
-      // 7-day cutoff, so both land under the same "Later" heading.
-      makeEvent({ date: '2026-07-06T12:00:00Z', merger_id: 'MN-2', merger_name: 'Bravo – Later' }),
-      makeEvent({ date: '2026-07-10T12:00:00Z', merger_id: 'MN-3', merger_name: 'Charlie – Later' }),
+      // 7-day cutoff, so both land under the same "Later" heading. Different
+      // types so they don't fall into the 2+ collapse threshold.
+      makeEvent({ date: '2026-07-06T12:00:00Z', merger_id: 'MN-2', merger_name: 'Bravo – Later', type: 'consultation_due' }),
+      makeEvent({ date: '2026-07-10T12:00:00Z', merger_id: 'MN-3', merger_name: 'Charlie – Later', type: 'determination_due' }),
     ]);
 
     expect(screen.getByText('Tomorrow')).toBeInTheDocument();
@@ -245,19 +246,30 @@ describe('UpcomingEventsTimeline', () => {
     expect(screen.getByText('6 Jul – 10 Jul')).toBeInTheDocument();
   });
 
-  it('applies the same 3+ collapse threshold within the combined "Later" entry', () => {
+  it('collapses a group of just 2 same-type events within the combined "Later" entry', () => {
+    // The Later entry already bundles a whole week, so it collapses a type
+    // as soon as there's more than one, unlike the 3+ threshold used for an
+    // individual day.
     renderTimeline([
       makeEvent({ date: '2026-07-06T12:00:00Z', merger_id: 'MN-1', merger_name: 'Alpha – One' }),
-      makeEvent({ date: '2026-07-08T12:00:00Z', merger_id: 'MN-2', merger_name: 'Bravo – Two' }),
-      makeEvent({ date: '2026-07-10T12:00:00Z', merger_id: 'MN-3', merger_name: 'Charlie – Three' }),
+      makeEvent({ date: '2026-07-10T12:00:00Z', merger_id: 'MN-2', merger_name: 'Bravo – Two' }),
     ]);
 
-    const summary = screen.getByRole('button', { name: /3 consultations due/ });
+    const summary = screen.getByRole('button', { name: /2 consultations due/ });
     expect(screen.queryByText('Alpha – One')).not.toBeInTheDocument();
 
     fireEvent.click(summary);
     expect(screen.getByText('Alpha – One')).toBeInTheDocument();
-    expect(screen.getByText('Charlie – Three')).toBeInTheDocument();
+    expect(screen.getByText('Bravo – Two')).toBeInTheDocument();
+  });
+
+  it('does not collapse a single event within the combined "Later" entry', () => {
+    renderTimeline([
+      makeEvent({ date: '2026-07-06T12:00:00Z', merger_id: 'MN-1', merger_name: 'Alpha – One' }),
+    ]);
+
+    expect(screen.queryByRole('button', { name: /consultations due/ })).not.toBeInTheDocument();
+    expect(screen.getByText('Alpha – One')).toBeInTheDocument();
   });
 
   it('shows only a chevron on a collapsed group, with no expand/collapse hint text', () => {

--- a/merger-tracker/frontend/src/components/__tests__/UpcomingEventsTimeline.test.jsx
+++ b/merger-tracker/frontend/src/components/__tests__/UpcomingEventsTimeline.test.jsx
@@ -214,8 +214,9 @@ describe('UpcomingEventsTimeline', () => {
     expect(screen.getAllByText('Later')).toHaveLength(1);
     expect(screen.getByText('Bravo – Later')).toBeInTheDocument();
     expect(screen.getByText('Charlie – Later')).toBeInTheDocument();
-    // No per-day weekday label for the combined entry.
-    expect(screen.queryByText(/Jul/)).not.toBeInTheDocument();
+    // Date range spans the earliest to latest event in the bundle, not a
+    // single weekday label.
+    expect(screen.getByText('6 Jul – 10 Jul')).toBeInTheDocument();
   });
 
   it('applies the same 3+ collapse threshold within the combined "Later" entry', () => {

--- a/merger-tracker/frontend/src/components/__tests__/UpcomingEventsTimeline.test.jsx
+++ b/merger-tracker/frontend/src/components/__tests__/UpcomingEventsTimeline.test.jsx
@@ -188,6 +188,21 @@ describe('UpcomingEventsTimeline', () => {
     expect(screen.queryByText('Alpha – One')).not.toBeInTheDocument();
   });
 
+  it('points the summary button\'s aria-controls at the revealed events', () => {
+    renderTimeline([
+      makeEvent({ date: '2026-06-30T12:00:00Z', merger_id: 'MN-1', merger_name: 'Alpha – One' }),
+      makeEvent({ date: '2026-06-30T12:00:00Z', merger_id: 'MN-2', merger_name: 'Bravo – Two' }),
+      makeEvent({ date: '2026-06-30T12:00:00Z', merger_id: 'MN-3', merger_name: 'Charlie – Three' }),
+    ]);
+
+    const summary = screen.getByRole('button', { name: /3 Consultations due/ });
+    const controlsId = summary.getAttribute('aria-controls');
+    expect(controlsId).toBeTruthy();
+
+    fireEvent.click(summary);
+    expect(document.getElementById(controlsId)).toContainElement(screen.getByText('Alpha – One'));
+  });
+
   it('does not collapse a group of fewer than 3 same-type events', () => {
     renderTimeline([
       makeEvent({ date: '2026-06-30T12:00:00Z', merger_id: 'MN-1', merger_name: 'Alpha – One' }),

--- a/merger-tracker/frontend/src/components/__tests__/UpcomingEventsTimeline.test.jsx
+++ b/merger-tracker/frontend/src/components/__tests__/UpcomingEventsTimeline.test.jsx
@@ -101,7 +101,7 @@ describe('UpcomingEventsTimeline', () => {
 
     // Three determination_due events collapse into a summary by default;
     // expand it to check the ordering underneath.
-    fireEvent.click(screen.getByRole('button', { name: /3 Determinations due/ }));
+    fireEvent.click(screen.getByRole('button', { name: /3 determinations due/ }));
 
     const links = screen.getAllByRole('link');
     const names = links.map((link) => within(link).getByText(/–/).textContent);
@@ -173,7 +173,7 @@ describe('UpcomingEventsTimeline', () => {
       makeEvent({ date: '2026-06-30T12:00:00Z', merger_id: 'MN-4', merger_name: 'Delta – Four' }),
     ]);
 
-    const summary = screen.getByRole('button', { name: /4 Consultations due/ });
+    const summary = screen.getByRole('button', { name: /4 consultations due/ });
     expect(summary).toHaveAttribute('aria-expanded', 'false');
     expect(screen.queryByText('Alpha – One')).not.toBeInTheDocument();
 
@@ -195,7 +195,7 @@ describe('UpcomingEventsTimeline', () => {
       makeEvent({ date: '2026-06-30T12:00:00Z', merger_id: 'MN-3', merger_name: 'Charlie – Three' }),
     ]);
 
-    const summary = screen.getByRole('button', { name: /3 Consultations due/ });
+    const summary = screen.getByRole('button', { name: /3 consultations due/ });
     const controlsId = summary.getAttribute('aria-controls');
     expect(controlsId).toBeTruthy();
 
@@ -209,7 +209,7 @@ describe('UpcomingEventsTimeline', () => {
       makeEvent({ date: '2026-06-30T12:00:00Z', merger_id: 'MN-2', merger_name: 'Bravo – Two' }),
     ]);
 
-    expect(screen.queryByRole('button', { name: /Consultations due/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /consultations due/ })).not.toBeInTheDocument();
     expect(screen.getByText('Alpha – One')).toBeInTheDocument();
     expect(screen.getByText('Bravo – Two')).toBeInTheDocument();
   });
@@ -241,7 +241,7 @@ describe('UpcomingEventsTimeline', () => {
       makeEvent({ date: '2026-07-10T12:00:00Z', merger_id: 'MN-3', merger_name: 'Charlie – Three' }),
     ]);
 
-    const summary = screen.getByRole('button', { name: /3 Consultations due/ });
+    const summary = screen.getByRole('button', { name: /3 consultations due/ });
     expect(screen.queryByText('Alpha – One')).not.toBeInTheDocument();
 
     fireEvent.click(summary);
@@ -257,7 +257,7 @@ describe('UpcomingEventsTimeline', () => {
     ]);
 
     expect(screen.queryByText('Tap to expand')).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: /3 Consultations due/ }));
+    fireEvent.click(screen.getByRole('button', { name: /3 consultations due/ }));
     expect(screen.queryByText('Tap to collapse')).not.toBeInTheDocument();
   });
 });

--- a/merger-tracker/frontend/src/pages/Dashboard.jsx
+++ b/merger-tracker/frontend/src/pages/Dashboard.jsx
@@ -232,20 +232,33 @@ function Dashboard() {
         </div>
       )}
 
-      {/* Upcoming Events (within 7 days) */}
+      {/* Upcoming Events: this week, then a "Later" timeline for the week
+          after. Both use calendar-day counts so the split agrees with the
+          day counts UpcomingEventsTimeline renders for the same events. */}
       {upcomingEvents && (() => {
         const eventsWithin7Days = upcomingEvents.filter(event => {
           if (isDatePast(event.date)) return false;
-          // Calendar-day count so the filter agrees with the day counts
-          // UpcomingEventsTimeline renders for the same events.
           const daysRemaining = getCalendarDaysUntil(event.date);
           return daysRemaining !== null && daysRemaining <= 7;
         });
-        return eventsWithin7Days.length > 0 ? (
-          <div className="mb-8">
-            <UpcomingEventsTimeline events={eventsWithin7Days} />
-          </div>
-        ) : null;
+        const eventsNextWeek = upcomingEvents.filter(event => {
+          const daysRemaining = getCalendarDaysUntil(event.date);
+          return daysRemaining !== null && daysRemaining > 7 && daysRemaining <= 14;
+        });
+        return (
+          <>
+            {eventsWithin7Days.length > 0 && (
+              <div className="mb-8">
+                <UpcomingEventsTimeline events={eventsWithin7Days} />
+              </div>
+            )}
+            {eventsNextWeek.length > 0 && (
+              <div className="mb-8">
+                <UpcomingEventsTimeline events={eventsNextWeek} heading="Later" />
+              </div>
+            )}
+          </>
+        );
       })()}
 
       {/* Charts */}

--- a/merger-tracker/frontend/src/pages/Dashboard.jsx
+++ b/merger-tracker/frontend/src/pages/Dashboard.jsx
@@ -232,33 +232,22 @@ function Dashboard() {
         </div>
       )}
 
-      {/* Upcoming Events: this week, then a "Later" timeline for the week
-          after. Both use calendar-day counts so the split agrees with the
-          day counts UpcomingEventsTimeline renders for the same events. */}
+      {/* Upcoming Events: the next 7 days broken out day by day, plus the
+          week after bundled into a single trailing "Later" entry (handled
+          inside UpcomingEventsTimeline). Calendar-day counts so the cutoff
+          agrees with the day counts the timeline renders for the same
+          events. */}
       {upcomingEvents && (() => {
-        const eventsWithin7Days = upcomingEvents.filter(event => {
+        const eventsWithin14Days = upcomingEvents.filter(event => {
           if (isDatePast(event.date)) return false;
           const daysRemaining = getCalendarDaysUntil(event.date);
-          return daysRemaining !== null && daysRemaining <= 7;
+          return daysRemaining !== null && daysRemaining <= 14;
         });
-        const eventsNextWeek = upcomingEvents.filter(event => {
-          const daysRemaining = getCalendarDaysUntil(event.date);
-          return daysRemaining !== null && daysRemaining > 7 && daysRemaining <= 14;
-        });
-        return (
-          <>
-            {eventsWithin7Days.length > 0 && (
-              <div className="mb-8">
-                <UpcomingEventsTimeline events={eventsWithin7Days} />
-              </div>
-            )}
-            {eventsNextWeek.length > 0 && (
-              <div className="mb-8">
-                <UpcomingEventsTimeline events={eventsNextWeek} heading="Later" />
-              </div>
-            )}
-          </>
-        );
+        return eventsWithin14Days.length > 0 ? (
+          <div className="mb-8">
+            <UpcomingEventsTimeline events={eventsWithin14Days} />
+          </div>
+        ) : null;
       })()}
 
       {/* Charts */}

--- a/merger-tracker/frontend/src/utils/dates.js
+++ b/merger-tracker/frontend/src/utils/dates.js
@@ -245,6 +245,25 @@ export const formatWeekday = (dateString) => {
   }
 };
 
+/**
+ * Format a date range as day + month for each end (e.g. "2 Sep – 7 Sep"),
+ * for agenda views that bundle several days under one heading.
+ * @param {string} startDate - Start date in ISO format
+ * @param {string} endDate - End date in ISO format
+ * @returns {string} The formatted range
+ */
+export const formatDateRange = (startDate, endDate) => {
+  if (!startDate || !endDate) return 'N/A';
+  try {
+    const start = parseDateOnly(startDate);
+    const end = parseDateOnly(endDate);
+    if (!isValid(start) || !isValid(end)) return 'Invalid date';
+    return `${format(start, 'd MMM')} – ${format(end, 'd MMM')}`;
+  } catch {
+    return 'Invalid date';
+  }
+};
+
 export const calculateDuration = (startDate, endDate) => {
   if (!startDate || !endDate) return null;
   try {


### PR DESCRIPTION
Days with 3+ events of the same type (e.g. consultations) now collapse
into a "N Consultations due" summary that expands on click/tap, so a
busy day doesn't crowd the list. The dashboard also gains a second
"Later" timeline covering the following week (days 8-14), using the
same grouping.