### PR TITLE
Add judicial review card for merger detail page

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -134,6 +134,14 @@ data/
 │                         #   tribunal matter pages by scripts/scrape_tribunal.py (the daily
 │                         #   scrape-tribunal.yml workflow, which drives a real Chrome via
 │                         #   nodriver to clear Cloudflare); the other fields are hand-maintained.
+│                         #   judicial_reviews.json is a hand-maintained overlay of Federal Court
+│                         #   judicial reviews, keyed by merger_id, merged in at
+│                         #   generate_static_data time (loaders.load_judicial_reviews +
+│                         #   enrichment.link_judicial_reviews). Sets the merger's
+│                         #   judicial_review record (applicant, filed date, case number, case
+│                         #   URL) for a link-out card to the Commonwealth Courts Portal. Unlike
+│                         #   tribunal_appeals.json there is no scraping and no documents are
+│                         #   mirrored — every field is entered by hand.
 ├── known_notification_dates.json # Manually-confirmed/frozen notification dates
 │   processed/phase1_estimates.json # Frozen filing-time phase-1 duration estimates,
 │                         #   keyed by merger_id. Written by generate_static_data.py

--- a/data/output/mergers.json
+++ b/data/output/mergers.json
@@ -4152,6 +4152,12 @@
           }
         ]
       },
+      "judicial_review": {
+        "applicant": "Coles",
+        "filed_date": "2026-07-15",
+        "case_number": "NSD1310/2026",
+        "case_url": "https://www.comcourts.gov.au/file/Federal/P/nsd1310/2026/actions"
+      },
       "phase_1_estimate": {
         "expected_business_days": 18,
         "range_business_days": [

--- a/data/output/mergers.json
+++ b/data/output/mergers.json
@@ -4154,7 +4154,7 @@
       },
       "judicial_review": {
         "applicant": "Coles",
-        "filed_date": "2026-07-15",
+        "filed_date": "2026-07-17",
         "case_number": "NSD1310/2026",
         "case_url": "https://www.comcourts.gov.au/file/Federal/P/nsd1310/2026/actions"
       },

--- a/data/processed/judicial_reviews.json
+++ b/data/processed/judicial_reviews.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "Manually-maintained Federal Court of Australia judicial review data, keyed by ACCC merger_id. Merged into the frontend data by scripts/static_data (see loaders.load_judicial_reviews and enrichment.link_judicial_reviews). Unlike tribunal_appeals.json, no documents are scraped or mirrored here — this is just enough to surface a link-out card to the court's own case page on the Commonwealth Courts Portal. Fields: applicant (who sought the review), filed_date (bare ISO 'YYYY-MM-DD'), case_number (the Federal Court file number, e.g. 'NSD1310/2026'), case_url (the Commonwealth Courts Portal case page, e.g. https://www.comcourts.gov.au/file/Federal/P/nsd1310/2026/actions). All fields are hand-maintained.",
+  "MN-01068": {
+    "applicant": "Coles",
+    "filed_date": "2026-07-15",
+    "case_number": "NSD1310/2026",
+    "case_url": "https://www.comcourts.gov.au/file/Federal/P/nsd1310/2026/actions"
+  }
+}

--- a/data/processed/judicial_reviews.json
+++ b/data/processed/judicial_reviews.json
@@ -2,7 +2,7 @@
   "_comment": "Manually-maintained Federal Court of Australia judicial review data, keyed by ACCC merger_id. Merged into the frontend data by scripts/static_data (see loaders.load_judicial_reviews and enrichment.link_judicial_reviews). Unlike tribunal_appeals.json, no documents are scraped or mirrored here — this is just enough to surface a link-out card to the court's own case page on the Commonwealth Courts Portal. Fields: applicant (who sought the review), filed_date (bare ISO 'YYYY-MM-DD'), case_number (the Federal Court file number, e.g. 'NSD1310/2026'), case_url (the Commonwealth Courts Portal case page, e.g. https://www.comcourts.gov.au/file/Federal/P/nsd1310/2026/actions). All fields are hand-maintained.",
   "MN-01068": {
     "applicant": "Coles",
-    "filed_date": "2026-07-15",
+    "filed_date": "2026-07-17",
     "case_number": "NSD1310/2026",
     "case_url": "https://www.comcourts.gov.au/file/Federal/P/nsd1310/2026/actions"
   }

--- a/merger-tracker/frontend/public/data/mergers/MN-01068.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-01068.json
@@ -679,7 +679,7 @@
   },
   "judicial_review": {
     "applicant": "Coles",
-    "filed_date": "2026-07-15",
+    "filed_date": "2026-07-17",
     "case_number": "NSD1310/2026",
     "case_url": "https://www.comcourts.gov.au/file/Federal/P/nsd1310/2026/actions"
   },

--- a/merger-tracker/frontend/public/data/mergers/MN-01068.json
+++ b/merger-tracker/frontend/public/data/mergers/MN-01068.json
@@ -677,6 +677,12 @@
       }
     ]
   },
+  "judicial_review": {
+    "applicant": "Coles",
+    "filed_date": "2026-07-15",
+    "case_number": "NSD1310/2026",
+    "case_url": "https://www.comcourts.gov.au/file/Federal/P/nsd1310/2026/actions"
+  },
   "phase_1_estimate": {
     "expected_business_days": 18,
     "range_business_days": [

--- a/merger-tracker/frontend/src/pages/MergerDetail.jsx
+++ b/merger-tracker/frontend/src/pages/MergerDetail.jsx
@@ -424,11 +424,11 @@ function MergerDetail() {
             href={merger.judicial_review.case_url}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-3 bg-blue-50/80 rounded-2xl border border-blue-200/60 shadow-card p-4 mb-6 hover:bg-blue-50 hover:border-blue-300/60 transition-all group"
+            className="flex items-center gap-3 bg-amber-50/80 rounded-2xl border border-amber-200/60 shadow-card p-4 mb-6 hover:bg-amber-50 hover:border-amber-300/60 transition-all group"
             aria-label={`View the judicial review case${merger.judicial_review.applicant ? ` requested by ${merger.judicial_review.applicant}` : ''} on the Commonwealth Courts Portal`}
           >
-            <div className="flex-shrink-0 w-9 h-9 rounded-xl bg-blue-100 flex items-center justify-center">
-              <FaBalanceScale className="h-4 w-4 text-blue-600" aria-hidden="true" />
+            <div className="flex-shrink-0 w-9 h-9 rounded-xl bg-amber-100 flex items-center justify-center">
+              <FaBalanceScale className="h-4 w-4 text-amber-600" aria-hidden="true" />
             </div>
             <div className="flex-1 min-w-0">
               <p className="text-sm font-medium text-gray-900">
@@ -439,7 +439,7 @@ function MergerDetail() {
                 {merger.judicial_review.case_number}
               </p>
             </div>
-            <ExternalLinkIcon className="h-3.5 w-3.5 text-blue-600 flex-shrink-0" />
+            <ExternalLinkIcon className="h-3.5 w-3.5 text-amber-600 flex-shrink-0" />
           </a>
         )}
 

--- a/merger-tracker/frontend/src/pages/MergerDetail.jsx
+++ b/merger-tracker/frontend/src/pages/MergerDetail.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate, Link } from 'react-router';
-import { FaChevronLeft, FaLink, FaComment, FaGavel } from 'react-icons/fa';
+import { FaChevronLeft, FaLink, FaComment, FaGavel, FaBalanceScale } from 'react-icons/fa';
 import ReactMarkdown from 'react-markdown';
 import LoadingSpinner from '../components/LoadingSpinner';
 import ErrorCard from '../components/ErrorCard';
@@ -412,6 +412,34 @@ function MergerDetail() {
               </p>
             </div>
             <ExternalLinkIcon className="h-3.5 w-3.5 text-amber-600 flex-shrink-0" />
+          </a>
+        )}
+
+        {/* Judicial review link — a Federal Court review is a separate avenue
+            from a Tribunal appeal, so this links straight to the court's own
+            case page on the Commonwealth Courts Portal rather than to any
+            locally-hosted document. */}
+        {merger.judicial_review?.case_url && (
+          <a
+            href={merger.judicial_review.case_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-3 bg-blue-50/80 rounded-2xl border border-blue-200/60 shadow-card p-4 mb-6 hover:bg-blue-50 hover:border-blue-300/60 transition-all group"
+            aria-label={`View the judicial review case${merger.judicial_review.applicant ? ` requested by ${merger.judicial_review.applicant}` : ''} on the Commonwealth Courts Portal`}
+          >
+            <div className="flex-shrink-0 w-9 h-9 rounded-xl bg-blue-100 flex items-center justify-center">
+              <FaBalanceScale className="h-4 w-4 text-blue-600" aria-hidden="true" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-gray-900">
+                {merger.judicial_review.applicant ? `Judicial review requested by ${merger.judicial_review.applicant}` : 'Judicial review requested'}
+                {merger.judicial_review.filed_date ? ` on ${formatDateLong(merger.judicial_review.filed_date)}` : ''}
+              </p>
+              <p className="text-xs text-gray-500 mt-0.5">
+                {merger.judicial_review.case_number}
+              </p>
+            </div>
+            <ExternalLinkIcon className="h-3.5 w-3.5 text-blue-600 flex-shrink-0" />
           </a>
         )}
 

--- a/scripts/generate_static_data.py
+++ b/scripts/generate_static_data.py
@@ -51,6 +51,7 @@ from pathlib import Path
 from static_data.business_days import check_holiday_horizon
 from static_data.enrichment import (
     enrich_merger,
+    link_judicial_reviews,
     link_related_mergers,
     link_related_parties,
     link_similar_mergers,
@@ -65,6 +66,7 @@ from static_data.loaders import (
     load_nocc_data,
     load_questionnaire_data,
     load_related_mergers,
+    load_judicial_reviews,
     load_related_parties,
     load_similar_mergers,
     load_tribunal_appeals,
@@ -141,6 +143,10 @@ def main():
     if tribunal_appeals:
         print(f"Loaded {len(tribunal_appeals)} tribunal appeal(s)")
 
+    judicial_reviews = load_judicial_reviews()
+    if judicial_reviews:
+        print(f"Loaded {len(judicial_reviews)} judicial review(s)")
+
     print("Enriching mergers...")
     enriched = [
         enrich_merger(m, commentary, questionnaire_data, nocc_data) for m in mergers
@@ -157,6 +163,9 @@ def main():
     appeal_linked = link_tribunal_appeals(enriched, tribunal_appeals)
     if appeal_linked:
         print(f"  Linked {appeal_linked} tribunal appeal(s)")
+    judicial_review_linked = link_judicial_reviews(enriched, judicial_reviews)
+    if judicial_review_linked:
+        print(f"  Linked {judicial_review_linked} judicial review(s)")
     # Freeze + attach filing-time phase-1 duration estimates. New notification
     # mergers get an estimate computed from completed-review history and frozen
     # into data/processed/phase1_estimates.json; existing entries are reused so

--- a/scripts/static_data/enrichment.py
+++ b/scripts/static_data/enrichment.py
@@ -502,6 +502,38 @@ def link_tribunal_appeals(enriched_mergers: list, appeals: dict) -> int:
     return linked
 
 
+def link_judicial_reviews(enriched_mergers: list, judicial_reviews: dict) -> int:
+    """Attach Federal Court judicial review data to mergers in-place.
+
+    For every merger with an entry in ``judicial_reviews`` (keyed by
+    merger_id), sets ``judicial_review`` to the review record (applicant,
+    filed date, case number, case URL) so a link-out card to the court's
+    Commonwealth Courts Portal case page can be rendered on the detail page.
+
+    Unlike tribunal appeals, no documents are scraped or mirrored, and no
+    lifecycle status is tracked — this is deliberately a much lighter overlay.
+    Returns the number of mergers linked.
+    """
+    if not judicial_reviews:
+        return 0
+
+    linked = 0
+    for merger in enriched_mergers:
+        mid = merger.get('merger_id', '')
+        review = judicial_reviews.get(mid)
+        if not review:
+            continue
+
+        merger['judicial_review'] = {
+            'applicant': review.get('applicant'),
+            'filed_date': review.get('filed_date'),
+            'case_number': review.get('case_number'),
+            'case_url': review.get('case_url'),
+        }
+        linked += 1
+    return linked
+
+
 def link_related_mergers(enriched_mergers: list, related_mergers: dict) -> int:
     """Attach ``related_merger`` entries to each merger in-place, with resolved names.
 

--- a/scripts/static_data/loaders.py
+++ b/scripts/static_data/loaders.py
@@ -15,6 +15,7 @@ RELATED_MERGERS_JSON = REPO_ROOT / "data" / "processed" / "related_mergers.json"
 RELATED_PARTIES_JSON = REPO_ROOT / "data" / "processed" / "related_parties.json"
 SIMILAR_MERGERS_JSON = REPO_ROOT / "data" / "processed" / "similar_mergers.json"
 TRIBUNAL_APPEALS_JSON = REPO_ROOT / "data" / "processed" / "tribunal_appeals.json"
+JUDICIAL_REVIEWS_JSON = REPO_ROOT / "data" / "processed" / "judicial_reviews.json"
 
 
 def load_mergers() -> list:
@@ -142,6 +143,26 @@ def load_tribunal_appeals() -> dict:
         return {k: v for k, v in data.items() if not k.startswith('_')}
     except (json.JSONDecodeError, IOError) as e:
         print(f"Warning: Could not load tribunal_appeals.json: {e}")
+        return {}
+
+
+def load_judicial_reviews() -> dict:
+    """Load Federal Court judicial review data from judicial_reviews.json.
+
+    Returns a dict keyed by merger_id mapping to the judicial review record
+    (applicant, filed date, case number, case URL). Metadata keys (starting
+    with ``_``) are stripped. Returns an empty dict if the file is missing or
+    malformed.
+    """
+    if not JUDICIAL_REVIEWS_JSON.exists():
+        return {}
+
+    try:
+        with open(JUDICIAL_REVIEWS_JSON, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        return {k: v for k, v in data.items() if not k.startswith('_')}
+    except (json.JSONDecodeError, IOError) as e:
+        print(f"Warning: Could not load judicial_reviews.json: {e}")
         return {}
 
 

--- a/scripts/tests/test_judicial_reviews.py
+++ b/scripts/tests/test_judicial_reviews.py
@@ -1,0 +1,105 @@
+"""Tests for the Federal Court judicial review overlay.
+
+Covers loading judicial_reviews.json and linking review records onto
+enriched mergers (the ``judicial_review`` field). Unlike tribunal appeals,
+there is no documents list, no event-timeline folding, and no lifecycle
+status to track — this overlay only carries enough to render a link-out
+card to the court's own case page.
+"""
+
+import json
+import os
+import sys
+import unittest.mock
+from pathlib import Path
+
+# Add scripts directory to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+# Mock heavy transitive imports before importing modules that need them
+sys.modules.setdefault('pdfplumber', unittest.mock.MagicMock())
+sys.modules.setdefault('markdownify', unittest.mock.MagicMock())
+sys.modules.setdefault('requests', unittest.mock.MagicMock())
+
+from static_data import loaders
+from static_data.enrichment import enrich_merger, link_judicial_reviews
+
+
+def _phase2_not_approved(merger_id='MN-0001'):
+    return {
+        'merger_id': merger_id,
+        'merger_name': f'{merger_id} deal',
+        'status': 'Assessment completed',
+        'stage': 'Phase 2 - detailed assessment',
+        'accc_determination': 'Not approved',
+        'determination_publication_date': '2026-07-01T12:00:00Z',
+        'end_of_determination_period': '2026-07-02T12:00:00Z',
+        'effective_notification_datetime': '2025-11-27T12:00:00Z',
+        'events': [
+            {'title': 'Merger notified to ACCC', 'date': '2025-11-27T12:00:00Z'},
+            {'title': 'ACCC decided notification is subject to Phase 2 review', 'date': '2026-01-29T12:00:00Z'},
+        ],
+    }
+
+
+def _judicial_review(merger_id='MN-0001'):
+    return {
+        merger_id: {
+            'applicant': 'Coles',
+            'filed_date': '2026-07-15',
+            'case_number': 'NSD1310/2026',
+            'case_url': 'https://www.comcourts.gov.au/file/Federal/P/nsd1310/2026/actions',
+        }
+    }
+
+
+class TestLinkJudicialReviews:
+    def test_sets_record(self):
+        mergers = [enrich_merger(_phase2_not_approved())]
+        linked = link_judicial_reviews(mergers, _judicial_review())
+        assert linked == 1
+        m = mergers[0]
+        assert m['judicial_review']['applicant'] == 'Coles'
+        assert m['judicial_review']['filed_date'] == '2026-07-15'
+        assert m['judicial_review']['case_number'] == 'NSD1310/2026'
+        assert m['judicial_review']['case_url'] == 'https://www.comcourts.gov.au/file/Federal/P/nsd1310/2026/actions'
+
+    def test_no_entry_means_no_record(self):
+        mergers = [enrich_merger(_phase2_not_approved())]
+        linked = link_judicial_reviews(mergers, _judicial_review('MN-9999'))
+        assert linked == 0
+        assert 'judicial_review' not in mergers[0]
+
+    def test_empty_dict_is_noop(self):
+        mergers = [enrich_merger(_phase2_not_approved())]
+        assert link_judicial_reviews(mergers, {}) == 0
+
+
+class TestLoader:
+    def test_strips_metadata_keys(self, tmp_path, monkeypatch):
+        path = tmp_path / 'judicial_reviews.json'
+        path.write_text(json.dumps({'_comment': 'x', 'MN-0001': _judicial_review()['MN-0001']}))
+        monkeypatch.setattr(loaders, 'JUDICIAL_REVIEWS_JSON', path)
+        data = loaders.load_judicial_reviews()
+        assert set(data.keys()) == {'MN-0001'}
+
+    def test_missing_file_returns_empty(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(loaders, 'JUDICIAL_REVIEWS_JSON', tmp_path / 'nope.json')
+        assert loaders.load_judicial_reviews() == {}
+
+
+class TestRealDataFile:
+    def test_committed_file_is_valid(self):
+        """The checked-in overlay parses and every entry has the required fields."""
+        repo_root = Path(__file__).resolve().parent.parent.parent
+        path = repo_root / 'data' / 'processed' / 'judicial_reviews.json'
+        with open(path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+
+        for merger_id, review in data.items():
+            if merger_id.startswith('_'):
+                continue
+            assert review.get('applicant')
+            assert review.get('filed_date')
+            assert review.get('case_number')
+            assert review.get('case_url', '').startswith('https://www.comcourts.gov.au/')


### PR DESCRIPTION
Adds a hand-maintained data/processed/judicial_reviews.json overlay
(mirroring tribunal_appeals.json but without document scraping/hosting),
loaders.load_judicial_reviews() and enrichment.link_judicial_reviews() to
merge it into each merger's static JSON, and a blue link-out card on
MergerDetail.jsx showing "Judicial review requested by {applicant} on
{filed_date}" / "{case_number}", linking straight to the court's own case
page (e.g. Commonwealth Courts Portal) rather than a locally-hosted
document.

Seeds the real Coles Kalgoorlie matter (MN-01068, NSD1310/2026) and
regenerates the affected static data file.