### PR TITLE
Remove Commentary page from navbar

### DIFF
--- a/merger-tracker/frontend/src/constants/navPages.js
+++ b/merger-tracker/frontend/src/constants/navPages.js
@@ -9,7 +9,7 @@ export const NAV_PAGES = [
   { label: 'Industries', path: '/industries', shortcut: 'i', inNavbar: true, navOrder: 4, inPalette: true, paletteOrder: 4 },
   { label: 'Parties', path: '/parties', inNavbar: false, inPalette: true, paletteOrder: 5 },
   { label: 'Analysis', path: '/analysis', shortcut: 'a', inNavbar: true, navOrder: 6, inPalette: true, paletteOrder: 6 },
-  { label: 'Commentary', path: '/commentary', shortcut: 'c', inNavbar: true, navOrder: 5, inPalette: true, paletteOrder: 7 },
+  { label: 'Commentary', path: '/commentary', shortcut: 'c', inNavbar: false, inPalette: true, paletteOrder: 7 },
   {
     label: 'Digest',
     navbarLabel: 'Catch me up',


### PR DESCRIPTION
Commentary stays reachable via the command palette, its g-c keyboard
shortcut, and direct link, but is no longer listed in the top nav.