### PR TITLE
fix: treat dash character variants as equivalent when matching event titles

### DIFF
--- a/data/processed/mergers.json
+++ b/data/processed/mergers.json
@@ -26713,11 +26713,6 @@
         "url": "https://www.accc.gov.au/system/files/moderated_files/Black%20Rhino%20Group%20%E2%80%93%20s87B%20Undertaking%20%E2%80%93%20Public%20version_2.pdf",
         "url_gh": "/mergers/MN-90008/Black Rhino Group \u2013 s87B Undertaking \u2013 Public version_2.pdf",
         "status": "live"
-      },
-      {
-        "date": "2026-06-19T12:00:00Z",
-        "title": "Timeline extended by 10 business days - following request by parties",
-        "display_title": "Timeline extended by 10 business days - following request by parties"
       }
     ],
     "is_waiver": false

--- a/scripts/detect_duplicates.py
+++ b/scripts/detect_duplicates.py
@@ -35,6 +35,7 @@ from pathlib import Path
 
 from constants.site import REPO as _REPO, mergers_fyi_url
 from date_utils import parse_iso_datetime
+from normalization import normalize_dashes
 
 SCRIPT_DIR = Path(__file__).parent
 REPO_ROOT = SCRIPT_DIR.parent
@@ -44,8 +45,13 @@ SIMILARITY_THRESHOLD = 0.80
 
 
 def normalise_title(title: str) -> str:
-    """Strip leading/trailing whitespace and punctuation for fuzzy comparison."""
-    return re.sub(r"[\s\W]+$", "", title.strip()).lower()
+    """Strip leading/trailing whitespace and punctuation, and canonicalise
+    dash characters, for comparison. The ACCC site inconsistently uses
+    different dash characters for the same wording (e.g. an en dash '–' in
+    one scrape becomes a hyphen '-' in a later one), so titles that differ
+    only by dash character are treated as identical rather than merely
+    similar."""
+    return re.sub(r"[\s\W]+$", "", normalize_dashes(title).strip()).lower()
 
 
 def extract_type_prefix(title: str) -> str:
@@ -168,22 +174,28 @@ def find_duplicates(merger: dict) -> list[dict]:
     grouped: list[dict] = []
     used: set[int] = set()
 
-    # --- pass 1: exact (date, title) matches ---
+    # --- pass 1: exact (date, title) matches, ignoring dash-character choice ---
+    # Keyed on the dash-normalised title only (not full fuzzy normalisation)
+    # so titles that differ purely by dash character (e.g. an en dash '–' vs
+    # a hyphen '-') are still recognised as the same event and reported as
+    # CERTAIN. Case and punctuation differences remain in the LIKELY pass
+    # below, unchanged from before.
     from collections import defaultdict
     exact: dict[tuple, list[int]] = defaultdict(list)
     for idx, ev in enumerate(events):
         date = parse_date(ev.get("date", ""))
         title = ev.get("title", "")
         if date and title:
-            exact[(date, title)].append(idx)
+            exact[(date, normalize_dashes(title))].append(idx)
 
-    for (date, title), indices in exact.items():
+    for (date, _norm_title), indices in exact.items():
         if len(indices) > 1:
+            titles = list(dict.fromkeys(events[i].get("title", "") for i in indices))
             grouped.append({
                 "kind": "certain",
                 "indices": indices,
                 "date": date,
-                "titles": [title],
+                "titles": titles,
                 "events": [events[i] for i in indices],
             })
             used.update(indices)

--- a/scripts/extract_mergers.py
+++ b/scripts/extract_mergers.py
@@ -23,7 +23,7 @@ from parse_questionnaire import (
     _DEFAULT_CACHE_PATH as _Q_CACHE_PATH,
     _NEG_CACHE_KEY as _Q_NEG_CACHE_KEY,
 )
-from normalization import normalize_determination
+from normalization import normalize_determination, normalize_dashes
 from constants.site import REPO, mergers_fyi_url
 from cutoff import get_skipped_merger_ids, is_waiver_merger
 from date_utils import parse_text_to_iso, parse_iso_datetime
@@ -899,7 +899,7 @@ def _merge_events(scraped_events, existing_merger_data, merger_id, frozen_events
                 # captured.
                 replacement_row = next(
                     (e for e in scraped_without_url
-                     if e.get('title') == existing_event.get('title')
+                     if _normalize_event_title(e.get('title')) == _normalize_event_title(existing_event.get('title'))
                      and _dates_within_one_day(
                          e.get('date', ''), existing_event.get('date', ''))),
                     None,
@@ -913,7 +913,8 @@ def _merge_events(scraped_events, existing_merger_data, merger_id, frozen_events
                     merged_events.append(existing_event)
         else:
             matching_scraped = next(
-                (e for e in scraped_without_url if e['title'] == existing_event['title']),
+                (e for e in scraped_without_url
+                 if _normalize_event_title(e['title']) == _normalize_event_title(existing_event['title'])),
                 None
             )
             if matching_scraped:
@@ -971,10 +972,12 @@ def _drop_superseded_removed_events(events):
 
 
 def _normalize_event_title(title):
-    """Whitespace- and case-insensitive form of an event title, for matching
-    the same timeline entry across scrapes (the ACCC occasionally re-cases
-    titles, e.g. "Summary of Reasons" vs "Summary of reasons")."""
-    return ' '.join((title or '').split()).casefold()
+    """Whitespace-, dash-, and case-insensitive form of an event title, for
+    matching the same timeline entry across scrapes (the ACCC occasionally
+    re-cases titles, e.g. "Summary of Reasons" vs "Summary of reasons", or
+    swaps the dash character used, e.g. an en dash '–' becoming a hyphen
+    '-')."""
+    return ' '.join(normalize_dashes(title or '').split()).casefold()
 
 
 def _mentions_reasons(event):

--- a/scripts/normalization.py
+++ b/scripts/normalization.py
@@ -6,7 +6,22 @@ scripts in the data processing pipeline to ensure consistent behavior and
 avoid code duplication.
 """
 
+import re
+
 from constants import merger_status
+
+# Unicode dash-like characters the ACCC site uses interchangeably for the same
+# wording (e.g. an event title scraped with an en dash '–' can reappear later
+# with a plain hyphen '-'). Comparisons that need to recognise the "same"
+# title across scrapes should normalize through this first.
+_DASH_CHARS = "‐‑‒–—―−"
+
+
+def normalize_dashes(text: str) -> str:
+    """Replace en/em dashes and other unicode dash variants with a plain hyphen '-'."""
+    if not text:
+        return text
+    return re.sub(f"[{_DASH_CHARS}]", "-", text)
 
 
 def normalize_determination(determination: str) -> str | None:

--- a/scripts/tests/test_detect_duplicates.py
+++ b/scripts/tests/test_detect_duplicates.py
@@ -67,6 +67,30 @@ def test_exact_duplicate_still_certain():
     assert groups[0]["kind"] == "certain"
 
 
+def test_dash_variant_title_is_certain_not_likely():
+    """A title that differs only by dash character (en dash vs hyphen) is a
+    typographic difference, not a wording difference, so it should be
+    reported as CERTAIN like any other exact duplicate rather than merely
+    LIKELY."""
+    merger = {
+        "merger_id": "MN-90008",
+        "events": [
+            {
+                "date": "2026-06-19T12:00:00Z",
+                "title": "Timeline extended by 10 business days – following request by parties",
+            },
+            {
+                "date": "2026-06-19T12:00:00Z",
+                "title": "Timeline extended by 10 business days - following request by parties",
+            },
+        ],
+    }
+    groups = find_duplicates(merger)
+    assert len(groups) == 1
+    assert groups[0]["kind"] == "certain"
+    assert set(groups[0]["indices"]) == {0, 1}
+
+
 def test_different_event_types_one_day_apart_not_grouped():
     """The tolerance must not group genuinely distinct documents."""
     merger = {

--- a/scripts/tests/test_pipeline.py
+++ b/scripts/tests/test_pipeline.py
@@ -109,6 +109,57 @@ class TestMergeEventsAttachmentDropped:
 
 
 # ---------------------------------------------------------------------------
+# _merge_events: URL-less timeline rows are matched by title regardless of
+# which dash character the ACCC happens to render
+# ---------------------------------------------------------------------------
+
+class TestMergeEventsUrllessTitleDashVariant:
+    """Plain (URL-less) timeline rows, e.g. "Timeline extended by N business
+    days ...", are matched across scrapes purely by exact title. The ACCC
+    site inconsistently renders the same wording with an en dash '–' in one
+    scrape and a plain hyphen '-' in a later one. Without dash-insensitive
+    matching, that difference is invisible to a human reader but breaks the
+    exact-string match, so the scraper leaves the old title's event alone
+    and appends a fresh copy in the new dash style as a separate event —
+    and keeps doing so on every subsequent scrape (MN-90008).
+    """
+
+    TITLE_EN_DASH = "Timeline extended by 10 business days – following request by parties"
+    TITLE_HYPHEN = "Timeline extended by 10 business days - following request by parties"
+
+    def _existing(self, title):
+        return {
+            "events": [
+                {
+                    "date": "2026-06-19T12:00:00Z",
+                    "title": title,
+                    "display_title": title,
+                },
+            ],
+        }
+
+    def test_hyphen_scrape_matches_existing_en_dash_event(self):
+        scraped = [{"date": "2026-06-19T12:00:00Z", "title": self.TITLE_HYPHEN}]
+        merged = _merge_events(scraped, self._existing(self.TITLE_EN_DASH), "MN-90008", set())
+        assert len(merged) == 1, "dash-variant title must not create a duplicate event"
+
+    def test_en_dash_scrape_matches_existing_hyphen_event(self):
+        scraped = [{"date": "2026-06-19T12:00:00Z", "title": self.TITLE_EN_DASH}]
+        merged = _merge_events(scraped, self._existing(self.TITLE_HYPHEN), "MN-90008", set())
+        assert len(merged) == 1, "dash-variant title must not create a duplicate event"
+
+    def test_identical_title_still_matches(self):
+        scraped = [{"date": "2026-06-19T12:00:00Z", "title": self.TITLE_HYPHEN}]
+        merged = _merge_events(scraped, self._existing(self.TITLE_HYPHEN), "MN-90008", set())
+        assert len(merged) == 1
+
+    def test_genuinely_different_title_is_not_matched(self):
+        scraped = [{"date": "2026-06-19T12:00:00Z", "title": "A completely different event"}]
+        merged = _merge_events(scraped, self._existing(self.TITLE_EN_DASH), "MN-90008", set())
+        assert len(merged) == 2
+
+
+# ---------------------------------------------------------------------------
 # _merge_events: re-uploaded documents must not duplicate their event
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
MN-90008 had two "Timeline extended by 10 business days" events for
2026-06-19 that differ only by an en dash vs. a hyphen in the title.
extract_mergers._merge_events matches URL-less events by exact title
string, so once the ACCC site's rendering of the wording changed, the
stale en-dash entry stopped matching and the scraper appended a fresh
copy in the new dash style instead of updating in place — and would
keep doing so on every future scrape regardless of which duplicate
copy is kept.

Normalize dash characters (en dash, em dash, minus sign, etc.) to a
plain hyphen before comparing titles:
- extract_mergers._normalize_event_title, used by _merge_events'
  title-matching branches, so future scrapes recognise the same
  event regardless of which dash character the ACCC renders.
- detect_duplicates.find_duplicates' exact-match pass, so a
  dash-only title difference is reported as CERTAIN rather than only
  caught by the fuzzy LIKELY pass.

The dash-normalizing helper lives in the shared normalization module.
detect_duplicates.suggest_deletion's fallback (keep the earlier
entry) is unchanged; with matching now dash-insensitive it no longer
matters which duplicate copy survives.

Also removes MN-90008's now-CERTAIN duplicate event via
detect_duplicates.py --apply-fixes.