### PR TITLE
Word lower-bound-only pre-notification estimates as a ceiling, not a point

### DIFF
--- a/merger-tracker/frontend/src/components/PreNotificationEstimate.jsx
+++ b/merger-tracker/frontend/src/components/PreNotificationEstimate.jsx
@@ -5,6 +5,7 @@ import { formatDateLong } from '../utils/dates';
 import {
   getPreNotificationEstimate,
   PRE_NOTIFICATION_AFTER,
+  PRE_NOTIFICATION_BEFORE,
   PRE_NOTIFICATION_NONE,
 } from '../utils/preNotification';
 
@@ -17,6 +18,9 @@ const describe = ({ kind, startDate }) => {
   }
   if (kind === PRE_NOTIFICATION_AFTER) {
     return `this merger entered pre-notification sometime after ${formatDateLong(startDate)}`;
+  }
+  if (kind === PRE_NOTIFICATION_BEFORE) {
+    return `this merger entered pre-notification sometime before ${formatDateLong(startDate)}`;
   }
   return `this merger entered pre-notification around ${formatDateLong(startDate)}`;
 };

--- a/merger-tracker/frontend/src/components/__tests__/PreNotificationEstimate.test.jsx
+++ b/merger-tracker/frontend/src/components/__tests__/PreNotificationEstimate.test.jsx
@@ -36,7 +36,7 @@ describe('PreNotificationEstimate', () => {
     ).toBeInTheDocument();
   });
 
-  it('dates the start of pre-notification when only a lower bound is proven', () => {
+  it('gives the date as a ceiling when only a lower bound is proven', () => {
     renderCallout(merger({
       pre_notification: {
         estimated_days: 7,
@@ -47,7 +47,10 @@ describe('PreNotificationEstimate', () => {
       },
     }));
 
-    expect(screen.getByText(/entered pre-notification around 20 May 2026/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/entered pre-notification sometime before 20 May 2026/)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/around/)).not.toBeInTheDocument();
   });
 
   it('gives the date as a floor when only an upper bound is known', () => {

--- a/merger-tracker/frontend/src/utils/preNotification.js
+++ b/merger-tracker/frontend/src/utils/preNotification.js
@@ -16,6 +16,8 @@ export const PRE_NOTIFICATION_NONE = 'none';
 export const PRE_NOTIFICATION_AROUND = 'around';
 /** Only the earliest possible start is known, so the date is a floor rather than a point. */
 export const PRE_NOTIFICATION_AFTER = 'after';
+/** Only the latest possible start is known, so the date is a ceiling rather than a point. */
+export const PRE_NOTIFICATION_BEFORE = 'before';
 
 /**
  * How a merger's pre-notification period should be described, or null when
@@ -39,11 +41,15 @@ export const getPreNotificationEstimate = (merger) => {
     return { kind: PRE_NOTIFICATION_NONE, startDate: null };
   }
 
-  // An upper bound alone says only that the case number can't have been issued
-  // before its anchor, so the date is where the period starts at the earliest.
-  const kind = estimate.basis === 'upper-bound-only'
-    ? PRE_NOTIFICATION_AFTER
-    : PRE_NOTIFICATION_AROUND;
+  // A single bound gives an endpoint, not a point: an upper bound alone says
+  // only that the case number can't have been issued before its anchor (the
+  // period starts at the earliest there), and a lower bound alone only that it
+  // was issued by the time a later case was filed (the period starts at the
+  // latest there). Only a bracketed estimate has evidence on both sides and
+  // earns "around".
+  let kind = PRE_NOTIFICATION_AROUND;
+  if (estimate.basis === 'upper-bound-only') kind = PRE_NOTIFICATION_AFTER;
+  if (estimate.basis === 'lower-bound-only') kind = PRE_NOTIFICATION_BEFORE;
 
   return { kind, startDate: estimate.id_issued_estimated };
 };


### PR DESCRIPTION
A lower-bound-only estimate proves only the latest possible start of
pre-notification (a later case number was filed first), yet the callout
worded it "around <date>" as if the date were bracketed from both
sides. Mirror the upper-bound-only wording: those cases now read
"sometime before <date>", via a new PRE_NOTIFICATION_BEFORE kind.