### PR TITLE
Run tribunal scrape hourly, 8am-7pm Sydney (fixed AEST offset)

### DIFF
--- a/.github/workflows/check-deploy-assets.yml
+++ b/.github/workflows/check-deploy-assets.yml
@@ -39,10 +39,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 

--- a/.github/workflows/convert.yml
+++ b/.github/workflows/convert.yml
@@ -10,7 +10,7 @@ jobs:
   convert:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/detect-duplicates.yml
+++ b/.github/workflows/detect-duplicates.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/detect-related-mergers.yml
+++ b/.github/workflows/detect-related-mergers.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 

--- a/.github/workflows/detect-related-parties.yml
+++ b/.github/workflows/detect-related-parties.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 

--- a/.github/workflows/extract.yml
+++ b/.github/workflows/extract.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/fix-missing-notification-dates.yml
+++ b/.github/workflows/fix-missing-notification-dates.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -20,7 +20,7 @@ jobs:
         working-directory: merger-tracker/frontend
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -78,7 +78,7 @@ jobs:
         run: echo "${HOME}/go/bin" >> $GITHUB_PATH
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/publish-cli-sqlite.yml
+++ b/.github/workflows/publish-cli-sqlite.yml
@@ -30,10 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out main
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 

--- a/.github/workflows/scrape-tribunal.yml
+++ b/.github/workflows/scrape-tribunal.yml
@@ -33,10 +33,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: '3.12'
         cache: 'pip'

--- a/.github/workflows/scrape-tribunal.yml
+++ b/.github/workflows/scrape-tribunal.yml
@@ -15,8 +15,11 @@ on:
         required: false
         default: ''
   schedule:
-    # Daily at 6:23 AM UTC.
-    - cron: '23 6 * * *'
+    # Hourly, minute :23, from 8am to 7pm Sydney time (AEST, UTC+10).
+    # GitHub Actions cron has no DST awareness, so this is pinned to a fixed
+    # UTC+10 offset: during AEDT (roughly Oct-Apr) the actual window is
+    # 9am-8pm Sydney rather than 8am-7pm.
+    - cron: '23 22,23,0-9 * * *'
 
 permissions:
   contents: write

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Set up Go
       uses: actions/setup-go@v6

--- a/.github/workflows/send-weekly-email.yml
+++ b/.github/workflows/send-weekly-email.yml
@@ -28,13 +28,13 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # Shallow clone is enough — we only need digest.json
           fetch-depth: 1
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/update-sitemap.yml
+++ b/.github/workflows/update-sitemap.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 

--- a/.github/workflows/weekly-digest.yml
+++ b/.github/workflows/weekly-digest.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
           cache: 'pip'


### PR DESCRIPTION
Replaces the single daily 6:23 UTC run with an hourly one at minute :23
covering 8am-7pm Sydney time. GitHub Actions cron has no DST awareness,
so this pins to a fixed UTC+10 (AEST) offset; during AEDT the window
shifts to 9am-8pm Sydney.